### PR TITLE
feat: Add support for Falco exceptions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,7 @@ github.com/hashicorp/go-getter v1.4.0/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUC
 github.com/hashicorp/go-getter v1.5.0/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-getter v1.5.2 h1:XDo8LiAcDisiqZdv0TKgz+HtX3WN7zA2JD1R1tjsabE=
 github.com/hashicorp/go-getter v1.5.2/go.mod h1:orNH3BTYLu/fIxGIdLjLoAJHWMDQ/UKQr5O4m3iBuoo=
+github.com/hashicorp/go-getter v1.5.3 h1:NF5+zOlQegim+w/EUhSLh6QhXHmZMEeHLQzllkQ3ROU=
 github.com/hashicorp/go-getter v1.5.3/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
@@ -263,9 +264,11 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.13.0 h1:1Pth+pdWJAufJuWWjaVOVNEkoRTOjGn3hQpAqj4aPdg=
 github.com/hashicorp/terraform-exec v0.13.0/go.mod h1:SGhto91bVRlgXQWcJ5znSz+29UZIa8kpBbkGwQ+g9E8=
+github.com/hashicorp/terraform-exec v0.14.0 h1:UQoUcxKTZZXhyyK68Cwn4mApT4mnFPmEXPiqaHL9r+w=
 github.com/hashicorp/terraform-exec v0.14.0/go.mod h1:qrAASDq28KZiMPDnQ02sFS9udcqEkRly002EA2izXTA=
 github.com/hashicorp/terraform-json v0.8.0 h1:XObQ3PgqU52YLQKEaJ08QtUshAfN3yu4u8ebSW0vztc=
 github.com/hashicorp/terraform-json v0.8.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
+github.com/hashicorp/terraform-json v0.12.0 h1:8czPgEEWWPROStjkWPUnTQDXmpmZPlkQAwYYLETaTvw=
 github.com/hashicorp/terraform-json v0.12.0/go.mod h1:pmbq9o4EuL43db5+0ogX10Yofv1nozM+wskr/bGFJpI=
 github.com/hashicorp/terraform-plugin-go v0.2.1 h1:EW/R8bB2Zbkjmugzsy1d27yS8/0454b3MtYHkzOknqA=
 github.com/hashicorp/terraform-plugin-go v0.2.1/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
@@ -446,6 +449,7 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/sysdig/internal/client/secure/models.go
+++ b/sysdig/internal/client/secure/models.go
@@ -149,11 +149,12 @@ type Details struct {
 	Syscalls *Syscalls `json:"syscalls,omitempty"`
 
 	// Falco
-	Append    *bool      `json:"append,omitempty"`
-	Source    string     `json:"source,omitempty"`
-	Output    string     `json:"output"`
-	Condition *Condition `json:"condition,omitempty"`
-	Priority  string     `json:"priority,omitempty"`
+	Append     *bool        `json:"append,omitempty"`
+	Source     string       `json:"source,omitempty"`
+	Output     string       `json:"output"`
+	Condition  *Condition   `json:"condition,omitempty"`
+	Priority   string       `json:"priority,omitempty"`
+	Exceptions []*Exception `json:"exceptions,omitempty"`
 
 	RuleType string `json:"ruleType"`
 }
