### PR TITLE
fix: update entry_point for workload-agent > 2.2.0

### DIFF
--- a/sysdig/data_source_sysdig_fargate_workload_agent.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent.go
@@ -28,7 +28,7 @@ const agentinoKiltDefinition = `build {
             name: "SysdigInstrumentation"
             image: ${config.agent_image}
             volumes: ["/opt/draios"]
-            entry_point: ["/opt/draios/bin/waitforever"]
+            entry_point: ["/opt/draios/bin/logwriter"]
         }
     ]
 }`


### PR DESCRIPTION
Starting from v2.2.0, the expected entry point is `logwriter`.