### PR TITLE
feat: Allow minimal configuration while appending to Falco rule

### DIFF
--- a/sysdig/resource_sysdig_secure_rule.go
+++ b/sysdig/resource_sysdig_secure_rule.go
@@ -16,7 +16,8 @@ func createRuleSchema(original map[string]*schema.Schema) map[string]*schema.Sch
 		},
 		"description": {
 			Type:     schema.TypeString,
-			Required: true,
+			Optional: true,
+			Default:  "",
 		},
 		"tags": {
 			Type:     schema.TypeList,

--- a/sysdig/secure/models.go
+++ b/sysdig/secure/models.go
@@ -150,7 +150,7 @@ type Details struct {
 	// Falco
 	Append    *bool      `json:"append,omitempty"`
 	Source    string     `json:"source,omitempty"`
-	Output    string     `json:"output,omitempty"`
+	Output    string     `json:"output"`
 	Condition *Condition `json:"condition,omitempty"`
 	Priority  string     `json:"priority,omitempty"`
 

--- a/website/docs/r/sysdig_secure_rule_container.md
+++ b/website/docs/r/sysdig_secure_rule_container.md
@@ -28,7 +28,7 @@ resource "sysdig_secure_rule_container" "sample" {
 ## Argument Reference
 
 * `name` - (Required) The name of the Secure rule. It must be unique.
-* `description` - (Required) The description of Secure rule.
+* `description` - (Optional) The description of Secure rule. By default is empty.
 * `tags` - (Optional) A list of tags for this rule.
 
 ### Matching

--- a/website/docs/r/sysdig_secure_rule_falco.md
+++ b/website/docs/r/sysdig_secure_rule_falco.md
@@ -33,7 +33,7 @@ resource "sysdig_secure_rule_falco" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Secure rule. It must be unique.
-* `description` - (Required) The description of Secure rule.
+* `description` - (Optional) The description of Secure rule. By default is empty.
 * `tags` - (Optional) A list of tags for this rule.
 
 - - -
@@ -41,9 +41,9 @@ The following arguments are supported:
 ### Conditions
 
 * `condition` - (Required) A [Falco condition](https://falco.org/docs/rules/) is simply a Boolean predicate on Sysdig events expressed using the Sysdig [filter syntax](http://www.sysdig.org/wiki/sysdig-user-guide/#filtering) and macro terms. 
-* `output` - (Required) Add additional information to each Falco notification's output.
-* `priority` - (Required) The priority of the Falco rule. It can be: "emergency", "alert", "critical", "error", "warning", "notice", "informational", "informational" or "debug".
-* `source` - (Required) The source of the event. It can be either "syscall" or "k8s_audit".
+* `output` - (Optional) Add additional information to each Falco notification's output. Required if append is false.
+* `priority` - (Optional) The priority of the Falco rule. It can be: "emergency", "alert", "critical", "error", "warning", "notice", "informational", "informational" or "debug". By default is "warning".
+* `source` - (Optional) The source of the event. It can be either "syscall" or "k8s_audit". Required if append is false.
 * `append` - (Optional) This indicates that the rule being created appends the condition to an existing Sysdig-provided rule. By default this is false. Appending to user-created rules is not supported by the API.
 
 ## Attributes Reference

--- a/website/docs/r/sysdig_secure_rule_filesystem.md
+++ b/website/docs/r/sysdig_secure_rule_filesystem.md
@@ -38,7 +38,7 @@ resource "sysdig_secure_rule_filesystem"  "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Secure rule. It must be unique.
-* `description` - (Required) The description of Secure rule.
+* `description` - (Optional) The description of Secure rule. By default is empty.
 * `tags` - (Optional) A list of tags for this rule.
 
 ### Read Only

--- a/website/docs/r/sysdig_secure_rule_network.md
+++ b/website/docs/r/sysdig_secure_rule_network.md
@@ -41,7 +41,7 @@ resource "sysdig_secure_rule_network" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Secure rule. It must be unique.
-* `description` - (Required) The description of Secure rule.
+* `description` - (Optional) The description of Secure rule. By default is empty.
 * `tags` - (Optional) A list of tags for this rule.
 
 ### Disallow incoming or outgoing connections

--- a/website/docs/r/sysdig_secure_rule_process.md
+++ b/website/docs/r/sysdig_secure_rule_process.md
@@ -28,7 +28,7 @@ resource "sysdig_secure_rule_process" "sample" {
 ## Argument Reference
 
 * `name` - (Required) The name of the Secure rule. It must be unique.
-* `description` - (Required) The description of Secure rule.
+* `description` - (Optional) The description of Secure rule. By default is empty.
 * `tags` - (Optional) A list of tags for this rule.
 
 ### Matching

--- a/website/docs/r/sysdig_secure_rule_syscall.md
+++ b/website/docs/r/sysdig_secure_rule_syscall.md
@@ -27,7 +27,7 @@ resource "sysdig_secure_rule_syscall" "foo" {
 ## Argument Reference
 
 * `name` - (Required) The name of the Secure rule. It must be unique.
-* `description` - (Required) The description of Secure rule.
+* `description` - (Optional) The description of Secure rule. By default is empty.
 * `tags` - (Optional) A list of tags for this rule.
 
 ### Matching


### PR DESCRIPTION
The current scenario is that even for `append=true` Falco rules, almost all the fields are still required, like description, output and priority.
This PR allows having only name, condition and append=true set for a new rule appending to an existing one.