### PR TITLE
fix(monitor_team): update default theme property in docs

### DIFF
--- a/website/docs/r/monitor_team.md
+++ b/website/docs/r/monitor_team.md
@@ -46,7 +46,7 @@ data "sysdig_current_user" "me" {
 
 * `description` - (Optional) A description of the team.
 
-* `theme` - (Optional) Colour of the team. Default: "#73A1F7".
+* `theme` - (Optional) Colour of the team. Default: "#05C391".
 
 * `scope_by` - (Optional) Scope for the team. Default: "container".
 


### PR DESCRIPTION
small documentation update. 

the hex value of the `theme` property in `sysdig_monitor_team` in the documentation does not match the actual code value (as seen in https://github.com/sysdiglabs/terraform-provider-sysdig/blob/master/sysdig/resource_sysdig_monitor_team.go#L38). 
