### PR TITLE
feat: Increase timeout for lists, macros and rules

### DIFF
--- a/sysdig/resource_sysdig_secure_list.go
+++ b/sysdig/resource_sysdig_secure_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 func resourceSysdigSecureList() *schema.Resource {
-	timeout := 30 * time.Second
+	timeout := 5 * time.Minute
 
 	return &schema.Resource{
 		CreateContext: resourceSysdigListCreate,

--- a/sysdig/resource_sysdig_secure_macro.go
+++ b/sysdig/resource_sysdig_secure_macro.go
@@ -10,7 +10,7 @@ import (
 )
 
 func resourceSysdigSecureMacro() *schema.Resource {
-	timeout := 30 * time.Second
+	timeout := 5 * time.Minute
 
 	return &schema.Resource{
 		CreateContext: resourceSysdigMacroCreate,

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -23,7 +23,7 @@ func resourceSysdigSecureRuleContainer() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(timeout),
 			Update: schema.DefaultTimeout(timeout),
-			Read: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
 			Delete: schema.DefaultTimeout(timeout),
 		},
 

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -12,7 +12,7 @@ import (
 )
 
 func resourceSysdigSecureRuleContainer() *schema.Resource {
-	timeout := 30 * time.Second
+	timeout := 5 * time.Minute
 
 	return &schema.Resource{
 		CreateContext: resourceSysdigRuleContainerCreate,
@@ -22,6 +22,9 @@ func resourceSysdigSecureRuleContainer() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read: schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
 		},
 
 		Schema: createRuleSchema(map[string]*schema.Schema{

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -26,7 +26,7 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(timeout),
 			Update: schema.DefaultTimeout(timeout),
-			Read: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
 			Delete: schema.DefaultTimeout(timeout),
 		},
 

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -15,7 +15,7 @@ import (
 )
 
 func resourceSysdigSecureRuleFalco() *schema.Resource {
-	timeout := 30 * time.Second
+	timeout := 5 * time.Minute
 
 	return &schema.Resource{
 		CreateContext: resourceSysdigRuleFalcoCreate,
@@ -25,6 +25,9 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read: schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
 		},
 
 		Schema: createRuleSchema(map[string]*schema.Schema{

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -23,7 +23,7 @@ func resourceSysdigSecureRuleProcess() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(timeout),
 			Update: schema.DefaultTimeout(timeout),
-			Read: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
 			Delete: schema.DefaultTimeout(timeout),
 		},
 

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -12,7 +12,7 @@ import (
 )
 
 func resourceSysdigSecureRuleProcess() *schema.Resource {
-	timeout := 30 * time.Second
+	timeout := 5 * time.Minute
 
 	return &schema.Resource{
 		CreateContext: resourceSysdigRuleProcessCreate,
@@ -22,6 +22,9 @@ func resourceSysdigSecureRuleProcess() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read: schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
 		},
 
 		Schema: createRuleSchema(map[string]*schema.Schema{

--- a/sysdig/resource_sysdig_secure_rule_syscall.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall.go
@@ -12,7 +12,7 @@ import (
 )
 
 func resourceSysdigSecureRuleSyscall() *schema.Resource {
-	timeout := 30 * time.Second
+	timeout := 5 * time.Minute
 
 	return &schema.Resource{
 		CreateContext: resourceSysdigRuleSyscallCreate,
@@ -22,6 +22,9 @@ func resourceSysdigSecureRuleSyscall() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read: schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
 		},
 
 		Schema: createRuleSchema(map[string]*schema.Schema{

--- a/sysdig/resource_sysdig_secure_rule_syscall.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall.go
@@ -23,7 +23,7 @@ func resourceSysdigSecureRuleSyscall() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(timeout),
 			Update: schema.DefaultTimeout(timeout),
-			Read: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
 			Delete: schema.DefaultTimeout(timeout),
 		},
 


### PR DESCRIPTION
Customers like Yahoo Japan are encountering "context deadline exceeded" errors while using the provider. For them, working with some sysdig resources may take longer than 30 seconds. This PR increases the timeout for those resources.