### PR TITLE
feat: configure Fargate instrumentation log group

### DIFF
--- a/sysdig/data_source_sysdig_fargate_ECS_test.go
+++ b/sysdig/data_source_sysdig_fargate_ECS_test.go
@@ -151,3 +151,26 @@ func TestTransform(t *testing.T) {
 		})
 	}
 }
+
+func TestLogGroup(t *testing.T) {
+	jsonConfig, _ := json.Marshal(testKiltDefinition)
+	kiltConfig := &cfnpatcher.Configuration{
+		Kilt:               agentinoKiltDefinition,
+		ImageAuthSecret:    "image_auth_secret",
+		OptIn:              false,
+		UseRepositoryHints: true,
+		RecipeConfig:       string(jsonConfig),
+	}
+
+	logConfig := map[string]interface{}{
+		"group":         "test_log_group",
+		"stream_prefix": "test_prefix",
+		"region":        "test_region",
+	}
+
+	inputContainerDefinition, _ := ioutil.ReadFile("testfiles/fargate_log_group.json")
+	patched, _ := patchFargateTaskDefinition(context.Background(), string(inputContainerDefinition), kiltConfig, logConfig)
+	expectedContainerDefinition, _ := ioutil.ReadFile("testfiles/fargate_log_group_expected.json")
+
+	sortAndCompare(t, expectedContainerDefinition, []byte(*patched))
+}

--- a/sysdig/data_source_sysdig_fargate_ECS_test.go
+++ b/sysdig/data_source_sysdig_fargate_ECS_test.go
@@ -82,7 +82,7 @@ func TestECStransformation(t *testing.T) {
 		RecipeConfig:       string(jsonConf),
 	}
 
-	patchedOutput, err := patchFargateTaskDefinition(context.Background(), string(inputfile), kiltConfig)
+	patchedOutput, err := patchFargateTaskDefinition(context.Background(), string(inputfile), kiltConfig, nil)
 	if err != nil {
 		t.Fatalf("Cannot execute PatchFargateTaskDefinition : %v", err.Error())
 	}
@@ -144,7 +144,7 @@ func TestTransform(t *testing.T) {
 			}
 
 			inputContainerDefinition, _ := ioutil.ReadFile("testfiles/" + testName + ".json")
-			patched, _ := patchFargateTaskDefinition(context.Background(), string(inputContainerDefinition), kiltConfig)
+			patched, _ := patchFargateTaskDefinition(context.Background(), string(inputContainerDefinition), kiltConfig, nil)
 			expectedContainerDefinition, _ := ioutil.ReadFile("testfiles/" + testName + "_expected.json")
 
 			sortAndCompare(t, expectedContainerDefinition, []byte(*patched))

--- a/sysdig/data_source_sysdig_fargate_workload_agent.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent.go
@@ -78,6 +78,31 @@ func dataSourceSysdigFargateWorkloadAgent() *schema.Resource {
 				Description: "the collector port to connect to",
 				Optional:    true,
 			},
+			"log_configuration": {
+				Type:        schema.TypeSet,
+				MaxItems:    1,
+				Description: "configuration for instrumentation logs using the awslogs driver",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group": {
+							Type:        schema.TypeString,
+							Description: "The log group where the awslogs driver will send log streams",
+							Required:    true,
+						},
+						"stream_prefix": {
+							Type:        schema.TypeString,
+							Description: "Prefix for the instrumentation log stream",
+							Required:    true,
+						},
+						"region": {
+							Type:        schema.TypeString,
+							Description: "Region for the log group",
+							Required:    true,
+						},
+					},
+				},
+			},
 			"output_container_definitions": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/sysdig/data_source_sysdig_fargate_workload_agent.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent.go
@@ -7,6 +7,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Jeffail/gabs/v2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/falcosecurity/kilt/runtimes/cloudformation/cfnpatcher"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -125,8 +128,45 @@ type cfnStack struct {
 	Resources map[string]cfnResource `json:"Resources"`
 }
 
+// fargatePostKiltModifications performs any additional changes needed after
+// Kilt has applied it's transformations
+func fargatePostKiltModifications(patchedBytes []byte, logConfig map[string]interface{}) ([]byte, error) {
+	if len(logConfig) == 0 {
+		// no log configuration provided, nothing to do
+		return patchedBytes, nil
+	}
+
+	containers, err := gabs.ParseJSON(patchedBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse containers for post-processing: %s", err)
+	}
+
+	for _, container := range containers.Children() {
+		containerName, ok := container.Search("Name").Data().(string)
+		if !ok || containerName != "SysdigInstrumentation" {
+			// not the instrumentation container, skip it
+			continue
+		}
+
+		awsLogConfig := &ecs.LogConfiguration{
+			LogDriver: aws.String("awslogs"),
+			Options: map[string]*string{
+				"awslogs-group":         aws.String(logConfig["group"].(string)),
+				"awslogs-stream-prefix": aws.String(logConfig["stream_prefix"].(string)),
+				"awslogs-region":        aws.String(logConfig["region"].(string)),
+			},
+		}
+		_, err = container.Set(awsLogConfig, "LogConfiguration")
+		if err != nil {
+			return nil, fmt.Errorf("failed to set log configuration: %s", err)
+		}
+	}
+
+	return containers.Bytes(), nil
+}
+
 // PatchFargateTaskDefinition modifies the container definitions
