### PR TITLE
Fargate | Add the parameter sysdig_logging to the fargate_workload_agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/rs/zerolog v1.26.1 // indirect
 	github.com/spf13/cast v1.4.1
+	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	golang.org/x/net v0.0.0-20220111093109-d55c255bac03 // indirect

--- a/sysdig/data_source_sysdig_fargate_ECS_test.go
+++ b/sysdig/data_source_sysdig_fargate_ECS_test.go
@@ -20,6 +20,7 @@ var (
 		OrchestratorPort: "orchestrator_port",
 		CollectorHost:    "collector_host",
 		CollectorPort:    "collector_port",
+		SysdigLogging:    "sysdig_logging",
 	}
 
 	testContainerDefinitionFiles = []string{
@@ -67,6 +68,7 @@ func TestECStransformation(t *testing.T) {
 		OrchestratorPort: "orchestrator_port",
 		CollectorHost:    "collector_host",
 		CollectorPort:    "collector_port",
+		SysdigLogging:    "sysdig_logging",
 	}
 
 	jsonConf, err := json.Marshal(&recipeConfig)

--- a/sysdig/data_source_sysdig_fargate_workload_agent.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent.go
@@ -21,7 +21,7 @@ const agentinoKiltDefinition = `build {
         "SYSDIG_COLLECTOR": ${config.collector_host}
         "SYSDIG_COLLECTOR_PORT": ${config.collector_port}
         "SYSDIG_ACCESS_KEY": ${config.sysdig_access_key}
-        "SYSDIG_LOGGING": ""
+        "SYSDIG_LOGGING": ${config.sysdig_logging}
     }
     mount: [
         {
@@ -76,6 +76,11 @@ func dataSourceSysdigFargateWorkloadAgent() *schema.Resource {
 			"collector_port": {
 				Type:        schema.TypeString,
 				Description: "the collector port to connect to",
+				Optional:    true,
+			},
+			"sysdig_logging": {
+				Type:        schema.TypeString,
+				Description: "the instrumentation logging level",
 				Optional:    true,
 			},
 			"output_container_definitions": {
@@ -169,6 +174,7 @@ type KiltRecipeConfig struct {
 	OrchestratorPort string `json:"orchestrator_port"`
 	CollectorHost    string `json:"collector_host"`
 	CollectorPort    string `json:"collector_port"`
+	SysdigLogging    string `json:"sysdig_logging"`
 }
 
 func dataSourceSysdigFargateWorkloadAgentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -179,6 +185,7 @@ func dataSourceSysdigFargateWorkloadAgentRead(ctx context.Context, d *schema.Res
 		OrchestratorPort: d.Get("orchestrator_port").(string),
 		CollectorHost:    d.Get("collector_host").(string),
 		CollectorPort:    d.Get("collector_port").(string),
+		SysdigLogging:    d.Get("sysdig_logging").(string),
 	}
 
 	jsonConf, err := json.Marshal(&recipeConfig)

--- a/sysdig/data_source_sysdig_fargate_workload_agent_test.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent_test.go
@@ -34,6 +34,7 @@ data "sysdig_fargate_workload_agent" "test" {
 	collector_port = 1234
 	sysdig_access_key = "abcdef"
 	workload_agent_image = "busybox"
+	sysdig_logging = "info"
 }
 `
 }

--- a/sysdig/testfiles/ECSInstrumented.json
+++ b/sysdig/testfiles/ECSInstrumented.json
@@ -17,7 +17,7 @@
       },
       {
         "Name": "SYSDIG_LOGGING",
-        "Value": ""
+        "Value": "sysdig_logging"
       },
       {
         "Name": "SYSDIG_ENDPOINT",

--- a/sysdig/testfiles/fargate_cmd_test_expected.json
+++ b/sysdig/testfiles/fargate_cmd_test_expected.json
@@ -30,7 +30,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_combined_test_expected.json
+++ b/sysdig/testfiles/fargate_combined_test_expected.json
@@ -30,7 +30,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_entrypoint_test_expected.json
+++ b/sysdig/testfiles/fargate_entrypoint_test_expected.json
@@ -27,7 +27,7 @@
       },
       {
         "Name": "SYSDIG_LOGGING",
-        "Value": ""
+        "Value": "sysdig_logging"
       },
       {
         "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_env_test_expected.json
+++ b/sysdig/testfiles/fargate_env_test_expected.json
@@ -27,7 +27,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_linuxparameters_test_expected.json
+++ b/sysdig/testfiles/fargate_linuxparameters_test_expected.json
@@ -27,7 +27,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_volumesfrom_test_expected.json
+++ b/sysdig/testfiles/fargate_volumesfrom_test_expected.json
@@ -30,7 +30,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/website/docs/d/fargate_workload_agent.md
+++ b/website/docs/d/fargate_workload_agent.md
@@ -39,6 +39,7 @@ data "sysdig_fargate_workload_agent" "instrumented_containers" {
 * `orchestrator_port` - (Optional) The orchestrator port to connect to.
 * `collector_host` - (Optional) The collector host to connect to.
 * `collector_port` - (Optional) The collector port to connect to.
+* `sysdig_logging` - (Optional) The instrumentation logging level: `trace`, `debug`, `info`, `warning`, `error`, `silent`.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Currently, there is no way to set the instrumentation logging level.

This PR fixes that by adding the parameter `sysdig_logging` to the `fargate_workload_agent`.