### PR TITLE
Support query param & response breaking changes in cloudsec

### DIFF
--- a/sysdig/internal/client/secure/cloud_account.go
+++ b/sysdig/internal/client/secure/cloud_account.go
@@ -10,14 +10,14 @@ import (
 
 func (client *sysdigSecureClient) cloudAccountURL(includeExternalID bool) string {
 	if includeExternalID {
-		return fmt.Sprintf("%s/api/cloud/v2/accounts?includeExternalID=true&upsert=true", client.URL)
+		return fmt.Sprintf("%s/api/cloud/v2/accounts?includeExternalId=true&upsert=true", client.URL)
 	}
 	return fmt.Sprintf("%s/api/cloud/v2/accounts", client.URL)
 }
 
 func (client *sysdigSecureClient) cloudAccountByIdURL(accountID string, includeExternalID bool) string {
 	if includeExternalID {
-		return fmt.Sprintf("%s/api/cloud/v2/accounts/%s?includeExternalID=true", client.URL, accountID)
+		return fmt.Sprintf("%s/api/cloud/v2/accounts/%s?includeExternalId=true", client.URL, accountID)
 	}
 	return fmt.Sprintf("%s/api/cloud/v2/accounts/%s", client.URL, accountID)
 }


### PR DESCRIPTION
```
Accommodate all the API changes by altering all query params to end in Id for CloudSec API endpoints

This can be done by checking the API Docs under Cloud and updating all the endpoints to send the revised query params.

I.e if we were sending account before, in your PR we should send in accountId with the same values.

Also we will be adding a change to support a change in response data 

I.e if the response included customerID before, in your PR we should expect customerId
```

Jira ticket: https://sysdig.atlassian.net/browse/SSPROD-11466

Dependent on https://github.com/draios/secure-backend/pull/6397 being merged first