### PR TITLE
Fix regexp in order to match right strings and multiple whitespaces

### DIFF
--- a/sysdig/resource_sysdig_monitor_alert_event.go
+++ b/sysdig/resource_sysdig_monitor_alert_event.go
@@ -170,8 +170,8 @@ func eventAlertFromResourceData(data *schema.ResourceData) (alert *monitor.Alert
 	return
 }
 
-// https://regex101.com/r/mmpz0D/1
-var alertConditionRegex = regexp.MustCompile(`count\(customEvent\)\s?(?P<rel>[^\w])\s?(?P<count>\d+)`)
+// fixed with https://regex101.com/r/79VIkC/1
+var alertConditionRegex = regexp.MustCompile(`count\(customEvent\)\s*(?P<rel>[^\w\s]+)\s*(?P<count>\d+)`)
 
 func eventAlertToResourceData(alert *monitor.Alert, data *schema.ResourceData) (err error) {
 	err = alertToResourceData(alert, data)


### PR DESCRIPTION
The previous regexp wasn't able to catch up quantifier with multiple chars like `>=` `<=` `!=`
This change fix also the possibility to discard multiple whitespaces between groups (https://regex101.com/r/79VIkC/1)

