### PR TITLE
feat: Support for PromQL Alerts (#108)

### DIFF
--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -78,6 +78,7 @@ func Provider() *schema.Provider {
 			"sysdig_monitor_alert_event":                    resourceSysdigMonitorAlertEvent(),
 			"sysdig_monitor_alert_anomaly":                  resourceSysdigMonitorAlertAnomaly(),
 			"sysdig_monitor_alert_group_outlier":            resourceSysdigMonitorAlertGroupOutlier(),
+			"sysdig_monitor_alert_promql":                   resourceSysdigMonitorAlertPromql(),
 			"sysdig_monitor_dashboard":                      resourceSysdigMonitorDashboard(),
 			"sysdig_monitor_notification_channel_email":     resourceSysdigMonitorNotificationChannelEmail(),
 			"sysdig_monitor_notification_channel_opsgenie":  resourceSysdigMonitorNotificationChannelOpsGenie(),

--- a/sysdig/resource_sysdig_monitor_alert_promql.go
+++ b/sysdig/resource_sysdig_monitor_alert_promql.go
@@ -1,0 +1,151 @@
+package sysdig
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig/internal/client/monitor"
+)
+
+func resourceSysdigMonitorAlertPromql() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		CreateContext: resourceSysdigAlertPromqlCreate,
+		UpdateContext: resourceSysdigAlertPromqlUpdate,
+		ReadContext:   resourceSysdigAlertPromqlRead,
+		DeleteContext: resourceSysdigAlertPromqlDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: createAlertSchema(map[string]*schema.Schema{
+			"promql": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		}),
+	}
+}
+
+func resourceSysdigAlertPromqlCreate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client, err := i.(SysdigClients).sysdigMonitorClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	alert, err := promqlAlertFromResourceData(data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	alertCreated, err := client.CreateAlert(ctx, *alert)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(strconv.Itoa(alertCreated.ID))
+	data.Set("version", alertCreated.Version)
+	return nil
+}
+
+func resourceSysdigAlertPromqlUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client, err := i.(SysdigClients).sysdigMonitorClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	alert, err := promqlAlertFromResourceData(data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	alert.ID, _ = strconv.Atoi(data.Id())
+
+	_, err = client.UpdateAlert(ctx, *alert)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceSysdigAlertPromqlRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client, err := i.(SysdigClients).sysdigMonitorClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := strconv.Atoi(data.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	alert, err := client.GetAlertById(ctx, id)
+
+	if err != nil {
+		data.SetId("")
+		return nil
+	}
+
+	err = promqlAlertToResourceData(&alert, data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceSysdigAlertPromqlDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client, err := i.(SysdigClients).sysdigMonitorClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := strconv.Atoi(data.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.DeleteAlert(ctx, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func promqlAlertFromResourceData(data *schema.ResourceData) (alert *monitor.Alert, err error) {
+	alert, err = alertFromResourceData(data)
+	if err != nil {
+		return
+	}
+
+	alert.Type = "PROMETHEUS"
+
+	alert.Condition = data.Get("promql").(string)
+
+	return
+}
+
+func promqlAlertToResourceData(alert *monitor.Alert, data *schema.ResourceData) (err error) {
+	err = alertToResourceData(alert, data)
+	if err != nil {
+		return
+	}
+
+	data.Set("promql", alert.Condition)
+
+	return
+}

--- a/sysdig/resource_sysdig_monitor_alert_promql_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_promql_test.go
@@ -1,0 +1,56 @@
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccAlertPromql(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_MONITOR_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_MONITOR_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: alertPromqlWithName(rText()),
+			},
+			{
+				ResourceName:      "sysdig_monitor_alert_promql.sample",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func alertPromqlWithName(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_promql" "sample" {
+	name = "TERRAFORM TEST - PROMQL %s"
+	description = "TERRAFORM TEST - PROMQL %s"
+	severity = 3
+
+	promql = "(elasticsearch_jvm_memory_used_bytes{area=\"heap\"} / elasticsearch_jvm_memory_max_bytes{area=\"heap\"}) * 100 > 80"
+
+	trigger_after_minutes = 10
+
+	enabled = false
+}
+`, name, name)
+}

--- a/website/docs/r/sysdig_monitor_alert_promql.md
+++ b/website/docs/r/sysdig_monitor_alert_promql.md
@@ -1,0 +1,75 @@
+---
+layout: "sysdig"
+page_title: "Sysdig: sysdig_monitor_alert_promql"
+sidebar_current: "docs-sysdig-monitor-alert-promql"
+description: |-
+  Creates a Sysdig Monitor PromQL Alert.
+---
+
+# sysdig\_monitor\_alert\_promql
+
+Creates a Sysdig Monitor PromQL Alert. Monitor prometheus metrics and alert if they violate user-defined PromQL-based metric expression.
+
+`~> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.`
+
+## Example usage
+
+```hcl
+resource "sysdig_monitor_alert_promql" "sample" {
+	name = "Elasticsearch JVM heap usage"
+	description = "A Kubernetes pod failed to restart"
+	severity = 6
+
+	promql = "(elasticsearch_jvm_memory_used_bytes{area=\"heap\"} / elasticsearch_jvm_memory_max_bytes{area=\"heap\"}) * 100 > 80"
+	trigger_after_minutes = 10
+}
+```
+
+## Argument Reference
+
+### Common alert arguments
+
+These arguments are common to all alerts in Sysdig Monitor.
+
+* `name` - (Required) The name of the Monitor alert. It must be unique.
+* `description` - (Optional) The description of Monitor alert.
+* `severity` - (Optional) Severity of the Monitor alert. It must be a value between 0 and 7,
+               with 0 being the most critical and 7 the less critical. Defaults to 4.
+* `trigger_after_minutes` - (Required) Threshold of time for the status to stabilize until the alert is fired.
+* `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
+* `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
+* `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.
+* `custom_notification` - (Optional) Allows to define a custom notification title, prepend and append text.
+
+### `custom_notification`
+
+By defining this field, the user can modify the title and the body of the message sent when the alert
+is fired.
+
+* `title` - (Required) Sets the title of the alert. It is commonly defined as `{{__alert_name__}} is {{__alert_status__}}`.
+* `prepend` - (Optional) Text to add before the alert template.
+* `append` - (Optional) Text to add after the alert template.
+
+### PromQL alert arguments
+
+* `promql` - (Required) PromQL-based metric expression to alert on. Example: `histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m]) > 0.15` or `predict_linear(sysdig_fs_free_bytes{fstype!~"tmpfs"}[1h], 24*3600) < 10000000000`.
+
+## Attributes Reference
+
+### Common alert attributes
+
+In addition to all arguments above, the following attributes are exported, which are common to all the
+alerts in Sysdig Monitor:
+
+* `id` - ID of the alert created.
+* `version` - Current version of the resource in Sysdig Monitor.
+* `team` - Team ID that owns the alert.
+
+
+## Import
+
+PromQL Monitor alerts can be imported using the alert ID, e.g.
+
+```
+$ terraform import sysdig_monitor_alert_promql.example 12345
+```

--- a/website/sysdig.erb
+++ b/website/sysdig.erb
@@ -113,6 +113,9 @@
                 <li<%= sidebar_current("docs-sysdig-monitor-alert-metric") %>>
                   <a href="/docs/providers/sysdig/r/sysdig_monitor_alert_metric.html">sysdig_monitor_alert_metric</a>
                 </li>
+                <li<%= sidebar_current("docs-sysdig-monitor-alert-promql") %>>
+                  <a href="/docs/providers/sysdig/r/sysdig_monitor_alert_promql.html">sysdig_monitor_alert_promql</a>
+                </li>
                 <li<%= sidebar_current("docs-sysdig-monitor-dashboard") %>>
                   <a href="/docs/providers/sysdig/r/sysdig_monitor_dashboard.html">sysdig_monitor_dashboard</a>
                 </li>


### PR DESCRIPTION
This adds support to PromQL alerts using the new resource: `sysdig_monitor_alert_promql`.

The same could be achieved in a more succinct way defining a new field in the resource `sysdig_monitor_alert_metric` as described by the good PR https://github.com/sysdiglabs/terraform-provider-sysdig/pull/123, reported here is an alternative way: my understanding is that a new resource could provide a more coherent interface from a user perspective.