### PR TITLE
Let's assume there's no whitespace at all

### DIFF
--- a/sysdig/resource_sysdig_monitor_alert_event.go
+++ b/sysdig/resource_sysdig_monitor_alert_event.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/sysdig/resource_sysdig_monitor_alert_event.go
+++ b/sysdig/resource_sysdig_monitor_alert_event.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -177,7 +178,7 @@ func eventAlertToResourceData(alert *monitor.Alert, data *schema.ResourceData) (
 
 	var event_rel string
 	var event_count int
-	_, err = fmt.Sscanf(alert.Condition, "count(customEvent) %s %d", &event_rel, &event_count)
+	_, err = fmt.Sscanf(strings.ReplaceAll(alert.Condition, " ", ""), "count(customEvent)%s%d", &event_rel, &event_count)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Since the API allow storing the field with or without whitespace (or in a fancy combination), let's just assume there's no whitespace at all and act on that.
Or, we could use regexp and have a more robust solution.