### PR TITLE
Add Benchmark Task resource

### DIFF
--- a/sysdig/internal/client/secure/benchmark_task.go
+++ b/sysdig/internal/client/secure/benchmark_task.go
@@ -1,0 +1,64 @@
+package secure
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func (client *sysdigSecureClient) createBenchmarkTaskURL() string {
+	return fmt.Sprintf("%s/api/benchmarks/v2/tasks", client.URL)
+}
+
+func (client *sysdigSecureClient) benchmarkTaskByIdURL(id string) string {
+	return fmt.Sprintf("%s/api/benchmarks/v2/tasks/%s", client.URL, id)
+}
+
+func (client *sysdigSecureClient) CreateBenchmarkTask(ctx context.Context, task *BenchmarkTask) (*BenchmarkTask, error) {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodPost, client.createBenchmarkTaskURL(), task.ToJSON())
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
+		err = errorFromResponse(response)
+		return nil, err
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(response.Body)
+	return BenchmarkTaskFromJSON(bodyBytes), nil
+}
+
+func (client *sysdigSecureClient) GetBenchmarkTask(ctx context.Context, id string) (*BenchmarkTask, error) {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodGet, client.benchmarkTaskByIdURL(id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, errorFromResponse(response)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return BenchmarkTaskFromJSON(bodyBytes), nil
+}
+
+func (client *sysdigSecureClient) DeleteBenchmarkTask(ctx context.Context, id string) error {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodDelete, client.benchmarkTaskByIdURL(id), nil)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNoContent && response.StatusCode != http.StatusOK {
+		return errorFromResponse(response)
+	}
+	return nil
+}