-func patchFargateTaskDefinition(ctx context.Context, containerDefinitions string, kiltConfig *cfnpatcher.Configuration) (patched *string, err error) {
+func patchFargateTaskDefinition(ctx context.Context, containerDefinitions string, kiltConfig *cfnpatcher.Configuration, logConfig map[string]interface{}) (patched *string, err error) {
 	var cdefs []map[string]interface{}
 	err = json.Unmarshal([]byte(containerDefinitions), &cdefs)
 	if err != nil {
@@ -183,6 +223,8 @@ func patchFargateTaskDefinition(ctx context.Context, containerDefinitions string
 		return nil, err
 	}
 
+	patchedBytes, err = fargatePostKiltModifications(patchedBytes, logConfig)
+
 	patchedString := string(patchedBytes)
 	return &patchedString, nil
 }
@@ -221,7 +263,12 @@ func dataSourceSysdigFargateWorkloadAgentRead(ctx context.Context, d *schema.Res
 
 	containerDefinitions := d.Get("container_definitions").(string)
 
-	outputContainerDefinitions, err := patchFargateTaskDefinition(ctx, containerDefinitions, kiltConfig)
+	logConfig := map[string]interface{}{}
+	if logConfiguration := d.Get("log_configuration").(*schema.Set).List(); len(logConfiguration) > 0 {
+		logConfig = logConfiguration[0].(map[string]interface{})
+	}
+
+	outputContainerDefinitions, err := patchFargateTaskDefinition(ctx, containerDefinitions, kiltConfig, logConfig)
 	if err != nil {
 		return diag.Errorf("Error applying configuration patch: %v", err.Error())
 	}

--- a/sysdig/testfiles/fargate_log_group.json
+++ b/sysdig/testfiles/fargate_log_group.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "test",
+        "image": "test_image:latest",
+        "entryPoint": [
+            "/bin/test"
+        ],
+        "command": [
+            "test",
+            "--test-arg",
+            "test-arg-value"
+        ]
+    }
+]

--- a/sysdig/testfiles/fargate_log_group_expected.json
+++ b/sysdig/testfiles/fargate_log_group_expected.json
@@ -60,13 +60,14 @@
         "RepositoryCredentials": {
             "CredentialsParameter": "image_auth_secret"
         },
-        "logConfiguration": {
-            "logDriver": "awslogs",
-            "options": {
+        "LogConfiguration": {
+            "LogDriver": "awslogs",
+            "Options": {
                 "awslogs-group": "test_log_group",
                 "awslogs-stream-prefix": "test_prefix",
                 "awslogs-region": "test_region"
-            }
+            },
+            "SecretOptions": null
         }
     }
 ]

--- a/sysdig/testfiles/fargate_log_group_expected.json
+++ b/sysdig/testfiles/fargate_log_group_expected.json
@@ -1,0 +1,72 @@
+[
+    {
+        "name": "test",
+        "Image": "test_image:latest",
+        "EntryPoint": [
+            "/opt/draios/bin/instrument"
+        ],
+        "Command": [
+            "/bin/test",
+            "test",
+            "--test-arg",
+            "test-arg-value"
+        ],
+        "Environment": [
+            {
+                "Name": "SYSDIG_ORCHESTRATOR_PORT",
+                "Value": "orchestrator_port"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR",
+                "Value": "collector_host"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR_PORT",
+                "Value": "collector_port"
+            },
+            {
+                "Name": "SYSDIG_ACCESS_KEY",
+                "Value": "sysdig_access_key"
+            },
+            {
+                "Name": "SYSDIG_LOGGING",
+                "Value": ""
+            },
+            {
+                "Name": "SYSDIG_ORCHESTRATOR",
+                "Value": "orchestrator_host"
+            }
+        ],
+        "LinuxParameters": {
+            "Capabilities": {
+                "Add": [
+                    "SYS_PTRACE"
+                ]
+            }
+        },
+        "VolumesFrom": [
+            {
+                "ReadOnly": true,
+                "SourceContainer": "SysdigInstrumentation"
+            }
+        ]
+    },
+    {
+        "EntryPoint": [
+            "/opt/draios/bin/logwriter"
+        ],
+        "Image": "workload_agent_image",
+        "Name": "SysdigInstrumentation",
+        "RepositoryCredentials": {
+            "CredentialsParameter": "image_auth_secret"
+        },
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "test_log_group",
+                "awslogs-stream-prefix": "test_prefix",
+                "awslogs-region": "test_region"
+            }
+        }
+    }
+]

--- a/website/docs/d/fargate_workload_agent.md
+++ b/website/docs/d/fargate_workload_agent.md
@@ -39,6 +39,10 @@ data "sysdig_fargate_workload_agent" "instrumented_containers" {
 * `orchestrator_port` - (Optional) The orchestrator port to connect to.
 * `collector_host` - (Optional) The collector host to connect to.
 * `collector_port` - (Optional) The collector port to connect to.
+* `log_configuration` - (Optional) Configuration for the awslogs driver on the instrumentation container. All three values must be specified if instrumentation logging is desired:
+  * `group` - The name of the existing log group for instrumentation logs
+  * `stream_prefix` - Prefix for the instrumentation log stream
+  * `region` - The AWS region where the target log group resides
 
 
 ## Attributes Reference


### PR DESCRIPTION
Adds a new optional parameter block `log_configuration` which can be used to configure the `LogConfiguration` block on the sysdig instrumentation container, using the `awslogs` driver.