### PR TITLE
doc: remove documentation about direct mode

### DIFF
--- a/website/docs/d/fargate_workload_agent.md
+++ b/website/docs/d/fargate_workload_agent.md
@@ -12,7 +12,7 @@ Updates the fargate workload definition to add a [Sysdig Agent](https://docs.sys
 
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
-You can connect the Sysdig agent directly to a collector (using `collector_host` and `collector` port) or through an orchestrator (using `orchestrator_host` and `orchestrator_port`). For details about how to deploy an orchestrator check the [Sysdig Orchestrator module](https://registry.terraform.io/modules/sysdiglabs/fargate-orchestrator-agent/aws/latest).
+You'll need to connect the Sysdig Agent to the Sysdig backend through an orchestrator. For details about how to deploy an orchestrator check the [Sysdig Orchestrator module](https://registry.terraform.io/modules/sysdiglabs/fargate-orchestrator-agent/aws/latest).
 
 ## Example Usage
 
@@ -24,8 +24,8 @@ data "sysdig_fargate_workload_agent" "instrumented_containers" {
   workload_agent_image = "quay.io/sysdig/workload-agent:latest"
 
   sysdig_access_key = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-  collector_host    = "collector-static.sysdigcloud.com"
-  collector_port    = 6443
+  orchestrator_host    = module.fargate-orchestrator-agent.orchestrator_host
+  orchestrator_port    = module.fargate-orchestrator-agent.orchestrator_port
 }
 ```
 
@@ -33,12 +33,10 @@ data "sysdig_fargate_workload_agent" "instrumented_containers" {
 
 * `container_definitions` - (Required) The input Fargate container definitions to instrument with the Sysdig workload agent.
 * `sysdig_access_key` - (Required) The Sysdig Access Key (Agent token).
+* `orchestrator_host` - (Required) The orchestrator host to connect to.
+* `orchestrator_port` - (Required) The orchestrator port to connect to.
 * `workload_agent_image` - (Required) The Sysdig workload agent image.
 * `image_auth_secret` - (Optional) The registry authentication secret.
-* `orchestrator_host` - (Optional) The orchestrator host to connect to.
-* `orchestrator_port` - (Optional) The orchestrator port to connect to.
-* `collector_host` - (Optional) The collector host to connect to.
-* `collector_port` - (Optional) The collector port to connect to.
 * `log_configuration` - (Optional) Configuration for the awslogs driver on the instrumentation container. All three values must be specified if instrumentation logging is desired:
   * `group` - The name of the existing log group for instrumentation logs
   * `stream_prefix` - Prefix for the instrumentation log stream


### PR DESCRIPTION
There's no benefit in running direct mode, so remove the documentation for it. The right way of connecting to the backend is via the orchestrator agent.
