### PR TITLE
fix: Solve API not returning the expected error format

### DIFF
--- a/sysdig/internal/client/monitor/helpers.go
+++ b/sysdig/internal/client/monitor/helpers.go
@@ -23,7 +23,11 @@ func errorFromResponse(response *http.Response) error {
 	}
 
 	if searchArray, ok := search.([]interface{}); ok {
-		return errors.New(strings.Join(cast.ToStringSlice(searchArray), ", "))
+		errorString := strings.Join(cast.ToStringSlice(searchArray), ", ")
+		if errorString == "" {
+			return errors.New(response.Status)
+		}
+		return errors.New(errorString)
 	}
 
 	toString := cast.ToString(search)

--- a/sysdig/internal/client/monitor/helpers.go
+++ b/sysdig/internal/client/monitor/helpers.go
@@ -17,7 +17,7 @@ func errorFromResponse(response *http.Response) error {
 		return errors.New(response.Status)
 	}
 
-	search, err := jmespath.Search("[message, errors[].[reason, message]][][] | join(', ', @)", data)
+	search, err := jmespath.Search("[error, message, errors[].[reason, message]][][] | join(', ', @)", data)
 	if err != nil {
 		return errors.New(response.Status)
 	}
@@ -26,5 +26,9 @@ func errorFromResponse(response *http.Response) error {
 		return errors.New(strings.Join(cast.ToStringSlice(searchArray), ", "))
 	}
 
-	return errors.New(cast.ToString(search))
+	toString := cast.ToString(search)
+	if toString == "" {
+		return errors.New(response.Status)
+	}
+	return errors.New(toString)
 }


### PR DESCRIPTION
The API doesn't return the error in the same format as the provider expected.
> panic: Invalid diagnostic: empty summary. This is always a bug in the provider implementation