### PR TITLE
Adding workload identity alias field in cloud account

### DIFF
--- a/sysdig/internal/client/secure/models.go
+++ b/sysdig/internal/client/secure/models.go
@@ -366,13 +366,14 @@ func VulnerabilityExceptionFromJSON(body []byte) *VulnerabilityException {
 // -------- CloudAccount --------
 
 type CloudAccount struct {
-	AccountID                 string `json:"accountId"`
-	Provider                  string `json:"provider"`
-	Alias                     string `json:"alias"`
-	RoleAvailable             bool   `json:"roleAvailable"`
-	RoleName                  string `json:"roleName"`
-	ExternalID                string `json:"externalId,omitempty"`
-	WorkLoadIdentityAccountID string `json:"workloadIdentityAccountId,omitempty"`
+	AccountID                    string `json:"accountId"`
+	Provider                     string `json:"provider"`
+	Alias                        string `json:"alias"`
+	RoleAvailable                bool   `json:"roleAvailable"`
+	RoleName                     string `json:"roleName"`
+	ExternalID                   string `json:"externalId,omitempty"`
+	WorkLoadIdentityAccountID    string `json:"workloadIdentityAccountId,omitempty"`
+	WorkLoadIdentityAccountAlias string `json:"workLoadIdentityAccountAlias,omitempty"`
 }
 
 func (e *CloudAccount) ToJSON() io.Reader {

--- a/sysdig/resource_sysdig_secure_cloud_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_account.go
@@ -62,6 +62,10 @@ func resourceSysdigSecureCloudAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"workload_identity_account_alias": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -85,6 +89,7 @@ func resourceSysdigSecureCloudAccountCreate(ctx context.Context, d *schema.Resou
 	_ = d.Set("role_name", cloudAccount.RoleName)
 	_ = d.Set("external_id", cloudAccount.ExternalID)
 	_ = d.Set("workload_identity_account_id", cloudAccount.WorkLoadIdentityAccountID)
+	_ = d.Set("workload_identity_account_alias", cloudAccount.WorkLoadIdentityAccountAlias)
 
 	return nil
 }
@@ -112,6 +117,7 @@ func resourceSysdigSecureCloudAccountRead(ctx context.Context, d *schema.Resourc
 	_ = d.Set("role_name", cloudAccount.RoleName)
 	_ = d.Set("external_id", cloudAccount.ExternalID)
 	_ = d.Set("workload_identity_account_id", cloudAccount.WorkLoadIdentityAccountID)
+	_ = d.Set("workload_identity_account_alias", cloudAccount.WorkLoadIdentityAccountAlias)
 
 	return nil
 }
@@ -151,11 +157,12 @@ func resourceSysdigSecureCloudAccountDelete(ctx context.Context, d *schema.Resou
 
 func cloudAccountFromResourceData(d *schema.ResourceData) *secure.CloudAccount {
 	return &secure.CloudAccount{
-		AccountID:                 d.Get("account_id").(string),
-		Provider:                  d.Get("cloud_provider").(string),
-		Alias:                     d.Get("alias").(string),
-		RoleAvailable:             d.Get("role_enabled").(bool),
-		RoleName:                  d.Get("role_name").(string),
-		WorkLoadIdentityAccountID: d.Get("workload_identity_account_id").(string),
+		AccountID:                    d.Get("account_id").(string),
+		Provider:                     d.Get("cloud_provider").(string),
+		Alias:                        d.Get("alias").(string),
+		RoleAvailable:                d.Get("role_enabled").(bool),
+		RoleName:                     d.Get("role_name").(string),
+		WorkLoadIdentityAccountID:    d.Get("workload_identity_account_id").(string),
+		WorkLoadIdentityAccountAlias: d.Get("workload_identity_account_alias").(string),
 	}
 }

--- a/sysdig/resource_sysdig_secure_cloud_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_account_test.go
@@ -98,6 +98,7 @@ resource "sysdig_secure_cloud_account" "sample-1" {
   role_enabled        = "false"
   role_name            = "CustomRoleName"
   workload_identity_account_id = "sample-1-%s"
+  workload_identity_account_alias = "%s"
 }
 `, accountID, accountID, accountID)
 }

--- a/website/docs/r/secure_cloud_account.md
+++ b/website/docs/r/secure_cloud_account.md
@@ -22,6 +22,7 @@ resource "sysdig_secure_cloud_account" "sample" {
   role_enabled        = "false"
   role_name           = "CustomRoleName"
   workload_identity_account_id = "457345678065"
+  workload_identity_account_alias = "prod-alias"
 }
 ```
 
@@ -38,6 +39,8 @@ resource "sysdig_secure_cloud_account" "sample" {
 * `role_name` - (Optional) The name of the role Sysdig will have permission to AssumeRole if `role_enaled` is set to `true`. Default: `SysdigCloudBench`.
 
 * `workload_identity_account_id` - (Optional) For GCP only. The account id in which workload identity is present for this account in gcp org.
+
+* `workload_identity_account_alias` - (Optional) For GCP only. The alias of workload identity is present for this account in gcp org.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->