--- a/sysdig/internal/client/secure/client.go
+++ b/sysdig/internal/client/secure/client.go
@@ -58,6 +58,10 @@ type SysdigSecureClient interface {
 	DeleteCloudAccount(context.Context, string) error
 	UpdateCloudAccount(context.Context, string, *CloudAccount) (*CloudAccount, error)
 	GetTrustedCloudIdentity(context.Context, string) (string, error)
+
+	CreateBenchmarkTask(context.Context, *BenchmarkTask) (*BenchmarkTask, error)
+	GetBenchmarkTask(context.Context, string) (*BenchmarkTask, error)
+	DeleteBenchmarkTask(context.Context, string) error
 }
 
 func WithExtraHeaders(client SysdigSecureClient, extraHeaders map[string]string) SysdigSecureClient {

--- a/sysdig/internal/client/secure/models.go
+++ b/sysdig/internal/client/secure/models.go
@@ -385,6 +385,11 @@ func CloudAccountFromJSON(body []byte) *CloudAccount {
 
 // -------- BenchmarkTask --------
 
+var SupportedBenchmarkTaskSchemas = []string{
+	"aws_foundations_bench-1.3.0",
+	"gcp_foundations_bench-1.2.0",
+}
+
 type BenchmarkTask struct {
 	ID       int    `json:"id,omitempty"`
 	Name     string `json:"name"`

--- a/sysdig/internal/client/secure/models.go
+++ b/sysdig/internal/client/secure/models.go
@@ -382,3 +382,26 @@ func CloudAccountFromJSON(body []byte) *CloudAccount {
 
 	return &result
 }
+
+// -------- BenchmarkTask --------
+
+type BenchmarkTask struct {
+	ID       int    `json:"id,omitempty"`
+	Name     string `json:"name"`
+	Schema   string `json:"schema"`
+	Scope    string `json:"scope"`
+	Schedule string `json:"schedule"`
+	Enabled  bool   `json:"enabled"`
+}
+
+func (t *BenchmarkTask) ToJSON() io.Reader {
+	payload, _ := json.Marshal(*t)
+	return bytes.NewBuffer(payload)
+}
+
+func BenchmarkTaskFromJSON(body []byte) *BenchmarkTask {
+	var result BenchmarkTask
+	json.Unmarshal(body, &result)
+
+	return &result
+}

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -71,6 +71,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_vulnerability_exception":        resourceSysdigSecureVulnerabilityException(),
 			"sysdig_secure_vulnerability_exception_list":   resourceSysdigSecureVulnerabilityExceptionList(),
 			"sysdig_secure_cloud_account":                  resourceSysdigSecureCloudAccount(),
+			"sysdig_secure_benchmark_task":                 resourceSysdigSecureBenchmarkTask(),
 
 			"sysdig_monitor_alert_downtime":                 resourceSysdigMonitorAlertDowntime(),
 			"sysdig_monitor_alert_metric":                   resourceSysdigMonitorAlertMetric(),

--- a/sysdig/resource_sysdig_secure_benchmark_task.go
+++ b/sysdig/resource_sysdig_secure_benchmark_task.go
@@ -1,0 +1,124 @@
+package sysdig
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig/internal/client/secure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceSysdigSecureBenchmarkTask() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		CreateContext: resourceSysdigSecureBenchmarkTaskCreate,
+		ReadContext:   resourceSysdigSecureBenchmarkTaskRead,
+		DeleteContext: resourceSysdigSecureBenchmarkTaskDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
+		},
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"schema": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"schedule": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+		},
+	}
+}
+
+func resourceSysdigSecureBenchmarkTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	benchmarkTask, err := client.CreateBenchmarkTask(ctx, benchmarkTaskFromResourceData(d))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(strconv.Itoa(benchmarkTask.ID))
+	d.Set("name", benchmarkTask.Name)
+	d.Set("schema", benchmarkTask.Schema)
+	d.Set("scope", benchmarkTask.Scope)
+	d.Set("schedule", benchmarkTask.Schedule)
+	d.Set("enabled", benchmarkTask.Enabled)
+
+	return nil
+}
+
+func resourceSysdigSecureBenchmarkTaskRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		d.SetId("")
+		return diag.FromErr(err)
+	}
+
+	benchmarkTask, err := client.GetBenchmarkTask(ctx, d.Id())
+	if err != nil {
+		d.SetId("")
+		return diag.FromErr(err)
+	}
+
+	d.SetId(strconv.Itoa(benchmarkTask.ID))
+	d.Set("name", benchmarkTask.Name)
+	d.Set("schema", benchmarkTask.Schema)
+	d.Set("scope", benchmarkTask.Scope)
+	d.Set("schedule", benchmarkTask.Schedule)
+	d.Set("enabled", benchmarkTask.Enabled)
+
+	return nil
+}
+
+func resourceSysdigSecureBenchmarkTaskDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.DeleteBenchmarkTask(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func benchmarkTaskFromResourceData(d *schema.ResourceData) *secure.BenchmarkTask {
+	return &secure.BenchmarkTask{
+		Name:     d.Get("name").(string),
+		Schema:   d.Get("schema").(string),
+		Scope:    d.Get("scope").(string),
+		Schedule: d.Get("schedule").(string),
+		Enabled:  d.Get("enabled").(bool),
+	}
+}

--- a/sysdig/resource_sysdig_secure_benchmark_task.go
+++ b/sysdig/resource_sysdig_secure_benchmark_task.go
@@ -28,29 +28,34 @@ func resourceSysdigSecureBenchmarkTask() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"schema": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"scope": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"schedule": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/sysdig/resource_sysdig_secure_benchmark_task.go
+++ b/sysdig/resource_sysdig_secure_benchmark_task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/draios/terraform-provider-sysdig/sysdig/internal/client/secure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceSysdigSecureBenchmarkTask() *schema.Resource {
@@ -37,9 +38,10 @@ func resourceSysdigSecureBenchmarkTask() *schema.Resource {
 				ForceNew: true,
 			},
 			"schema": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(secure.SupportedBenchmarkTaskSchemas, false),
 			},
 			"scope": {
 				Type:     schema.TypeString,

--- a/sysdig/resource_sysdig_secure_benchmark_task_test.go
+++ b/sysdig/resource_sysdig_secure_benchmark_task_test.go
@@ -1,0 +1,51 @@
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccSecureBenchmarkTask(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: secureBenchmarkTaskWithName(rText()),
+			},
+			{
+				ResourceName:      "sysdig_secure_benchmark_task.sample",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func secureBenchmarkTaskWithName(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_benchmark_task" "sample" {
+  name     = "%s"
+  schedule = "0 6 * * *"
+  schema   = "aws_foundations_bench-1.3.0"
+  scope    = "aws.accountId = \"123456789012\" and aws.region = \"us-west-2\""
+  enabled  = "true"
+}
+`, name)
+}

--- a/sysdig/resource_sysdig_secure_benchmark_task_test.go
+++ b/sysdig/resource_sysdig_secure_benchmark_task_test.go
@@ -55,7 +55,7 @@ resource "sysdig_secure_benchmark_task" "sample" {
 
 func multiRegionSecureBenchmarkTaskWithName(name string) string {
 	return fmt.Sprintf(`
-resource "sysdig_secure_benchmark_task" "sample2" {
+resource "sysdig_secure_benchmark_task" "sample" {
   name     = "%s"
   schedule = "0 6 * * *"
   schema   = "aws_foundations_bench-1.3.0"

--- a/sysdig/resource_sysdig_secure_benchmark_task_test.go
+++ b/sysdig/resource_sysdig_secure_benchmark_task_test.go
@@ -55,7 +55,7 @@ resource "sysdig_secure_benchmark_task" "sample" {
 
 func multiRegionSecureBenchmarkTaskWithName(name string) string {
 	return fmt.Sprintf(`
-resource "sysdig_secure_benchmark_task" "sample" {
+resource "sysdig_secure_benchmark_task" "sample2" {
   name     = "%s"
   schedule = "0 6 * * *"
   schema   = "aws_foundations_bench-1.3.0"

--- a/sysdig/resource_sysdig_secure_benchmark_task_test.go
+++ b/sysdig/resource_sysdig_secure_benchmark_task_test.go
@@ -30,6 +30,9 @@ func TestAccSecureBenchmarkTask(t *testing.T) {
 				Config: secureBenchmarkTaskWithName(rText()),
 			},
 			{
+				Config: multiRegionSecureBenchmarkTaskWithName(rText()),
+			},
+			{
 				ResourceName:      "sysdig_secure_benchmark_task.sample",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -45,7 +48,19 @@ resource "sysdig_secure_benchmark_task" "sample" {
   schedule = "0 6 * * *"
   schema   = "aws_foundations_bench-1.3.0"
   scope    = "aws.accountId = \"123456789012\" and aws.region = \"us-west-2\""
-  enabled  = "true"
+  enabled  = true
+}
+`, name)
+}
+
+func multiRegionSecureBenchmarkTaskWithName(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_benchmark_task" "sample" {
+  name     = "%s"
+  schedule = "0 6 * * *"
+  schema   = "aws_foundations_bench-1.3.0"
+  scope    = "aws.accountId = \"123456789012\" and aws.region in (\"us-east-1\", \"us-west-2\" \"eu-central-1\")"
+  enabled  = true
 }
 `, name)
 }

--- a/sysdig/resource_sysdig_secure_benchmark_task_test.go
+++ b/sysdig/resource_sysdig_secure_benchmark_task_test.go
@@ -59,7 +59,7 @@ resource "sysdig_secure_benchmark_task" "sample" {
   name     = "%s"
   schedule = "0 6 * * *"
   schema   = "aws_foundations_bench-1.3.0"
-  scope    = "aws.accountId = \"123456789012\" and aws.region in (\"us-east-1\", \"us-west-2\" \"eu-central-1\")"
+  scope    = "aws.accountId = \"123456789012\" and aws.region in (\"us-east-1\", \"us-west-2\", \"eu-central-1\")"
   enabled  = true
 }
 `, name)

--- a/website/docs/r/sysdig_secure_benchmark_task.md
+++ b/website/docs/r/sysdig_secure_benchmark_task.md
@@ -1,0 +1,45 @@
+---
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_benchmark_task"
+sidebar_current: "docs-sysdig_secure_benchmark_task"
+description: |-
+  Creates a Sysdig Secure Benchmark Task.
+---
+
+# sysdig\_secure\_benchmark_task
+
+Creates a Sysdig Secure Benchmark Task.
+
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
+
+## Example usage
+
+```hcl
+resource "sysdig_secure_benchmark_task" "sample" {
+  name     = "My Benchmark Task"
+  schedule = "0 6 * * *"
+  schema   = "aws_foundations_bench-1.3.0"
+  scope    = "aws.accountId = \"123456789012\" and aws.region = \"us-west-2\""
+  enabled  = "true"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The unique identifier of the cloud account. e.g. for AWS: `123456789012`, 
+
+* `schedule` - (Required) The schedule (as a cron expression: [Minute Hour Day DayOfWeek DayOfMonth]) on which this task should be run. The schedule may not be more frequent than once per day.
+
+* `schema` - (Required) The identifier of the benchmark schema of which to run. Possible values are: `aws_foundations_bench-1.3.0`, `gcp_foundations_bench-1.2.0`.
+
+* `scope` - (Required) The Sysdig scope expression on which to run this benchmark: e.g. `aws.accountId = \"123456789012\" and aws.region = \"us-west-2\"`. The labels available are `aws.accountId`, `aws.region`, `gcp.projectId` and `gcp.region`. Only the `=` and `and` operators are supported.
+
+* `enabled` - (Optional) Whether or not this task should be enabled. Default: `true`.
+
+## Import
+
+Secure Benchmark Tasks can be imported using the `id`, e.g.
+
+```
+$ terraform import sysdig_secure_benchmark_task.sample 1
+```

--- a/website/docs/r/sysdig_secure_cloud_account.md
+++ b/website/docs/r/sysdig_secure_cloud_account.md
@@ -35,7 +35,7 @@ resource "sysdig_secure_cloud_account" "sample" {
 
 ## Import
 
-Secure Teams can be imported using the `account_id`, e.g.
+Secure Cloud Accounts can be imported using the `account_id`, e.g.
 
 ```
 $ terraform import sysdig_secure_cloud_account.sample 123456789012

--- a/website/sysdig.erb
+++ b/website/sysdig.erb
@@ -25,6 +25,9 @@
             <li<%= sidebar_current("docs-sysdig-secure-resources") %>>
               <a href="#">Resources</a>
               <ul class="nav nav-auto-expand">
+                <li<%= sidebar_current("docs-sysdig-secure-benchmark-task") %>>
+                  <a href="/docs/providers/sysdig/r/sysdig_secure_benchmark_task.html">sysdig_secure_benchmark_task</a>
+                </li>
                 <li<%= sidebar_current("docs-sysdig-secure-cloud-account") %>>
                   <a href="/docs/providers/sysdig/r/sysdig_secure_cloud_account.html">sysdig_secure_cloud_account</a>
                 </li>


### PR DESCRIPTION
We would like to add the ability to https://github.com/sysdiglabs/terraform-aws-secure-for-cloud to automatically create a benchmark task when using the cloud-bench module. 

This PR adds a Secure Benchmark Task resource.

Tested using a local build and https://github.com/sysdiglabs/terraform-aws-secure-for-cloud/pull/17