### PR TITLE
Update cloud account URL to upsert

### DIFF
--- a/sysdig/internal/client/secure/cloud_account.go
+++ b/sysdig/internal/client/secure/cloud_account.go
@@ -10,7 +10,7 @@ import (
 
 func (client *sysdigSecureClient) cloudAccountURL(includeExternalID bool) string {
 	if includeExternalID {
-		return fmt.Sprintf("%s/api/cloud/v2/accounts?includeExternalID=true", client.URL)
+		return fmt.Sprintf("%s/api/cloud/v2/accounts?includeExternalID=true&upsert=true", client.URL)
 	}
 	return fmt.Sprintf("%s/api/cloud/v2/accounts", client.URL)
 }


### PR DESCRIPTION
URL needs to include `upsert` query param to upsert a cloud account if it already exists, avoiding 409 conflict