### PR TITLE
feat: Add a target to install/uninstall the provider locally

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,10 +5,26 @@ WEBSITE_REPO=github.com/hashicorp/terraform-website
 VERSION=$(shell [ ! -z `git tag -l --contains HEAD` ] && git tag -l --contains HEAD || git rev-parse --short HEAD)
 GOPATH=$(shell go env GOPATH)
 
+TERRAFORM_PLUGIN_ROOT_DIR=$(HOME)/.terraform.d/plugins
+TERRAFORM_PROVIDER_REFERENCE_NAME=local
+TERRAFORM_PROVIDER_NAME=sysdiglabs/$(PKG_NAME)
+TERRAFORM_PROVIDER_DEV_VERSION=1.0.0
+TERRAFORM_PLATFORM=$(shell terraform version -json | jq -r .platform)
+TERRAFORM_SYSDIG_PLUGIN_DIR=$(TERRAFORM_PLUGIN_ROOT_DIR)/$(TERRAFORM_PROVIDER_REFERENCE_NAME)/$(TERRAFORM_PROVIDER_NAME)/$(TERRAFORM_PROVIDER_DEV_VERSION)/$(TERRAFORM_PLATFORM)
+
 default: build
 
 build: fmtcheck
 	go install
+
+install: fmtcheck
+	go build -o terraform-provider-sysdig
+	mkdir -p $(TERRAFORM_SYSDIG_PLUGIN_DIR)
+	cp terraform-provider-sysdig $(TERRAFORM_SYSDIG_PLUGIN_DIR)/terraform-provider-sysdig
+
+uninstall:
+	rm -rf $(TERRAFORM_SYSDIG_PLUGIN_DIR)
+
 
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ That will add the provider to the terraform plugins dir. Then just set `source` 
 
 ```
 provider "aws" {
-  region = "us-east-1"
+  region = my_region
 }
 
 terraform {

--- a/README.md
+++ b/README.md
@@ -55,9 +55,40 @@ $ make test
 ```
 
 If you want to execute the acceptance tests, you can run `make testacc`.
+
 ```sh
 $ make testacc
 ```
+
+To use the local provider you just built, get it installed in your machine with:
+
+```sh
+$ make install
+```
+
+That will add the provider to the terraform plugins dir. Then just set `source` and `version` values appropiately:
+
+```
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    sysdig = {
+      source = "local/sysdiglabs/sysdig"
+      version = "~> 1.0.0"
+    }
+  }
+}
+```
+
+To uninstall the plugin:
+
+```
+$ make uninstall
+```
+
 
 <br/>:warning:Please note that you need a token for Monitor and Secure, and since the **acceptance tests create real infrastructure**
 you should execute them in an environment where you can remove the resorces easily.


### PR DESCRIPTION
Add `make install` to copy the provider to be used locally.