### PR TITLE
fix(secure-policy): Update falco rule exceptions type to match falco expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ make test
 If you want to execute the **acceptance tests**, you can run `make testacc`.
 - Follow [Terraform acceptance test guideliness](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests)
 - Please note that you need a token for Sysdig Monitor and another one for Sysdig Secure, and since the **acceptance tests create real infrastructure**
-you should execute them in an environment where you can remove the resorces easily.
+you should execute them in an environment where you can remove the resources easily.
 - Acceptance tests are launched in Sysdig production environment
 
 ```sh

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -78,9 +78,8 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"values": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeString,
 							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeList, Elem: &schema.Schema{Type: schema.TypeString}},
 						},
 						"fields": {
 							Type:     schema.TypeList,
@@ -289,9 +288,10 @@ func resourceSysdigRuleFalcoFromResourceData(d *schema.ResourceData) (secure.Rul
 				newFalcoException.Comps = comps
 			}
 
-			values := cast.ToSlice(exceptionMap["values"])
-			if len(values) >= 1 {
-				newFalcoException.Values = values
+			values := cast.ToString(exceptionMap["values"])
+			err := json.Unmarshal([]byte(values), &newFalcoException.Values)
+			if err != nil {
+				return secure.Rule{}, err
 			}
 
 			fields := cast.ToStringSlice(exceptionMap["fields"])

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -78,8 +78,9 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"values": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeList,
 							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeList, Elem: &schema.Schema{Type: schema.TypeString}},
 						},
 						"fields": {
 							Type:     schema.TypeList,
@@ -284,24 +285,17 @@ func resourceSysdigRuleFalcoFromResourceData(d *schema.ResourceData) (secure.Rul
 			}
 
 			comps := cast.ToStringSlice(exceptionMap["comps"])
-			if len(comps) == 1 {
-				newFalcoException.Comps = comps[0]
-			}
-			if len(comps) > 1 {
+			if len(comps) >= 1 {
 				newFalcoException.Comps = comps
 			}
 
-			values := cast.ToString(exceptionMap["values"])
-			err := json.Unmarshal([]byte(values), &newFalcoException.Values)
-			if err != nil {
-				return secure.Rule{}, err
+			values := cast.ToSlice(exceptionMap["values"])
+			if len(values) >= 1 {
+				newFalcoException.Values = values
 			}
 
 			fields := cast.ToStringSlice(exceptionMap["fields"])
-			if len(fields) == 1 {
-				newFalcoException.Fields = fields[0]
-			}
-			if len(fields) > 1 {
+			if len(fields) >= 1 {
 				newFalcoException.Fields = fields
 			}
 

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -191,12 +191,12 @@ resource "sysdig_secure_rule_falco" "falco_rule_with_exceptions" {
    name = "only_one_field"
    fields = ["ka.req.binding.subjects"]
    comps = ["in"]
-   values = jsonencode(["foo"])
+   values = jsonencode([["foo"]])
   }
   exceptions {
    name = "only_one_field_without_comps"
    fields = ["ka.req.binding.subjects"]
-   values = jsonencode(["foo"])
+   values = jsonencode([["foo"]])
   }
 }
 `, name)

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -213,7 +213,7 @@ resource "sysdig_secure_rule_falco" "attach_to_cluster_admin_role_exceptions" {
         name = "proc_name"
         fields = ["proc.name"]
         comps = ["in"]
-        values = jsonencode(["sh"])
+        values = jsonencode([["sh"]])
    }
 }`
 }

--- a/website/docs/r/secure_rule_falco.md
+++ b/website/docs/r/secure_rule_falco.md
@@ -30,7 +30,7 @@ resource "sysdig_secure_rule_falco" "example" {
     name   = "proc_names"
     fields = ["proc.name"]
     comps  = ["in"]
-    values = jsonencode(["python", "python2", "python3"]) # If only one element is provided, do not specify it a list of lists.
+    values = jsonencode([[["python", "python2", "python3"]]]) # If only one element is provided, it should still needs to be specified as a list of lists.
   }
 
   exceptions {


### PR DESCRIPTION
This PR fixes the way falco rule exceptions are handled.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->