### PR TITLE
feat: Add custom notification config for Monitor alerts

### DIFF
--- a/sysdig/monitor/models.go
+++ b/sysdig/monitor/models.go
@@ -10,6 +10,8 @@ import (
 type CustomNotification struct {
 	TitleTemplate  string `json:"titleTemplate"`
 	UseNewTemplate bool   `json:"useNewTemplate"`
+	PrependText    string `json:"prependText,omitempty"`
+	AppendText     string `json:"appendText,omitempty"`
 }
 
 type SysdigCapture struct {

--- a/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
@@ -57,6 +57,12 @@ resource "sysdig_monitor_alert_anomaly" "sample" {
 		filename = "TERRAFORM_TEST.scap"
 		duration = 15
 	}
+
+	custom_notification {
+		title = "{{__alert_name__}} is {{__alert_status__}}"
+		prepend = "{{kubernetes.deployment.name}}"
+		append = "{{kubernetes.deployment.name}}"
+	}
 }
 `, name, name)
 }

--- a/sysdig/resource_sysdig_monitor_alert_common.go
+++ b/sysdig/resource_sysdig_monitor_alert_common.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const defaultAlertTitle = "{{__alert_name__}} is {{__alert_status__}}"
+
 func createAlertSchema(original map[string]*schema.Schema) map[string]*schema.Schema {
 	alertSchema := map[string]*schema.Schema{
 		"name": {
@@ -57,7 +59,50 @@ func createAlertSchema(original map[string]*schema.Schema) map[string]*schema.Sc
 			Optional:     true,
 			ValidateFunc: validation.IntAtLeast(1),
 		},
-		"capture": resourceSysdigMonitorAlertCapture(),
+		"custom_notification": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"title": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"prepend": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"append": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"capture": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"filename": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringMatch(regexp.MustCompile(".*?\\.scap"), "the filename must end in .scap"),
+					},
+					"duration": {
+						Type:     schema.TypeInt,
+						Required: true,
+					},
+					"filter": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Default:  "",
+					},
+				},
+			},
+		},
 	}
 
 	for k, v := range original {
@@ -68,6 +113,7 @@ func createAlertSchema(original map[string]*schema.Schema) map[string]*schema.Sc
 }
 
 func alertFromResourceData(d *schema.ResourceData) (alert *monitor.Alert, err error) {
+
 	trigger_after_minutes := time.Duration(d.Get("trigger_after_minutes").(int)) * time.Minute
 	alert = &monitor.Alert{
 		Name:                   d.Get("name").(string),
@@ -76,9 +122,21 @@ func alertFromResourceData(d *schema.ResourceData) (alert *monitor.Alert, err er
 		SegmentBy:              []string{},
 		NotificationChannelIds: []int{},
 		CustomNotification: &monitor.CustomNotification{
-			TitleTemplate:  "{{__alert_name__}} is {{__alert_status__}}",
+			TitleTemplate:  defaultAlertTitle,
 			UseNewTemplate: true,
 		},
+	}
+
+	if _, ok := d.GetOk("custom_notification"); ok {
+		if title, ok := d.GetOk("custom_notification.0.title"); ok {
+			alert.CustomNotification.TitleTemplate = title.(string)
+		}
+		if prependText, ok := d.GetOk("custom_notification.0.prepend"); ok {
+			alert.CustomNotification.PrependText = prependText.(string)
+		}
+		if appendText, ok := d.GetOk("custom_notification.0.append"); ok {
+			alert.CustomNotification.AppendText = appendText.(string)
+		}
 	}
 
 	if scope, ok := d.GetOk("scope"); ok {
@@ -149,6 +207,23 @@ func alertToResourceData(alert *monitor.Alert, data *schema.ResourceData) (err e
 		data.Set("renotification_minutes", alert.ReNotifyMinutes)
 	}
 
+	if alert.CustomNotification != nil &&
+		(alert.CustomNotification.TitleTemplate != defaultAlertTitle || alert.CustomNotification.AppendText != "" || alert.CustomNotification.PrependText != "") {
+		customNotification := map[string]interface{}{
+			"title": alert.CustomNotification.TitleTemplate,
+		}
+
+		if alert.CustomNotification.AppendText != "" {
+			customNotification["append"] = alert.CustomNotification.AppendText
+		}
+
+		if alert.CustomNotification.PrependText != "" {
+			customNotification["prepend"] = alert.CustomNotification.PrependText
+		}
+
+		data.Set("custom_notification", []interface{}{customNotification})
+	}
+
 	if alert.SysdigCapture != nil && alert.SysdigCapture.Enabled {
 		capture := map[string]interface{}{
 			"filename": alert.SysdigCapture.Name,
@@ -161,31 +236,6 @@ func alertToResourceData(alert *monitor.Alert, data *schema.ResourceData) (err e
 	}
 
 	return
-}
-
-func resourceSysdigMonitorAlertCapture() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeSet,
-		Optional: true,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"filename": {
-					Type:         schema.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(".*?\\.scap"), "the filename must end in .scap"),
-				},
-				"duration": {
-					Type:     schema.TypeInt,
-					Required: true,
-				},
-				"filter": {
-					Type:     schema.TypeString,
-					Optional: true,
-					Default:  "",
-				},
-			},
-		},
-	}
 }
 
 func sysdigCaptureFromSet(d *schema.Set) (captures []*monitor.SysdigCapture, err error) {

--- a/website/docs/r/sysdig_monitor_alert_anomaly.md
+++ b/website/docs/r/sysdig_monitor_alert_anomaly.md
@@ -46,9 +46,10 @@ These arguments are common to all alerts in Sysdig Monitor.
 * `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
 * `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
 * `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.
- 
+* `capture` - (Optional) Enables the creation of a capture file of the syscalls during the event.
+* `custom_notification` - (Optional) Allows to define a custom notification title, prepend and append text.
 
-#### Capture
+### `capture`
 
 Enables the creation of a capture file of the syscalls during the event.
 
@@ -56,7 +57,16 @@ Enables the creation of a capture file of the syscalls during the event.
 * `duration` - (Required) Time frame in seconds of the capture.
 * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name contains nginx`.
 
-### Metric alert arguments
+### `custom_notification`
+
+By defining this field, the user can modify the title and the body of the message sent when the alert
+is fired.
+
+* `title` - (Required) Sets the title of the alert. It is commonly defined as `{{__alert_name__}} is {{__alert_status__}}`.
+* `prepend` - (Optional) Text to add before the alert template.
+* `append` - (Optional) Text to add after the alert template.
+
+### Anomaly alert arguments
 
 * `monitor` - (Required) Array of metrics to monitor and alert on. Example: `["cpu.used.percent", "cpu.cores.used", "memory.bytes.used", "fs.used.percent", "thread.count", "net.request.count.in"]`.
 * `multiple_alerts_by` - (Optional) List of segments to trigger a separate alert on. Example: `["kubernetes.cluster.name", "kubernetes.namespace.name"]`.  

--- a/website/docs/r/sysdig_monitor_alert_downtime.md
+++ b/website/docs/r/sysdig_monitor_alert_downtime.md
@@ -42,9 +42,10 @@ These arguments are common to all alerts in Sysdig Monitor.
 * `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
 * `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
 * `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.
- 
+* `capture` - (Optional) Enables the creation of a capture file of the syscalls during the event.
+* `custom_notification` - (Optional) Allows to define a custom notification title, prepend and append text.
 
-#### Capture
+### `capture`
 
 Enables the creation of a capture file of the syscalls during the event.
 
@@ -52,7 +53,16 @@ Enables the creation of a capture file of the syscalls during the event.
 * `duration` - (Required) Time frame in seconds of the capture.
 * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name contains nginx`.
 
-### Metric alert arguments
+### `custom_notification`
+
+By defining this field, the user can modify the title and the body of the message sent when the alert
+is fired.
+
+* `title` - (Required) Sets the title of the alert. It is commonly defined as `{{__alert_name__}} is {{__alert_status__}}`.
+* `prepend` - (Optional) Text to add before the alert template.
+* `append` - (Optional) Text to add after the alert template.
+
+### Downtime alert arguments
 
 * `entities_to_monitor` - (Required) List of metrics to monitor downtime and alert on. Example: `["kubernetes.namespace.name"]` to detect namespace removal or `["host.hostName"]` to detect host downtime.
 * `trigger_after_pct` - (Optional) Below of this percentage of downtime the alert will be triggered. Defaults to 100.  

--- a/website/docs/r/sysdig_monitor_alert_event.md
+++ b/website/docs/r/sysdig_monitor_alert_event.md
@@ -48,9 +48,10 @@ These arguments are common to all alerts in Sysdig Monitor.
 * `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
 * `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
 * `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.
- 
+* `capture` - (Optional) Enables the creation of a capture file of the syscalls during the event.
+* `custom_notification` - (Optional) Allows to define a custom notification title, prepend and append text.
 
-#### Capture
+### `capture`
 
 Enables the creation of a capture file of the syscalls during the event.
 
@@ -58,7 +59,16 @@ Enables the creation of a capture file of the syscalls during the event.
 * `duration` - (Required) Time frame in seconds of the capture.
 * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name contains nginx`.
 
-### Metric alert arguments
+### `custom_notification`
+
+By defining this field, the user can modify the title and the body of the message sent when the alert
+is fired.
+
+* `title` - (Required) Sets the title of the alert. It is commonly defined as `{{__alert_name__}} is {{__alert_status__}}`.
+* `prepend` - (Optional) Text to add before the alert template.
+* `append` - (Optional) Text to add after the alert template.
+
+### Event alert arguments
 
 * `event_name` - (Required) String that matches part of name, tag or the description of Sysdig Events.
 * `source` - (Required) Source of the event. It can be `docker` or `kubernetes`. 

--- a/website/docs/r/sysdig_monitor_alert_group_outlier.md
+++ b/website/docs/r/sysdig_monitor_alert_group_outlier.md
@@ -46,9 +46,10 @@ These arguments are common to all alerts in Sysdig Monitor.
 * `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
 * `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
 * `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.
- 
- 
-#### Capture
+* `capture` - (Optional) Enables the creation of a capture file of the syscalls during the event.
+* `custom_notification` - (Optional) Allows to define a custom notification title, prepend and append text.
+
+### `capture`
 
 Enables the creation of a capture file of the syscalls during the event.
 
@@ -56,7 +57,16 @@ Enables the creation of a capture file of the syscalls during the event.
 * `duration` - (Required) Time frame in seconds of the capture.
 * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name contains nginx`.
 
-### Metric alert arguments
+### `custom_notification`
+
+By defining this field, the user can modify the title and the body of the message sent when the alert
+is fired.
+
+* `title` - (Required) Sets the title of the alert. It is commonly defined as `{{__alert_name__}} is {{__alert_status__}}`.
+* `prepend` - (Optional) Text to add before the alert template.
+* `append` - (Optional) Text to add after the alert template.
+
+### Group Outlier alert arguments
 
 * `monitor` - (Required) Array of metrics to monitor and alert on. Example: `["cpu.used.percent", "cpu.cores.used", "memory.bytes.used", "fs.used.percent", "thread.count", "net.request.count.in"]`.  
 

--- a/website/docs/r/sysdig_monitor_alert_metric.md
+++ b/website/docs/r/sysdig_monitor_alert_metric.md
@@ -50,15 +50,25 @@ These arguments are common to all alerts in Sysdig Monitor.
 * `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
 * `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
 * `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.
- 
+* `capture` - (Optional) Enables the creation of a capture file of the syscalls during the event.
+* `custom_notification` - (Optional) Allows to define a custom notification title, prepend and append text.
 
-#### Capture
+### `capture`
 
 Enables the creation of a capture file of the syscalls during the event.
 
 * `filename` - (Required) Defines the name of the capture file.
 * `duration` - (Required) Time frame in seconds of the capture.
 * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name contains nginx`.
+
+### `custom_notification`
+
+By defining this field, the user can modify the title and the body of the message sent when the alert
+is fired.
+
+* `title` - (Required) Sets the title of the alert. It is commonly defined as `{{__alert_name__}} is {{__alert_status__}}`.
+* `prepend` - (Optional) Text to add before the alert template.
+* `append` - (Optional) Text to add after the alert template.
 
 ### Metric alert arguments
 


### PR DESCRIPTION
This PR the possibility to define a custom notification where the title can be modified and some text can be prepended or appended to the alert body.

Closes #40.