### PR TITLE
ci(Github): fix notification failure condition

### DIFF
--- a/.github/workflows/ci-scheduled-tests.yml
+++ b/.github/workflows/ci-scheduled-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
   slackNotification:
     needs: test
-    if: needs.test.result == 'failed'
+    if: ${{ failure() }}
     name: Slack Notification
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Actually, when the scheduled test fails, the slack notification doesn't work properly.

Following Github actions documentation (https://docs.github.com/en/actions/learn-github-actions/expressions#failure), we update the condition to detect any failure in the previous job (test).