### PR TITLE
feat(cloud-account): add new workload identity field for gcp organizational

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 *fargate* @marojor @achandras @francesco-racciatti
 
 # compliance
-*benchmark* @haresh-suresh  @nkraemer-sysdig 
+*benchmark* @haresh-suresh  @nkraemer-sysdig @sameer-in
 
 # monitor
 *monitor*alert* @arturodilecce @dbonf

--- a/sysdig/internal/client/secure/cloud_account.go
+++ b/sysdig/internal/client/secure/cloud_account.go
@@ -27,7 +27,7 @@ func (client *sysdigSecureClient) trustedCloudIdentityURL(provider string) strin
 }
 
 func (client *sysdigSecureClient) CreateCloudAccount(ctx context.Context, cloudAccount *CloudAccount) (*CloudAccount, error) {
-	response, err := client.doSysdigSecureRequest(ctx, http.MethodPost, client.cloudAccountURL(true), cloudAccount.ToJSON())
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodPost, client.cloudAccountURL(false), cloudAccount.ToJSON())
 	if err != nil {
 		return nil, err
 	}

--- a/sysdig/internal/client/secure/cloud_account.go
+++ b/sysdig/internal/client/secure/cloud_account.go
@@ -27,7 +27,7 @@ func (client *sysdigSecureClient) trustedCloudIdentityURL(provider string) strin
 }
 
 func (client *sysdigSecureClient) CreateCloudAccount(ctx context.Context, cloudAccount *CloudAccount) (*CloudAccount, error) {
-	response, err := client.doSysdigSecureRequest(ctx, http.MethodPost, client.cloudAccountURL(false), cloudAccount.ToJSON())
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodPost, client.cloudAccountURL(true), cloudAccount.ToJSON())
 	if err != nil {
 		return nil, err
 	}

--- a/sysdig/internal/client/secure/models.go
+++ b/sysdig/internal/client/secure/models.go
@@ -366,12 +366,13 @@ func VulnerabilityExceptionFromJSON(body []byte) *VulnerabilityException {
 // -------- CloudAccount --------
 
 type CloudAccount struct {
-	AccountID     string `json:"accountId"`
-	Provider      string `json:"provider"`
-	Alias         string `json:"alias"`
-	RoleAvailable bool   `json:"roleAvailable"`
-	RoleName      string `json:"roleName"`
-	ExternalID    string `json:"externalId,omitempty"`
+	AccountID                 string `json:"accountId"`
+	Provider                  string `json:"provider"`
+	Alias                     string `json:"alias"`
+	RoleAvailable             bool   `json:"roleAvailable"`
+	RoleName                  string `json:"roleName"`
+	ExternalID                string `json:"externalId,omitempty"`
+	WorkLoadIdentityAccountID string `json:"workloadIdentityAccountId,omitempty"`
 }
 
 func (e *CloudAccount) ToJSON() io.Reader {

--- a/sysdig/resource_sysdig_secure_cloud_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_account.go
@@ -58,6 +58,10 @@ func resourceSysdigSecureCloudAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"workload_identity_account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -80,6 +84,7 @@ func resourceSysdigSecureCloudAccountCreate(ctx context.Context, d *schema.Resou
 	_ = d.Set("role_enabled", cloudAccount.RoleAvailable)
 	_ = d.Set("role_name", cloudAccount.RoleName)
 	_ = d.Set("external_id", cloudAccount.ExternalID)
+	_ = d.Set("workload_identity_account_id", cloudAccount.WorkLoadIdentityAccountID)
 
 	return nil
 }
@@ -106,6 +111,7 @@ func resourceSysdigSecureCloudAccountRead(ctx context.Context, d *schema.Resourc
 	_ = d.Set("role_enabled", cloudAccount.RoleAvailable)
 	_ = d.Set("role_name", cloudAccount.RoleName)
 	_ = d.Set("external_id", cloudAccount.ExternalID)
+	_ = d.Set("workload_identity_account_id", cloudAccount.WorkLoadIdentityAccountID)
 
 	return nil
 }
@@ -145,10 +151,11 @@ func resourceSysdigSecureCloudAccountDelete(ctx context.Context, d *schema.Resou
 
 func cloudAccountFromResourceData(d *schema.ResourceData) *secure.CloudAccount {
 	return &secure.CloudAccount{
-		AccountID:     d.Get("account_id").(string),
-		Provider:      d.Get("cloud_provider").(string),
-		Alias:         d.Get("alias").(string),
-		RoleAvailable: d.Get("role_enabled").(bool),
-		RoleName:      d.Get("role_name").(string),
+		AccountID:                 d.Get("account_id").(string),
+		Provider:                  d.Get("cloud_provider").(string),
+		Alias:                     d.Get("alias").(string),
+		RoleAvailable:             d.Get("role_enabled").(bool),
+		RoleName:                  d.Get("role_name").(string),
+		WorkLoadIdentityAccountID: d.Get("workload_identity_account_id").(string),
 	}
 }

--- a/sysdig/resource_sysdig_secure_cloud_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_account_test.go
@@ -61,3 +61,43 @@ resource "sysdig_secure_cloud_account" "sample" {
   cloud_provider  = "aws"
 }`, accountID)
 }
+
+func TestAccSecureCloudAccountWID(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+	accID := rText()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: secureCloudAccountWithWID(accID),
+			},
+			{
+				ResourceName:      "sysdig_secure_cloud_account.sample-1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func secureCloudAccountWithWID(accountID string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_cloud_account" "sample-1" {
+  account_id          = "sample-1-%s"
+  cloud_provider      = "aws"
+  alias               = "%s"
+  role_enabled        = "false"
+  role_name            = "CustomRoleName"
+  workload_identity_account_id = "sample-1-%s"
+}
+`, accountID, accountID, accountID)
+}

--- a/website/docs/r/secure_cloud_account.md
+++ b/website/docs/r/secure_cloud_account.md
@@ -21,6 +21,7 @@ resource "sysdig_secure_cloud_account" "sample" {
   alias               = "prod"
   role_enabled        = "false"
   role_name           = "CustomRoleName"
+  workload_identity_account_id = "457345678065"
 }
 ```
 
@@ -35,6 +36,8 @@ resource "sysdig_secure_cloud_account" "sample" {
 * `role_enabled` - (Optional) Whether or not a role is provisioned withing this account, that Sysdig has permission to AssumeRole in order to run Benchmarks. Default: `false`.
 
 * `role_name` - (Optional) The name of the role Sysdig will have permission to AssumeRole if `role_enaled` is set to `true`. Default: `SysdigCloudBench`.
+
+* `workload_identity_account_id` - (Optional) For GCP only. The account id in which workload identity is present for this account in gcp org.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->
- Adding a new field in sysdig cloud account. its called `workload_identity_account_id`
- This is only used for GCP
- If a customer has GCP Org set up, then this field needs to be set to `account id` in which workload identity for current 
account is set up.