### PR TITLE
Add validation to cloud_provider

### DIFF
--- a/sysdig/data_source_sysdig_secure_trusted_cloud_identity.go
+++ b/sysdig/data_source_sysdig_secure_trusted_cloud_identity.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceSysdigSecureTrustedCloudIdentity() *schema.Resource {
@@ -20,8 +21,9 @@ func dataSourceSysdigSecureTrustedCloudIdentity() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"cloud_provider": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"aws", "gcp", "azure"}, false),
 			},
 			"identity": {
 				Type:     schema.TypeString,

--- a/sysdig/resource_sysdig_secure_cloud_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_account.go
@@ -7,6 +7,7 @@ import (
 	"github.com/draios/terraform-provider-sysdig/sysdig/internal/client/secure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceSysdigSecureCloudAccount() *schema.Resource {
@@ -33,8 +34,9 @@ func resourceSysdigSecureCloudAccount() *schema.Resource {
 				Required: true,
 			},
 			"cloud_provider": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"aws", "gcp", "azure"}, false),
 			},
 			"alias": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Add validation to the `cloud_provider` param of the `sysdig_secure_trusted_cloud_identity` datasource as suggested here: https://github.com/sysdiglabs/terraform-provider-sysdig/pull/113#discussion_r690289600

Also adds this same validation to the `sysdig_secure_cloud_account` resource.

This PR does not need to be released immediately, it can go along with the next functional release.