### PR TITLE
Support auto creation of missing benchmark resources (SSPROD-12557)

### DIFF
--- a/sysdig/resource_sysdig_secure_benchmark_task.go
+++ b/sysdig/resource_sysdig_secure_benchmark_task.go
@@ -3,6 +3,7 @@ package sysdig
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -95,6 +96,9 @@ func resourceSysdigSecureBenchmarkTaskRead(ctx context.Context, d *schema.Resour
 	benchmarkTask, err := client.GetBenchmarkTask(ctx, d.Id())
 	if err != nil {
 		d.SetId("")
+		if strings.Contains(err.Error(), "404") {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 
@@ -119,6 +123,9 @@ func resourceSysdigSecureBenchmarkTaskUpdate(ctx context.Context, d *schema.Reso
 
 	if err := client.SetBenchmarkTaskEnabled(ctx, d.Id(), enabled); err != nil {
 		d.SetId("")
+		if strings.Contains(err.Error(), "404") {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 
@@ -135,6 +142,10 @@ func resourceSysdigSecureBenchmarkTaskDelete(ctx context.Context, d *schema.Reso
 
 	err = client.DeleteBenchmarkTask(ctx, d.Id())
 	if err != nil {
+		d.SetId("")
+		if strings.Contains(err.Error(), "404") {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	return nil

--- a/sysdig/resource_sysdig_secure_cloud_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_account.go
@@ -2,6 +2,7 @@ package sysdig
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -93,6 +94,9 @@ func resourceSysdigSecureCloudAccountRead(ctx context.Context, d *schema.Resourc
 	cloudAccount, err := client.GetCloudAccountById(ctx, d.Id())
 	if err != nil {
 		d.SetId("")
+		if strings.Contains(err.Error(), "404") {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 
@@ -114,6 +118,9 @@ func resourceSysdigSecureCloudAccountUpdate(ctx context.Context, d *schema.Resou
 
 	_, err = client.UpdateCloudAccount(ctx, d.Id(), cloudAccountFromResourceData(d))
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 
@@ -128,6 +135,9 @@ func resourceSysdigSecureCloudAccountDelete(ctx context.Context, d *schema.Resou
 
 	err = client.DeleteCloudAccount(ctx, d.Id())
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	return nil


### PR DESCRIPTION
Other TF providers create a resource if it is missing (i.e. was manually deleted) instead of throwing a 404

Jira ticket: https://sysdig.atlassian.net/browse/SSPROD-12557