### PR TITLE
feat(monitor): deprecate not supported resources

### DIFF
--- a/sysdig/resource_sysdig_monitor_alert_anomaly.go
+++ b/sysdig/resource_sysdig_monitor_alert_anomaly.go
@@ -15,10 +15,11 @@ func resourceSysdigMonitorAlertAnomaly() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		CreateContext: resourceSysdigAlertAnomalyCreate,
-		UpdateContext: resourceSysdigAlertAnomalyUpdate,
-		ReadContext:   resourceSysdigAlertAnomalyRead,
-		DeleteContext: resourceSysdigAlertAnomalyDelete,
+		DeprecationMessage: "Anomaly Detection Alerts have been deprecated, \"sysdig_monitor_alert_anomaly\" will be removed in future releases",
+		CreateContext:      resourceSysdigAlertAnomalyCreate,
+		UpdateContext:      resourceSysdigAlertAnomalyUpdate,
+		ReadContext:        resourceSysdigAlertAnomalyRead,
+		DeleteContext:      resourceSysdigAlertAnomalyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/sysdig/resource_sysdig_monitor_alert_group_outlier.go
+++ b/sysdig/resource_sysdig_monitor_alert_group_outlier.go
@@ -15,10 +15,11 @@ func resourceSysdigMonitorAlertGroupOutlier() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		CreateContext: resourceSysdigAlertGroupOutlierCreate,
-		UpdateContext: resourceSysdigAlertGroupOutlierUpdate,
-		ReadContext:   resourceSysdigAlertGroupOutlierRead,
-		DeleteContext: resourceSysdigAlertGroupOutlierDelete,
+		DeprecationMessage: "Group Outlier Alerts have been deprecated, \"sysdig_monitor_alert_group_outlier\" will be removed in future releases",
+		CreateContext:      resourceSysdigAlertGroupOutlierCreate,
+		UpdateContext:      resourceSysdigAlertGroupOutlierUpdate,
+		ReadContext:        resourceSysdigAlertGroupOutlierRead,
+		DeleteContext:      resourceSysdigAlertGroupOutlierDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/website/docs/r/monitor_alert_anomaly.md
+++ b/website/docs/r/monitor_alert_anomaly.md
@@ -10,6 +10,8 @@ description: |-
 
 Creates a Sysdig Monitor Anomaly Alert. Monitor hosts based on their historical behaviors and alert when they deviate.
 
+~> **Deprecation Notice:** Anomaly Detection Alerts have been deprecated in Sysdig Monitor, `sysdig_monitor_alert_anomaly` will be removed in future releases, consider rewriting the resource as a promql alert.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/r/monitor_alert_group_outlier.md
+++ b/website/docs/r/monitor_alert_group_outlier.md
@@ -10,6 +10,8 @@ description: |-
 
 Creates a Sysdig Monitor Group Outlier Alert. Monitor a group of hosts and be notified when one acts differently from the rest.
 
+~> **Deprecation Notice:** Group Outlier Alerts have been deprecated in Sysdig Monitor, `sysdig_monitor_alert_group_outlier` will be removed in future releases, consider rewriting the resource as a promql alert.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage


### PR DESCRIPTION
Deprecate `sysdig_monitor_alert_anomaly` and `sysdig_monitor_alert_group_outlier` resources.
