### PR TITLE
feat: Make comps optional for falco exceptions

### DIFF
--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -74,7 +74,7 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 						},
 						"comps": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"values": {
@@ -190,6 +190,8 @@ func fieldOrCompsToStringSlice(fields any) ([]string, error) {
 		}
 	case string:
 		elements = append(elements, t)
+	case nil:
+		// do nothing
 	default:
 		return nil, fmt.Errorf("unexpected type: %T", t)
 	}

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -193,6 +193,11 @@ resource "sysdig_secure_rule_falco" "falco_rule_with_exceptions" {
    comps = ["in"]
    values = jsonencode(["foo"])
   }
+  exceptions {
+   name = "only_one_field_without_comps"
+   fields = ["ka.req.binding.subjects"]
+   values = jsonencode(["foo"])
+  }
 }
 `, name)
 }

--- a/website/docs/r/secure_rule_falco.md
+++ b/website/docs/r/secure_rule_falco.md
@@ -77,7 +77,7 @@ Supported fields for exceptions:
 
 * `name` - (Required) The name of the exception. Only used to provide a handy name, and to potentially link together values in a later rule that has `append = true`.
 * `fields` - (Required) Contains one or more fields that will extract a value from the syscall/k8s_audit events.
-* `comps` - (Required) Contains comparison operators that align 1-1 with the items in the fields property.
+* `comps` - (Optional) Contains comparison operators that align 1-1 with the items in the fields property.
 * `values` - (Required) Contains tuples of values. Each item in the tuple should align 1-1 with the corresponding field and comparison operator. Since the value can be a string, a list of strings or a list of a list of strings, the value of this field must be supplied in JSON format. You can use the default `jsonencode` function to provide this value. See the usage example on the top.
 
 ## Attributes Reference


### PR DESCRIPTION
The comps field can be optional in the API, and is automatically evaluated with a default value when imported in Falco and Cloud Connector.