### PR TITLE
fix: add the parameter sysdig_logging to the fargate_workload_agent

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Get dependencies
         run: |
           go get -u -v github.com/onsi/ginkgo/ginkgo
+          go mod tidy
 
       - name: Test
         run: make test

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	cloud.google.com/go/storage v1.13.0 // indirect
-	github.com/Jeffail/gabs/v2 v2.6.1 // indirect
+	github.com/Jeffail/gabs/v2 v2.6.1
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.42.32
@@ -28,8 +28,9 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/rs/zerolog v1.26.1 // indirect
+	github.com/rs/zerolog v1.26.1
 	github.com/spf13/cast v1.4.1
+	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	golang.org/x/net v0.0.0-20220111093109-d55c255bac03 // indirect

--- a/sysdig/data_source_sysdig_fargate_ECS_test.go
+++ b/sysdig/data_source_sysdig_fargate_ECS_test.go
@@ -20,6 +20,7 @@ var (
 		OrchestratorPort: "orchestrator_port",
 		CollectorHost:    "collector_host",
 		CollectorPort:    "collector_port",
+		SysdigLogging:    "sysdig_logging",
 	}
 
 	testContainerDefinitionFiles = []string{
@@ -67,6 +68,7 @@ func TestECStransformation(t *testing.T) {
 		OrchestratorPort: "orchestrator_port",
 		CollectorHost:    "collector_host",
 		CollectorPort:    "collector_port",
+		SysdigLogging:    "sysdig_logging",
 	}
 
 	jsonConf, err := json.Marshal(&recipeConfig)

--- a/sysdig/data_source_sysdig_fargate_workload_agent.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent.go
@@ -24,7 +24,7 @@ const agentinoKiltDefinition = `build {
         "SYSDIG_COLLECTOR": ${config.collector_host}
         "SYSDIG_COLLECTOR_PORT": ${config.collector_port}
         "SYSDIG_ACCESS_KEY": ${config.sysdig_access_key}
-        "SYSDIG_LOGGING": ""
+        "SYSDIG_LOGGING": ${config.sysdig_logging}
     }
     mount: [
         {
@@ -105,6 +105,11 @@ func dataSourceSysdigFargateWorkloadAgent() *schema.Resource {
 						},
 					},
 				},
+			},
+			"sysdig_logging": {
+				Type:        schema.TypeString,
+				Description: "the instrumentation logging level",
+				Optional:    true,
 			},
 			"output_container_definitions": {
 				Type:     schema.TypeString,
@@ -236,6 +241,7 @@ type KiltRecipeConfig struct {
 	OrchestratorPort string `json:"orchestrator_port"`
 	CollectorHost    string `json:"collector_host"`
 	CollectorPort    string `json:"collector_port"`
+	SysdigLogging    string `json:"sysdig_logging"`
 }
 
 func dataSourceSysdigFargateWorkloadAgentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -246,6 +252,7 @@ func dataSourceSysdigFargateWorkloadAgentRead(ctx context.Context, d *schema.Res
 		OrchestratorPort: d.Get("orchestrator_port").(string),
 		CollectorHost:    d.Get("collector_host").(string),
 		CollectorPort:    d.Get("collector_port").(string),
+		SysdigLogging:    d.Get("sysdig_logging").(string),
 	}
 
 	jsonConf, err := json.Marshal(&recipeConfig)

--- a/sysdig/data_source_sysdig_fargate_workload_agent_test.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent_test.go
@@ -34,6 +34,7 @@ data "sysdig_fargate_workload_agent" "test" {
 	collector_port = 1234
 	sysdig_access_key = "abcdef"
 	workload_agent_image = "busybox"
+	sysdig_logging = "info"
 }
 `
 }

--- a/sysdig/testfiles/ECSInstrumented.json
+++ b/sysdig/testfiles/ECSInstrumented.json
@@ -17,7 +17,7 @@
       },
       {
         "Name": "SYSDIG_LOGGING",
-        "Value": ""
+        "Value": "sysdig_logging"
       },
       {
         "Name": "SYSDIG_ENDPOINT",

--- a/sysdig/testfiles/fargate_cmd_test_expected.json
+++ b/sysdig/testfiles/fargate_cmd_test_expected.json
@@ -30,7 +30,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_combined_test_expected.json
+++ b/sysdig/testfiles/fargate_combined_test_expected.json
@@ -30,7 +30,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_entrypoint_test_expected.json
+++ b/sysdig/testfiles/fargate_entrypoint_test_expected.json
@@ -27,7 +27,7 @@
       },
       {
         "Name": "SYSDIG_LOGGING",
-        "Value": ""
+        "Value": "sysdig_logging"
       },
       {
         "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_env_test_expected.json
+++ b/sysdig/testfiles/fargate_env_test_expected.json
@@ -27,7 +27,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_linuxparameters_test_expected.json
+++ b/sysdig/testfiles/fargate_linuxparameters_test_expected.json
@@ -27,7 +27,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_log_group_expected.json
+++ b/sysdig/testfiles/fargate_log_group_expected.json
@@ -30,7 +30,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/sysdig/testfiles/fargate_volumesfrom_test_expected.json
+++ b/sysdig/testfiles/fargate_volumesfrom_test_expected.json
@@ -30,7 +30,7 @@
             },
             {
                 "Name": "SYSDIG_LOGGING",
-                "Value": ""
+                "Value": "sysdig_logging"
             },
             {
                 "Name": "SYSDIG_ORCHESTRATOR",

--- a/website/docs/d/fargate_workload_agent.md
+++ b/website/docs/d/fargate_workload_agent.md
@@ -43,6 +43,7 @@ data "sysdig_fargate_workload_agent" "instrumented_containers" {
   * `group` - The name of the existing log group for instrumentation logs
   * `stream_prefix` - Prefix for the instrumentation log stream
   * `region` - The AWS region where the target log group resides
+* `sysdig_logging` - (Optional) The instrumentation logging level: `trace`, `debug`, `info`, `warning`, `error`, `silent`.
 
 
 ## Attributes Reference


### PR DESCRIPTION
This PR adds the parameter `sysdig_logging` to the `fargate_workload_agent` so that users can set the instrumentation logging level at deployment time.