### PR TITLE
Clone from default HTTP transport to prevent issues with zeroed values

### DIFF
--- a/sysdig/internal/client/secure/client.go
+++ b/sysdig/internal/client/secure/client.go
@@ -73,12 +73,9 @@ func WithExtraHeaders(client SysdigSecureClient, extraHeaders map[string]string)
 
 func NewSysdigSecureClient(sysdigSecureAPIToken string, url string, insecure bool) SysdigSecureClient {
 	httpClient := retryablehttp.NewClient()
-	httpClient.HTTPClient = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-			Proxy:           http.ProxyFromEnvironment,
-		},
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+	httpClient.HTTPClient = &http.Client{Transport: transport}
 
 	return &sysdigSecureClient{
 		SysdigSecureAPIToken: sysdigSecureAPIToken,


### PR DESCRIPTION
Clone from the http.DefaultTransport to use sane defaults instead of zeroed values from a new http.Transport{} struct.