### PR TITLE
feat(secure-policy): Make capture name mandatory. Fixes #197

### DIFF
--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -113,7 +113,7 @@ func resourceSysdigSecurePolicy() *schema.Resource {
 									},
 									"name": {
 										Type:     schema.TypeString,
-										Optional: true,
+										Required: true,
 										Computed: true,
 									},
 								},

--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -114,7 +114,6 @@ func resourceSysdigSecurePolicy() *schema.Resource {
 									"name": {
 										Type:     schema.TypeString,
 										Required: true,
-										Computed: true,
 									},
 								},
 							},

--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -145,6 +145,7 @@ resource "sysdig_secure_policy" "sample_%d" {
     capture {
       seconds_before_event = 5
       seconds_after_event = 10
+      name = "testcapture"
     }
   }
 }


### PR DESCRIPTION
As described in #197 , the capture name field should be mandatory.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->