### PR TITLE
Respect proxy env vars in common HTTP client

### DIFF
--- a/sysdig/internal/client/common/client.go
+++ b/sysdig/internal/client/common/client.go
@@ -31,6 +31,7 @@ func NewSysdigCommonClient(sysdigAPIToken string, url string, insecure bool) Sys
 	client.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+			Proxy:           http.ProxyFromEnvironment,
 		},
 	}
 

--- a/sysdig/internal/client/common/client.go
+++ b/sysdig/internal/client/common/client.go
@@ -28,12 +28,12 @@ func WithExtraHeaders(client SysdigCommonClient, extraHeaders map[string]string)
 
 func NewSysdigCommonClient(sysdigAPIToken string, url string, insecure bool) SysdigCommonClient {
 	client := retryablehttp.NewClient()
-	client.HTTPClient = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-			Proxy:           http.ProxyFromEnvironment,
-		},
-	}
+    transport := http.DefaultTransport.(*http.Transport).Clone()
+    transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+
+    client.HTTPClient = &http.Client{
+        Transport: transport,
+    }
 
 	return &sysdigCommonClient{
 		SysdigAPIToken: sysdigAPIToken,

--- a/sysdig/internal/client/common/client.go
+++ b/sysdig/internal/client/common/client.go
@@ -28,12 +28,12 @@ func WithExtraHeaders(client SysdigCommonClient, extraHeaders map[string]string)
 
 func NewSysdigCommonClient(sysdigAPIToken string, url string, insecure bool) SysdigCommonClient {
 	client := retryablehttp.NewClient()
-    transport := http.DefaultTransport.(*http.Transport).Clone()
-    transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
 
-    client.HTTPClient = &http.Client{
-        Transport: transport,
-    }
+	client.HTTPClient = &http.Client{
+		Transport: transport,
+	}
 
 	return &sysdigCommonClient{
 		SysdigAPIToken: sysdigAPIToken,


### PR DESCRIPTION
Currently, API calls for "Sysdig Platform" resources/data sources from the "common" client don't respect proxy env vars (HTTPS_PROXY, NO_PROXY, etc.). When using the provider behind a proxy, this results in what seems like a provider hang.

While the monitor & secure clients do work behind a proxy & respect proxy env vars, any management of platform resources (ie. `resource "sysdig_user"`, `data "sysdig_current_user"`) fails behind a proxy.

This PR configures the common client to respect proxy settings like the [monitor](https://github.com/sysdiglabs/terraform-provider-sysdig/blob/master/sysdig/internal/client/monitor/client.go#L50) & [secure](https://github.com/sysdiglabs/terraform-provider-sysdig/blob/master/sysdig/internal/client/secure/client.go#L79) clients already do.