### PR TITLE
fix(secure-policy) Fix falco rule support to allow fields and comps to be optional

### DIFF
--- a/sysdig/internal/client/secure/models.go
+++ b/sysdig/internal/client/secure/models.go
@@ -205,7 +205,6 @@ type Exception struct {
 	Fields interface{} `json:"fields,omitempty"`
 	Comps  interface{} `json:"comps,omitempty"`
 	Values interface{} `json:"values,omitempty"`
-	Value  interface{} `json:"value,omitempty"`
 }
 
 func (r *Rule) ToJSON() io.Reader {

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -79,11 +79,7 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 						},
 						"values": {
 							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"value": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 						},
 						"fields": {
 							Type:     schema.TypeList,
@@ -298,20 +294,9 @@ func resourceSysdigRuleFalcoFromResourceData(d *schema.ResourceData) (secure.Rul
 			}
 
 			values := cast.ToString(exceptionMap["values"])
-			if values != "" {
-				err := json.Unmarshal([]byte(values), &newFalcoException.Values)
-				if err != nil {
-					return secure.Rule{}, err
-				}
-			} else if newFalcoException.Fields != nil && newFalcoException.Comps != nil {
-				return secure.Rule{}, errors.New("values is required on an exception when fields and comps are set")
-			}
-
-			value := cast.ToString(exceptionMap["value"])
-			newFalcoException.Value = value
-
-			if newFalcoException.Fields == nil && newFalcoException.Comps == nil && value == "" {
-				return secure.Rule{}, errors.New("value is required on an exception when fields and comps are not set")
+			err := json.Unmarshal([]byte(values), &newFalcoException.Values)
+			if err != nil {
+				return secure.Rule{}, err
 			}
 
 			falcoExceptions = append(falcoExceptions, newFalcoException)

--- a/website/docs/r/secure_rule_falco.md
+++ b/website/docs/r/secure_rule_falco.md
@@ -51,11 +51,6 @@ resource "sysdig_secure_rule_falco" "example" {
       [["java"], "sdjagent.jar"]
     ])
   }
-
-  exceptions {
-    name   = "image_suffix"
-    value = "secure-inline-scan" # Example of an exception with just a name/value pair
-  }
 }
 ```
 
@@ -83,12 +78,10 @@ Supported fields for exceptions:
 * `name` - (Required) The name of the exception. Only used to provide a handy name, and to potentially link together values in a later rule that has `append = true`.
 * `fields` - (Optional) Contains one or more fields that will extract a value from the syscall/k8s_audit events.
 * `comps` - (Optional) Contains comparison operators that align 1-1 with the items in the fields property.
-* `values` - (Optional) Contains tuples of values. Each item in the tuple should align 1-1 with the corresponding field
+* `values` - (Required) Contains tuples of values. Each item in the tuple should align 1-1 with the corresponding field
   and comparison operator. Since the value can be a string, a list of strings or a list of a list of strings, the value
   of this field must be supplied in JSON format. You can use the default `jsonencode` function to provide this value.
-  See the usage example on the top. **Required** if `fields` and `comps` are set.
-* `value` - (Optional) Contains the single value used when exception is a name/value pair. **Required** if `fields` and
-  `comps` are not set
+  See the usage example on the top.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adjusts the support for exceptions so that fields and comps are optional.  It also fixes the issue of adding a property that is not used by falco.
