### PR TITLE
doc: use a more specific name on `sysdig_fargate_workload_agent` example

### DIFF
--- a/website/docs/d/fargate_workload_agent.md
+++ b/website/docs/d/fargate_workload_agent.md
@@ -17,7 +17,7 @@ You can connect the Sysdig agent directly to a collector (using `collector_host`
 ## Example Usage
 
 ```terraform
-data "sysdig_fargate_workload_agent" "task_definition" {
+data "sysdig_fargate_workload_agent" "instrumented_containers" {
   container_definitions = "[]"
 
   image_auth_secret    = ""


### PR DESCRIPTION
The `sysdig_fargate_workload_agent` is supposed to have containers, not
task definitions.