### PR TITLE
feat: add alert group name v2

### DIFF
--- a/sysdig/internal/client/monitor/models.go
+++ b/sysdig/internal/client/monitor/models.go
@@ -48,6 +48,7 @@ type Alert struct {
 	Type                   string              `json:"type"` // computed MANUAL
 	Name                   string              `json:"name"`
 	Description            string              `json:"description"`
+	Group                  string              `json:"groupName"`
 	Enabled                bool                `json:"enabled"`
 	NotificationChannelIds []int               `json:"notificationChannelIds"`
 	Filter                 string              `json:"filter"`

--- a/sysdig/internal/client/monitor/models.go
+++ b/sysdig/internal/client/monitor/models.go
@@ -48,7 +48,7 @@ type Alert struct {
 	Type                   string              `json:"type"` // computed MANUAL
 	Name                   string              `json:"name"`
 	Description            string              `json:"description"`
-	Group                  string              `json:"groupName"`
+	Group                  string              `json:"groupName,omitempty"`
 	Enabled                bool                `json:"enabled"`
 	NotificationChannelIds []int               `json:"notificationChannelIds"`
 	Filter                 string              `json:"filter"`

--- a/sysdig/resource_sysdig_monitor_alert_common.go
+++ b/sysdig/resource_sysdig_monitor_alert_common.go
@@ -23,6 +23,10 @@ func createAlertSchema(original map[string]*schema.Schema) map[string]*schema.Sc
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"group": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"severity": {
 			Type:         schema.TypeInt,
 			Optional:     true,
@@ -148,6 +152,9 @@ func alertFromResourceData(d *schema.ResourceData) (alert *monitor.Alert, err er
 	if description, ok := d.GetOk("description"); ok {
 		alert.Description = description.(string)
 	}
+	if group, ok := d.GetOk("group"); ok {
+		alert.Group = group.(string)
+	}
 	if version, ok := d.GetOk("version"); ok {
 		alert.Version = version.(int)
 	}
@@ -195,6 +202,7 @@ func alertToResourceData(alert *monitor.Alert, data *schema.ResourceData) (err e
 	_ = data.Set("version", alert.Version)
 	_ = data.Set("name", alert.Name)
 	_ = data.Set("description", alert.Description)
+	_ = data.Set("group", alert.Group)
 	_ = data.Set("scope", alert.Filter)
 	_ = data.Set("trigger_after_minutes", int(trigger_after_minutes.Minutes()))
 	_ = data.Set("team", alert.TeamID)

--- a/website/docs/r/monitor_alert_anomaly.md
+++ b/website/docs/r/monitor_alert_anomaly.md
@@ -24,9 +24,9 @@ resource "sysdig_monitor_alert_anomaly" "sample" {
 
     trigger_after_minutes = 10
 
-	multiple_alerts_by = ["kubernetes.cluster.name", 
-                          "kubernetes.namespace.name", 
-                          "kubernetes.deployment.name", 
+	multiple_alerts_by = ["kubernetes.cluster.name",
+                          "kubernetes.namespace.name",
+                          "kubernetes.deployment.name",
                           "kubernetes.pod.name"]
 }
 ```
@@ -39,6 +39,7 @@ These arguments are common to all alerts in Sysdig Monitor.
 
 * `name` - (Required) The name of the Monitor alert. It must be unique.
 * `description` - (Optional) The description of Monitor alert.
+* `group` - (Optional) The group of Monitor alert.
 * `severity` - (Optional) Severity of the Monitor alert. It must be a value between 0 and 7,
                with 0 being the most critical and 7 the less critical. Defaults to 4.
 * `trigger_after_minutes` - (Required) Threshold of time for the status to stabilize until the alert is fired.

--- a/website/docs/r/monitor_alert_downtime.md
+++ b/website/docs/r/monitor_alert_downtime.md
@@ -21,7 +21,7 @@ resource "sysdig_monitor_alert_downtime" "sample" {
 	severity = 2
 
 	entities_to_monitor = ["kubernetes.namespace.name"]
-	
+
 	trigger_after_minutes = 10
 	trigger_after_pct = 100
 }
@@ -35,10 +35,11 @@ These arguments are common to all alerts in Sysdig Monitor.
 
 * `name` - (Required) The name of the Monitor alert. It must be unique.
 * `description` - (Optional) The description of Monitor alert.
+* `group` - (Optional) The group of Monitor alert.
 * `severity` - (Optional) Severity of the Monitor alert. It must be a value between 0 and 7,
                with 0 being the most critical and 7 the less critical. Defaults to 4.
 * `trigger_after_minutes` - (Required) Threshold of time for the status to stabilize until the alert is fired.
-* `scope` - (Optional) Part of the infrastructure where the alert is valid. Defaults to the entire infrastructure. 
+* `scope` - (Optional) Part of the infrastructure where the alert is valid. Defaults to the entire infrastructure.
 * `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
 * `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
 * `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.

--- a/website/docs/r/monitor_alert_event.md
+++ b/website/docs/r/monitor_alert_event.md
@@ -8,8 +8,8 @@ description: |-
 
 # Resource: sysdig_monitor_alert_event
 
-Creates a Sysdig Monitor Event Alert. Monitor occurrences of specific events, and alert if the total 
-number of occurrences violates a threshold. Useful for alerting on container, orchestration, and 
+Creates a Sysdig Monitor Event Alert. Monitor occurrences of specific events, and alert if the total
+number of occurrences violates a threshold. Useful for alerting on container, orchestration, and
 service events like restarts and deployments.
 
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
@@ -28,7 +28,7 @@ resource "sysdig_monitor_alert_event" "sample" {
 	event_count = 0
 
 	multiple_alerts_by = ["kubernetes.pod.name"]
-	
+
 	trigger_after_minutes = 1
 }
 ```
@@ -41,10 +41,11 @@ These arguments are common to all alerts in Sysdig Monitor.
 
 * `name` - (Required) The name of the Monitor alert. It must be unique.
 * `description` - (Optional) The description of Monitor alert.
+* `group` - (Optional) The group of Monitor alert.
 * `severity` - (Optional) Severity of the Monitor alert. It must be a value between 0 and 7,
                with 0 being the most critical and 7 the less critical. Defaults to 4.
 * `trigger_after_minutes` - (Required) Threshold of time for the status to stabilize until the alert is fired.
-* `scope` - (Optional) Part of the infrastructure where the alert is valid. Defaults to the entire infrastructure. 
+* `scope` - (Optional) Part of the infrastructure where the alert is valid. Defaults to the entire infrastructure.
 * `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
 * `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
 * `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.
@@ -71,7 +72,7 @@ is fired.
 ### Event alert arguments
 
 * `event_name` - (Required) String that matches part of name, tag or the description of Sysdig Events.
-* `source` - (Required) Source of the event. It can be `docker` or `kubernetes`. 
+* `source` - (Required) Source of the event. It can be `docker` or `kubernetes`.
 * `event_rel` - (Required) Relationship of the event count. It can be `>`, `>=`, `<`, `<=`, `=` or `!=`.
 * `event_count` - (Required) Number of events to match with event_rel.
 * `multiple_alerts_by` - (Optional) List of segments to trigger a separate alert on. Example: `["kubernetes.cluster.name", "kubernetes.namespace.name"]`.  

--- a/website/docs/r/monitor_alert_group_outlier.md
+++ b/website/docs/r/monitor_alert_group_outlier.md
@@ -21,7 +21,7 @@ resource "sysdig_monitor_alert_group_outlier" "sample" {
 	severity = 6
 
 	monitor = ["cpu.used.percent"]
-	
+
 	trigger_after_minutes = 10
 
 	capture {
@@ -39,10 +39,11 @@ These arguments are common to all alerts in Sysdig Monitor.
 
 * `name` - (Required) The name of the Monitor alert. It must be unique.
 * `description` - (Optional) The description of Monitor alert.
+* `group` - (Optional) The group of Monitor alert.
 * `severity` - (Optional) Severity of the Monitor alert. It must be a value between 0 and 7,
                with 0 being the most critical and 7 the less critical. Defaults to 4.
 * `trigger_after_minutes` - (Required) Threshold of time for the status to stabilize until the alert is fired.
-* `scope` - (Optional) Part of the infrastructure where the alert is valid. Defaults to the entire infrastructure. 
+* `scope` - (Optional) Part of the infrastructure where the alert is valid. Defaults to the entire infrastructure.
 * `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
 * `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
 * `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.

--- a/website/docs/r/monitor_alert_metric.md
+++ b/website/docs/r/monitor_alert_metric.md
@@ -43,10 +43,11 @@ These arguments are common to all alerts in Sysdig Monitor.
 
 * `name` - (Required) The name of the Monitor alert. It must be unique.
 * `description` - (Optional) The description of Monitor alert.
+* `group` - (Optional) The group of Monitor alert.
 * `severity` - (Optional) Severity of the Monitor alert. It must be a value between 0 and 7,
                with 0 being the most critical and 7 the less critical. Defaults to 4.
 * `trigger_after_minutes` - (Required) Threshold of time for the status to stabilize until the alert is fired.
-* `scope` - (Optional) Part of the infrastructure where the alert is valid. Defaults to the entire infrastructure. 
+* `scope` - (Optional) Part of the infrastructure where the alert is valid. Defaults to the entire infrastructure.
 * `enabled` - (Optional) Boolean that defines if the alert is enabled or not. Defaults to true.
 * `notification_channels` - (Optional) List of notification channel IDs where an alert must be sent to once fired.
 * `renotification_minutes` - (Optional) Number of minutes for the alert to re-notify until the status is solved.

--- a/website/docs/r/monitor_alert_promql.md
+++ b/website/docs/r/monitor_alert_promql.md
@@ -33,6 +33,7 @@ These arguments are common to all alerts in Sysdig Monitor.
 
 * `name` - (Required) The name of the Monitor alert. It must be unique.
 * `description` - (Optional) The description of Monitor alert.
+* `group` - (Optional) The group of Monitor alert.
 * `severity` - (Optional) Severity of the Monitor alert. It must be a value between 0 and 7,
                with 0 being the most critical and 7 the less critical. Defaults to 4.
 * `trigger_after_minutes` - (Required) Threshold of time for the status to stabilize until the alert is fired.


### PR DESCRIPTION
Add new field to monitor, to help organize alerts in sysdig UI. Instead of having them all in default.