### PR TITLE
fix(secure-policy): Add support for name/value exceptions

### DIFF
--- a/sysdig/internal/client/secure/models.go
+++ b/sysdig/internal/client/secure/models.go
@@ -202,9 +202,10 @@ type Condition struct {
 
 type Exception struct {
 	Name   string      `json:"name"`
-	Fields interface{} `json:"fields"`
-	Comps  interface{} `json:"comps"`
+	Fields interface{} `json:"fields,omitempty"`
+	Comps  interface{} `json:"comps,omitempty"`
 	Values interface{} `json:"values,omitempty"`
+	Value  interface{} `json:"value,omitempty"`
 }
 
 func (r *Rule) ToJSON() io.Reader {

--- a/website/docs/r/secure_rule_falco.md
+++ b/website/docs/r/secure_rule_falco.md
@@ -81,7 +81,7 @@ For more information about the syntax of the exceptions, check the [official Fal
 Supported fields for exceptions:
 
 * `name` - (Required) The name of the exception. Only used to provide a handy name, and to potentially link together values in a later rule that has `append = true`.
-* `fields` - (Required) Contains one or more fields that will extract a value from the syscall/k8s_audit events.
+* `fields` - (Optional) Contains one or more fields that will extract a value from the syscall/k8s_audit events.
 * `comps` - (Optional) Contains comparison operators that align 1-1 with the items in the fields property.
 * `values` - (Optional) Contains tuples of values. Each item in the tuple should align 1-1 with the corresponding field
   and comparison operator. Since the value can be a string, a list of strings or a list of a list of strings, the value

--- a/website/docs/r/secure_rule_falco.md
+++ b/website/docs/r/secure_rule_falco.md
@@ -51,6 +51,11 @@ resource "sysdig_secure_rule_falco" "example" {
       [["java"], "sdjagent.jar"]
     ])
   }
+
+  exceptions {
+    name   = "image_suffix"
+    value = "secure-inline-scan" # Example of an exception with just a name/value pair
+  }
 }
 ```
 
@@ -78,7 +83,12 @@ Supported fields for exceptions:
 * `name` - (Required) The name of the exception. Only used to provide a handy name, and to potentially link together values in a later rule that has `append = true`.
 * `fields` - (Required) Contains one or more fields that will extract a value from the syscall/k8s_audit events.
 * `comps` - (Optional) Contains comparison operators that align 1-1 with the items in the fields property.
-* `values` - (Required) Contains tuples of values. Each item in the tuple should align 1-1 with the corresponding field and comparison operator. Since the value can be a string, a list of strings or a list of a list of strings, the value of this field must be supplied in JSON format. You can use the default `jsonencode` function to provide this value. See the usage example on the top.
+* `values` - (Optional) Contains tuples of values. Each item in the tuple should align 1-1 with the corresponding field
+  and comparison operator. Since the value can be a string, a list of strings or a list of a list of strings, the value
+  of this field must be supplied in JSON format. You can use the default `jsonencode` function to provide this value.
+  See the usage example on the top. **Required** if `fields` and `comps` are set.
+* `value` - (Optional) Contains the single value used when exception is a name/value pair. **Required** if `fields` and
+  `comps` are not set
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds support for exceptions that use just name and value.
