### PR TITLE
fix: Solve fields not correctly set in multiple resources

### DIFF
--- a/sysdig/resource_sysdig_monitor_alert_common.go
+++ b/sysdig/resource_sysdig_monitor_alert_common.go
@@ -139,6 +139,7 @@ func alertToResourceData(alert *monitor.Alert, data *schema.ResourceData) (err e
 	data.Set("trigger_after_minutes", int(trigger_after_minutes.Minutes()))
 	data.Set("team", alert.TeamID)
 	data.Set("enabled", alert.Enabled)
+	data.Set("severity", alert.Severity)
 
 	if len(alert.NotificationChannelIds) > 0 {
 		data.Set("notification_channels", alert.NotificationChannelIds)

--- a/sysdig/resource_sysdig_monitor_team.go
+++ b/sysdig/resource_sysdig_monitor_team.go
@@ -154,6 +154,8 @@ func resourceSysdigMonitorTeamRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("scope_by", t.Show)
 	d.Set("filter", t.Filter)
 	d.Set("can_use_sysdig_capture", t.CanUseSysdigCapture)
+	d.Set("can_see_infrastructure_events", t.CanUseCustomEvents)
+	d.Set("can_use_aws_data", t.CanUseAwsMetrics)
 	d.Set("default_team", t.DefaultTeam)
 	d.Set("user_roles", userMonitorRolesToSet(t.UserRoles))
 	d.Set("entrypoint", entrypointToSet(t.EntryPoint))

--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -214,6 +214,7 @@ func resourceSysdigPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("scope", policy.Scope)
 	d.Set("enabled", policy.Enabled)
 	d.Set("version", policy.Version)
+	d.Set("severity", policy.Severity)
 
 	actions := []map[string]interface{}{{}}
 	for _, action := range policy.Actions {

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -47,7 +47,7 @@ func resourceSysdigSecureRuleNetwork() *schema.Resource {
 							Default:  true,
 						},
 						"ports": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,
@@ -67,7 +67,7 @@ func resourceSysdigSecureRuleNetwork() *schema.Resource {
 							Default:  true,
 						},
 						"ports": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,
@@ -133,15 +133,31 @@ func resourceSysdigRuleNetworkRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if len(rule.Details.TCPListenPorts.Items) > 0 {
+		tcpPorts := []int{}
+		for _, port := range rule.Details.TCPListenPorts.Items {
+			intPort, err := strconv.Atoi(port)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			tcpPorts = append(tcpPorts, intPort)
+		}
 		d.Set("tcp", []map[string]interface{}{{
 			"matching": rule.Details.TCPListenPorts.MatchItems,
-			"ports":    rule.Details.TCPListenPorts.Items,
+			"ports":    tcpPorts,
 		}})
 	}
 	if len(rule.Details.UDPListenPorts.Items) > 0 {
+		udpPorts := []int{}
+		for _, port := range rule.Details.UDPListenPorts.Items {
+			intPort, err := strconv.Atoi(port)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			udpPorts = append(udpPorts, intPort)
+		}
 		d.Set("udp", []map[string]interface{}{{
 			"matching": rule.Details.UDPListenPorts.MatchItems,
-			"ports":    rule.Details.UDPListenPorts.Items,
+			"ports":    udpPorts,
 		}})
 	}
 
@@ -200,23 +216,22 @@ func resourceSysdigRuleNetworkFromResourceData(d *schema.ResourceData) (rule sec
 	rule.Details.AllOutbound = d.Get("block_outbound").(bool)
 
 	rule.Details.TCPListenPorts.Items = []string{}
-	if tcpRules, ok := d.Get("tcp").([]interface{}); ok && len(tcpRules) > 0 {
+	if tcpRules := d.Get("tcp").([]interface{}); len(tcpRules) > 0 {
 		rule.Details.TCPListenPorts.MatchItems = d.Get("tcp.0.matching").(bool)
-		for _, port := range d.Get("tcp.0.ports").([]interface{}) {
-			if portStr, ok := port.(string); ok {
-				rule.Details.TCPListenPorts.Items = append(rule.Details.TCPListenPorts.Items, portStr)
-			}
+		for _, port := range d.Get("tcp.0.ports").(*schema.Set).List() {
+			portStr := port.(int)
+			rule.Details.TCPListenPorts.Items = append(rule.Details.TCPListenPorts.Items, strconv.Itoa(portStr))
 		}
 	}
 
 	rule.Details.UDPListenPorts.Items = []string{}
 	if udpRules, ok := d.Get("udp").([]interface{}); ok && len(udpRules) > 0 {
 		rule.Details.UDPListenPorts.MatchItems = d.Get("udp.0.matching").(bool)
-		for _, port := range d.Get("udp.0.ports").([]interface{}) {
-			if portStr, ok := port.(string); ok {
-				rule.Details.UDPListenPorts.Items = append(rule.Details.UDPListenPorts.Items, portStr)
-			}
+		for _, port := range d.Get("udp.0.ports").(*schema.Set).List() {
+			portStr := port.(int)
+			rule.Details.UDPListenPorts.Items = append(rule.Details.UDPListenPorts.Items, strconv.Itoa(portStr))
 		}
 	}
+
 	return
 }

--- a/sysdig/resource_sysdig_secure_rule_process_test.go
+++ b/sysdig/resource_sysdig_secure_rule_process_test.go
@@ -46,7 +46,7 @@ resource "sysdig_secure_rule_process" "foo" {
   tags = ["container", "cis"]
 
   matching = true // default
-  processes = ["bash"]
+  processes = ["bash", "sh"]
 }`, name, name)
 }
 
@@ -57,7 +57,7 @@ resource "sysdig_secure_rule_process" "foo" {
   description = "TERRAFORM TEST %s"
 
   matching = true // default
-  processes = ["bash"]
+  processes = ["bash", "sh"]
 }`, name, name)
 }
 


### PR DESCRIPTION
Some fields weren't being correctly set when retrieved from the API, like:

- `severity` in all `sysdig_monitor_alert_*` resources
- `can_see_infrastructure_events` in `sysdig_monitor_team`
- `can_use_aws_data` in `sysdig_monitor_team`
- `severity` in `sysdig_secure_policy`

Also
- `tcp.ports` and `udp.ports` in `sysdig_secure_rule_network` weren't being created correctly in the backend, thus, creating a network rule with no checked ports.