@@ -195,6 +196,13 @@ type Syscalls struct {
 type Condition struct {
 	Condition  string        `json:"condition"`
 	Components []interface{} `json:"components"`
+}
+
+type Exception struct {
+	Name   string      `json:"name"`
+	Fields interface{} `json:"fields"`
+	Comps  interface{} `json:"comps"`
+	Values interface{} `json:"values,omitempty"`
 }
 
 func (r *Rule) ToJSON() io.Reader {

--- a/website/docs/r/sysdig_secure_rule_falco.md
+++ b/website/docs/r/sysdig_secure_rule_falco.md
@@ -16,16 +16,42 @@ Creates a Sysdig Secure Falco Rule.
 
 ```hcl
 resource "sysdig_secure_rule_falco" "example" {
-  name = "Terminal shell in container" // ID
+  name        = "Terminal shell in container" // ID
   description = "A shell was used as the entrypoint/exec point into a container with an attached terminal."
-  tags = ["container", "shell", "mitre_execution"]
+  tags        = ["container", "shell", "mitre_execution"]
 
   condition = "spawned_process and container and shell_procs and proc.tty != 0 and container_entrypoint"
-  output = "A shell was spawned in a container with an attached terminal (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository)"
-  priority = "notice"
-  source = "syscall" // syscall or k8s_audit
-}
+  output    = "A shell was spawned in a container with an attached terminal (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository)"
+  priority  = "notice"
+  source    = "syscall" // syscall or k8s_audit
 
+
+  exceptions {
+    name   = "proc_names"
+    fields = ["proc.name"]
+    comps  = ["in"]
+    values = jsonencode(["python", "python2", "python3"]) # If only one element is provided, do not specify it a list of lists.
+  }
+
+  exceptions {
+    name   = "container_proc_name"
+    fields = ["container.id", "proc.name"]
+    comps  = ["=", "in"]
+    values = jsonencode([ # If more than one element is provided, you need to specify a list of lists.
+      ["host", ["docker_binaries", "k8s_binaries", "lxd_binaries", "nsenter"]]
+    ])
+  }
+
+  exceptions {
+    name   = "proc_cmdline"
+    fields = ["proc.name", "proc.cmdline"]
+    comps  = ["in", "contains"]
+    values = jsonencode([ # In this example, we are providing a pair of values for proc_cmdline, each one in a line.
+      [["python", "python2", "python3"], "/opt/draios/bin/sdchecks"],
+      [["java"], "sdjagent.jar"]
+    ])
+  }
+}
 ```
 
 ## Argument Reference
@@ -35,16 +61,24 @@ The following arguments are supported:
 * `name` - (Required) The name of the Secure rule. It must be unique.
 * `description` - (Optional) The description of Secure rule. By default is empty.
 * `tags` - (Optional) A list of tags for this rule.
-
-- - -
-
-### Conditions
-
 * `condition` - (Required) A [Falco condition](https://falco.org/docs/rules/) is simply a Boolean predicate on Sysdig events expressed using the Sysdig [filter syntax](http://www.sysdig.org/wiki/sysdig-user-guide/#filtering) and macro terms. 
 * `output` - (Optional) Add additional information to each Falco notification's output. Required if append is false.
 * `priority` - (Optional) The priority of the Falco rule. It can be: "emergency", "alert", "critical", "error", "warning", "notice", "info" or "debug". By default is "warning".
 * `source` - (Optional) The source of the event. It can be either "syscall", "k8s_audit" or "aws_cloudtrail". Required if append is false.
+* `exceptions` - (Optional) The exceptions key is a list of identifier plus list of tuples of filtercheck fields. See below for details.
 * `append` - (Optional) This indicates that the rule being created appends the condition to an existing Sysdig-provided rule. By default this is false. Appending to user-created rules is not supported by the API.
+
+### Exceptions
+
+Starting in 0.28.0, Falco supports an optional exceptions property to rules. The exceptions key is a list of identifier plus list of tuples of filtercheck fields.
+For more information about the syntax of the exceptions, check the [official Falco documentation](https://falco.org/docs/rules/exceptions/).
+
+Supported fields for exceptions:
+
+* `name` - (Required) The name of the exception. Only used to provide a handy name, and to potentially link together values in a later rule that has `append = true`.
+* `fields` - (Required) Contains one or more fields that will extract a value from the syscall/k8s_audit events.
+* `comps` - (Required) Contains comparison operators that align 1-1 with the items in the fields property.
+* `values` - (Required) Contains tuples of values. Each item in the tuple should align 1-1 with the corresponding field and comparison operator. Since the value can be a string, a list of strings or a list of a list of strings, the value of this field must be supplied in JSON format. You can use the default `jsonencode` function to provide this value. See the usage example on the top.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds support for [Falco exceptions](https://falco.org/docs/rules/exceptions/) in `sysdig_secure_rule_falco` resources.

Closes #106.