### PR TITLE
Refactor Azure Service Principal Attributes

### DIFF
--- a/sysdig/data_source_sysdig_secure_trusted_cloud_identity.go
+++ b/sysdig/data_source_sysdig_secure_trusted_cloud_identity.go
@@ -43,7 +43,7 @@ func dataSourceSysdigSecureTrustedCloudIdentity() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"azure_client_id": {
+			"azure_service_principal_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -79,10 +79,10 @@ func dataSourceSysdigSecureTrustedCloudIdentityRead(ctx context.Context, d *sche
 		}
 	case "azure":
 		// If identity is an Azure tenantID/clientID, separate into each part
-		tenantID, clientID, err := parseAzureCreds(identity)
+		tenantID, spID, err := parseAzureCreds(identity)
 		if err == nil {
 			_ = d.Set("azure_tenant_id", tenantID)
-			_ = d.Set("azure_client_id", clientID)
+			_ = d.Set("azure_service_principal_id", spID)
 
 		}
 	}

--- a/sysdig/helpers.go
+++ b/sysdig/helpers.go
@@ -34,8 +34,8 @@ func validateDiagFunc(validateFunc func(interface{}, string) ([]string, []error)
 	}
 }
 
-// parseAzureCreds splits an Azure Trusted Identity into a tenantID and a clientID
-func parseAzureCreds(azureTrustedIdentity string) (tenantID string, clientID string, err error) {
+// parseAzureCreds splits an Azure Trusted Identity into a tenantID and a service principal ID
+func parseAzureCreds(azureTrustedIdentity string) (tenantID string, spID string, err error) {
 	tokens := strings.Split(azureTrustedIdentity, ":")
 	if len(tokens) != 2 {
 		return "", "", errors.New("Not a valid Azure Trusted Identity")

--- a/website/docs/d/secure_trusted_cloud_identity.md
+++ b/website/docs/d/secure_trusted_cloud_identity.md
@@ -35,7 +35,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `aws_role_name` - If `identity` is a AWS IAM Role ARN, this attribute contains the name of the role, otherwise it contains the empty string. `cloud_provider` must be equal to `aws` or `gcp`.
 
-* `azure_tenant_id` - If `identity` contains credentials for an Azure Service Principal, this attribute contains its Tenant ID. `cloud_provider` must be equal to `azure`.
+* `azure_tenant_id` - If `identity` contains credentials for an Azure Service Principal, this attribute contains the service principal's Tenant ID. `cloud_provider` must be equal to `azure`.
 
-* `azure_client_id` - If `identity` contains credentials for an Azure Service Principal, this attribute contains its Client ID. `cloud_provider` must be equal to `azure`.
+* `azure_service_principal_id` - If `identity` contains credentials for an Azure Service Principal, this attribute contains the service principal's ID. `cloud_provider` must be equal to `azure`.
 


### PR DESCRIPTION
What was previously referred to as the client ID is actually the service principal ID; client ID should represent the ID of the application in which the service principal lives, and is not needed by the TF provider.