### PR TITLE
fix: Change falco rule priority to info

### DIFF
--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -41,7 +41,7 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Default:          "warning",
-				ValidateDiagFunc: validateDiagFunc(validation.StringInSlice([]string{"emergency", "alert", "critical", "error", "warning", "notice", "informational", "debug"}, false)),
+				ValidateDiagFunc: validateDiagFunc(validation.StringInSlice([]string{"emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"}, false)),
 			},
 			"source": {
 				Type:             schema.TypeString,

--- a/website/docs/d/sysdig_current_user.md
+++ b/website/docs/d/sysdig_current_user.md
@@ -10,7 +10,7 @@ description: |-
 
 Retrieves information about the current user performing the API calls.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/d/sysdig_secure_notification_channel.md
+++ b/website/docs/d/sysdig_secure_notification_channel.md
@@ -10,7 +10,7 @@ description: |-
 
 Retrieves the information of an existing Sysdig Secure Notification Channel.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_alert_anomaly.md
+++ b/website/docs/r/sysdig_monitor_alert_anomaly.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Anomaly Alert. Monitor hosts based on their historical behaviors and alert when they deviate.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_alert_downtime.md
+++ b/website/docs/r/sysdig_monitor_alert_downtime.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Downtime Alert. Monitor any type of entity - host, container, process, service, etc - and alert when the entity goes down.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_alert_event.md
+++ b/website/docs/r/sysdig_monitor_alert_event.md
@@ -12,7 +12,7 @@ Creates a Sysdig Monitor Event Alert. Monitor occurrences of specific events, an
 number of occurrences violates a threshold. Useful for alerting on container, orchestration, and 
 service events like restarts and deployments.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_alert_group_outlier.md
+++ b/website/docs/r/sysdig_monitor_alert_group_outlier.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Group Outlier Alert. Monitor a group of hosts and be notified when one acts differently from the rest.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_alert_metric.md
+++ b/website/docs/r/sysdig_monitor_alert_metric.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Metric Alert. Monitor time-series metrics and alert if they violate user-defined thresholds.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_dashboard.md
+++ b/website/docs/r/sysdig_monitor_dashboard.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Dashboard using PromQL queries.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_notification_channel_email.md
+++ b/website/docs/r/sysdig_monitor_notification_channel_email.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Notification Channel of type Email.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_notification_channel_opsgenie.md
+++ b/website/docs/r/sysdig_monitor_notification_channel_opsgenie.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Notification Channel of type OpsGenie.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_notification_channel_pagerduty.md
+++ b/website/docs/r/sysdig_monitor_notification_channel_pagerduty.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Notification Channel of type Pagerduty.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_notification_channel_slack.md
+++ b/website/docs/r/sysdig_monitor_notification_channel_slack.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Notification Channel of type Slack.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_notification_channel_sns.md
+++ b/website/docs/r/sysdig_monitor_notification_channel_sns.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Notification Channel of type Amazon SNS.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_notification_channel_victorops.md
+++ b/website/docs/r/sysdig_monitor_notification_channel_victorops.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Notification Channel of type VictorOps.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_notification_channel_webhook.md
+++ b/website/docs/r/sysdig_monitor_notification_channel_webhook.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Notification Channel of type Webhook.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_monitor_team.md
+++ b/website/docs/r/sysdig_monitor_team.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Monitor Team.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_list.md
+++ b/website/docs/r/sysdig_secure_list.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Falco List.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_macro.md
+++ b/website/docs/r/sysdig_secure_macro.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Falco Macro.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_notification_channel_email.md
+++ b/website/docs/r/sysdig_secure_notification_channel_email.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Notification Channel of type Email.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_notification_channel_opsgenie.md
+++ b/website/docs/r/sysdig_secure_notification_channel_opsgenie.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Notification Channel of type OpsGenie.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_notification_channel_pagerduty.md
+++ b/website/docs/r/sysdig_secure_notification_channel_pagerduty.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Notification Channel of type Pagerduty.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_notification_channel_slack.md
+++ b/website/docs/r/sysdig_secure_notification_channel_slack.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Notification Channel of type Slack.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_notification_channel_sns.md
+++ b/website/docs/r/sysdig_secure_notification_channel_sns.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Notification Channel of type Amazon SNS.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_notification_channel_victorops.md
+++ b/website/docs/r/sysdig_secure_notification_channel_victorops.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Notification Channel of type VictorOps.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_notification_channel_webhook.md
+++ b/website/docs/r/sysdig_secure_notification_channel_webhook.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Notification Channel of type Webhook.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_rule_container.md
+++ b/website/docs/r/sysdig_secure_rule_container.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Container Rule.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_rule_falco.md
+++ b/website/docs/r/sysdig_secure_rule_falco.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Falco Rule.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_rule_filesystem.md
+++ b/website/docs/r/sysdig_secure_rule_filesystem.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Filesystem Rule.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_rule_network.md
+++ b/website/docs/r/sysdig_secure_rule_network.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Network Rule.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_rule_process.md
+++ b/website/docs/r/sysdig_secure_rule_process.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Process Rule.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_rule_syscall.md
+++ b/website/docs/r/sysdig_secure_rule_syscall.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Syscall Rule.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_secure_team.md
+++ b/website/docs/r/sysdig_secure_team.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a Sysdig Secure Team.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 

--- a/website/docs/r/sysdig_user.md
+++ b/website/docs/r/sysdig_user.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates a user in Sysdig.
 
-`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
 
 ## Example usage
 


### PR DESCRIPTION
The API expects that field to be `info` instead of `informational`. 
Closes #59 