### PR TITLE
feat(legacy scanning policies and assignments): Add scanning policies and assignments for legacy engine

### DIFF
--- a/sysdig/internal/client/secure/client.go
+++ b/sysdig/internal/client/secure/client.go
@@ -63,6 +63,11 @@ type SysdigSecureClient interface {
 	GetBenchmarkTask(context.Context, string) (*BenchmarkTask, error)
 	DeleteBenchmarkTask(context.Context, string) error
 	SetBenchmarkTaskEnabled(context.Context, string, bool) error
+
+	CreateScanningPolicy(context.Context, ScanningPolicy) (ScanningPolicy, error)
+	GetScanningPolicyById(context.Context, string) (ScanningPolicy, error)
+	DeleteScanningPolicyById(context.Context, string) error
+	UpdateScanningPolicyById(context.Context, ScanningPolicy) (ScanningPolicy, error)
 }
 
 func WithExtraHeaders(client SysdigSecureClient, extraHeaders map[string]string) SysdigSecureClient {

--- a/sysdig/internal/client/secure/client.go
+++ b/sysdig/internal/client/secure/client.go
@@ -68,6 +68,10 @@ type SysdigSecureClient interface {
 	GetScanningPolicyById(context.Context, string) (ScanningPolicy, error)
 	DeleteScanningPolicyById(context.Context, string) error
 	UpdateScanningPolicyById(context.Context, ScanningPolicy) (ScanningPolicy, error)
+
+	CreateScanningPolicyAssignmentList(context.Context, ScanningPolicyAssignmentList) (ScanningPolicyAssignmentList, error)
+	GetScanningPolicyAssignmentList(context.Context) (ScanningPolicyAssignmentList, error)
+	DeleteScanningPolicyAssignmentList(context.Context, ScanningPolicyAssignmentList) error
 }
 
 func WithExtraHeaders(client SysdigSecureClient, extraHeaders map[string]string) SysdigSecureClient {

--- a/sysdig/internal/client/secure/models.go
+++ b/sysdig/internal/client/secure/models.go
@@ -416,3 +416,37 @@ func BenchmarkTaskFromJSON(body []byte) *BenchmarkTask {
 
 	return &result
 }
+
+// -------- Scanning Policies --------
+type ScanningPolicy struct {
+	ID             string         `json:"id,omitempty"`
+	Version        string         `json:"version,omitempty"`
+	Name           string         `json:"name"`
+	Comment        string         `json:"comment"`
+	IsDefault      bool           `json:"isDefault,omitempty"`
+	PolicyBundleId string         `json:"policyBundleId,omitempty"`
+	Rules          []ScanningGate `json:"rules"`
+}
+
+type ScanningGate struct {
+	ID      string              `json:"id,omitempty"`
+	Gate    string              `json:"gate"`
+	Trigger string              `json:"trigger"`
+	Action  string              `json:"action"`
+	Params  []ScanningGateParam `json:"params"`
+}
+
+type ScanningGateParam struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func (policy *ScanningPolicy) ToJSON() io.Reader {
+	payload, _ := json.Marshal(policy)
+	return bytes.NewBuffer(payload)
+}
+
+func ScanningPolicyFromJSON(body []byte) (result ScanningPolicy) {
+	_ = json.Unmarshal(body, &result)
+	return result
+}

--- a/sysdig/internal/client/secure/models.go
+++ b/sysdig/internal/client/secure/models.go
@@ -450,3 +450,34 @@ func ScanningPolicyFromJSON(body []byte) (result ScanningPolicy) {
 	_ = json.Unmarshal(body, &result)
 	return result
 }
+
+// -------- Scanning Policy Assignments --------
+type ScanningPolicyAssignmentList struct {
+	Items          []ScanningPolicyAssignment `json:"items"`
+	PolicyBundleId string                     `json:"policyBundleId"`
+}
+
+type ScanningPolicyAssignment struct {
+	ID           string                        `json:"id,omitempty"`
+	Name         string                        `json:"name"`
+	Registry     string                        `json:"registry"`
+	Repository   string                        `json:"repository"`
+	Image        ScanningPolicyAssignmentImage `json:"image"`
+	PolicyIDs    []string                      `json:"policy_ids"`
+	WhitelistIDs []string                      `json:"whitelist_ids"`
+}
+
+type ScanningPolicyAssignmentImage struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+func (policy *ScanningPolicyAssignmentList) ToJSON() io.Reader {
+	payload, _ := json.Marshal(policy)
+	return bytes.NewBuffer(payload)
+}
+
+func ScanningPolicyAssignmentFromJSON(body []byte) (result ScanningPolicyAssignmentList) {
+	_ = json.Unmarshal(body, &result)
+	return result
+}

--- a/sysdig/internal/client/secure/scanningpolicies.go
+++ b/sysdig/internal/client/secure/scanningpolicies.go
@@ -7,6 +7,20 @@ import (
 	"net/http"
 )
 
+func (client *sysdigSecureClient) scanningPoliciesURL() string {
+	return fmt.Sprintf("%s/api/scanning/v1/policies", client.URL)
+}
+
+func (client *sysdigSecureClient) scanningPolicyAssignmentURL() string {
+	return fmt.Sprintf("%s/api/scanning/v1/mappings", client.URL)
+}
+
+func (client *sysdigSecureClient) scanningPolicyURL(scanningPolicyId string) string {
+	return fmt.Sprintf("%s/api/scanning/v1/policies/%s", client.URL, scanningPolicyId)
+}
+
+// Scanning Policies
+
 func (client *sysdigSecureClient) CreateScanningPolicy(ctx context.Context, scanningPolicyRequest ScanningPolicy) (scanningPolicy ScanningPolicy, err error) {
 	response, err := client.doSysdigSecureRequest(ctx, http.MethodPost, client.scanningPoliciesURL(), scanningPolicyRequest.ToJSON())
 	if err != nil {
@@ -25,14 +39,6 @@ func (client *sysdigSecureClient) CreateScanningPolicy(ctx context.Context, scan
 	}
 
 	return ScanningPolicyFromJSON(body), nil
-}
-
-func (client *sysdigSecureClient) scanningPoliciesURL() string {
-	return fmt.Sprintf("%s/api/scanning/v1/policies", client.URL)
-}
-
-func (client *sysdigSecureClient) scanningPolicyURL(scanningPolicyId string) string {
-	return fmt.Sprintf("%s/api/scanning/v1/policies/%s", client.URL, scanningPolicyId)
 }
 
 func (client *sysdigSecureClient) GetScanningPolicyById(ctx context.Context, scanningPolicyID string) (scanningPolicy ScanningPolicy, err error) {
@@ -83,4 +89,58 @@ func (client *sysdigSecureClient) DeleteScanningPolicyById(ctx context.Context, 
 	}
 
 	return err
+}
+
+// Scanning Policy Assignments
+
+func (client *sysdigSecureClient) CreateScanningPolicyAssignmentList(ctx context.Context, scanningPolicyAssignmentRequest ScanningPolicyAssignmentList) (scanningPolicyAssignmentList ScanningPolicyAssignmentList, err error) {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodPut, client.scanningPolicyAssignmentURL(), scanningPolicyAssignmentRequest.ToJSON())
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		err = errorFromResponse(response)
+		return
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
+
+	return ScanningPolicyAssignmentFromJSON(body), nil
+}
+
+func (client *sysdigSecureClient) DeleteScanningPolicyAssignmentList(ctx context.Context, scanningPolicyAssignmentList ScanningPolicyAssignmentList) error {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodPut, client.scanningPolicyAssignmentURL(), scanningPolicyAssignmentList.ToJSON())
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNoContent && response.StatusCode != http.StatusOK {
+		return errorFromResponse(response)
+	}
+
+	return err
+}
+
+func (client *sysdigSecureClient) GetScanningPolicyAssignmentList(ctx context.Context) (scanningPolicyAssignmentList ScanningPolicyAssignmentList, err error) {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodGet, client.scanningPolicyAssignmentURL(), nil)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return ScanningPolicyAssignmentList{}, errorFromResponse(response)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
+	return ScanningPolicyAssignmentFromJSON(body), nil
 }

--- a/sysdig/internal/client/secure/scanningpolicies.go
+++ b/sysdig/internal/client/secure/scanningpolicies.go
@@ -12,7 +12,7 @@ func (client *sysdigSecureClient) scanningPoliciesURL() string {
 }
 
 func (client *sysdigSecureClient) scanningPolicyAssignmentURL() string {
-	return fmt.Sprintf("%s/api/scanning/v1/mappings", client.URL)
+	return fmt.Sprintf("%s/api/scanning/v1/mappings?bundleId=default", client.URL)
 }
 
 func (client *sysdigSecureClient) scanningPolicyURL(scanningPolicyId string) string {

--- a/sysdig/internal/client/secure/scanningpolicies.go
+++ b/sysdig/internal/client/secure/scanningpolicies.go
@@ -1,0 +1,86 @@
+package secure
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (client *sysdigSecureClient) CreateScanningPolicy(ctx context.Context, scanningPolicyRequest ScanningPolicy) (scanningPolicy ScanningPolicy, err error) {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodPost, client.scanningPoliciesURL(), scanningPolicyRequest.ToJSON())
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		err = errorFromResponse(response)
+		return
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
+
+	return ScanningPolicyFromJSON(body), nil
+}
+
+func (client *sysdigSecureClient) scanningPoliciesURL() string {
+	return fmt.Sprintf("%s/api/scanning/v1/policies", client.URL)
+}
+
+func (client *sysdigSecureClient) scanningPolicyURL(scanningPolicyId string) string {
+	return fmt.Sprintf("%s/api/scanning/v1/policies/%s", client.URL, scanningPolicyId)
+}
+
+func (client *sysdigSecureClient) GetScanningPolicyById(ctx context.Context, scanningPolicyID string) (scanningPolicy ScanningPolicy, err error) {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodGet, client.scanningPolicyURL(scanningPolicyID), nil)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return ScanningPolicy{}, errorFromResponse(response)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
+	return ScanningPolicyFromJSON(body), nil
+}
+
+func (client *sysdigSecureClient) UpdateScanningPolicyById(ctx context.Context, scanningPolicyRequest ScanningPolicy) (scanningPolicy ScanningPolicy, err error) {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodPut, client.scanningPolicyURL(scanningPolicyRequest.ID), scanningPolicyRequest.ToJSON())
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return ScanningPolicy{}, errorFromResponse(response)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
+	return ScanningPolicyFromJSON(body), nil
+}
+
+func (client *sysdigSecureClient) DeleteScanningPolicyById(ctx context.Context, scanningPolicyID string) error {
+	response, err := client.doSysdigSecureRequest(ctx, http.MethodDelete, client.scanningPolicyURL(scanningPolicyID), nil)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNoContent && response.StatusCode != http.StatusOK {
+		return errorFromResponse(response)
+	}
+
+	return err
+}

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -72,8 +72,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_vulnerability_exception_list":   resourceSysdigSecureVulnerabilityExceptionList(),
 			"sysdig_secure_cloud_account":                  resourceSysdigSecureCloudAccount(),
 			"sysdig_secure_benchmark_task":                 resourceSysdigSecureBenchmarkTask(),
-
-			"sysdig_secure_scanning_policy": resourceSysdigSecureScanningPolicy(),
+			"sysdig_secure_scanning_policy":                resourceSysdigSecureScanningPolicy(),
 
 			"sysdig_monitor_alert_downtime":                 resourceSysdigMonitorAlertDowntime(),
 			"sysdig_monitor_alert_metric":                   resourceSysdigMonitorAlertMetric(),

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -73,6 +73,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_cloud_account":                  resourceSysdigSecureCloudAccount(),
 			"sysdig_secure_benchmark_task":                 resourceSysdigSecureBenchmarkTask(),
 			"sysdig_secure_scanning_policy":                resourceSysdigSecureScanningPolicy(),
+			"sysdig_secure_scanning_policy_assignment":     resourceSysdigSecureScanningPolicyAssignment(),
 
 			"sysdig_monitor_alert_downtime":                 resourceSysdigMonitorAlertDowntime(),
 			"sysdig_monitor_alert_metric":                   resourceSysdigMonitorAlertMetric(),

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -73,6 +73,8 @@ func Provider() *schema.Provider {
 			"sysdig_secure_cloud_account":                  resourceSysdigSecureCloudAccount(),
 			"sysdig_secure_benchmark_task":                 resourceSysdigSecureBenchmarkTask(),
 
+			"sysdig_secure_scanning_policy": resourceSysdigSecureScanningPolicy(),
+
 			"sysdig_monitor_alert_downtime":                 resourceSysdigMonitorAlertDowntime(),
 			"sysdig_monitor_alert_metric":                   resourceSysdigMonitorAlertMetric(),
 			"sysdig_monitor_alert_event":                    resourceSysdigMonitorAlertEvent(),

--- a/sysdig/resource_sysdig_secure_scanningpolicies.go
+++ b/sysdig/resource_sysdig_secure_scanningpolicies.go
@@ -128,7 +128,7 @@ func resourceSysdigScanningPolicyUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	scanningPolicy := scanningPolicyFromResourceData(d)
-	id, _ := d.Get("id").(string)
+	id := d.Get("id").(string)
 	scanningPolicy.ID = id
 	_, err = client.UpdateScanningPolicyById(ctx, scanningPolicy)
 	if err != nil {
@@ -144,7 +144,7 @@ func resourceSysdigScanningPolicyRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	id, _ := d.Get("id").(string)
+	id := d.Get("id").(string)
 	scanningPolicy, err := client.GetScanningPolicyById(ctx, id)
 	if err != nil {
 		return diag.FromErr(err)
@@ -161,7 +161,7 @@ func resourceSysdigScanningPolicyDelete(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	id, _ := d.Get("id").(string)
+	id := d.Get("id").(string)
 	err = client.DeleteScanningPolicyById(ctx, id)
 	if err != nil {
 		return diag.FromErr(err)

--- a/sysdig/resource_sysdig_secure_scanningpolicies.go
+++ b/sysdig/resource_sysdig_secure_scanningpolicies.go
@@ -45,8 +45,7 @@ func resourceSysdigSecureScanningPolicy() *schema.Resource {
 			},
 			"isdefault": {
 				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 			"version": {
 				Type:     schema.TypeString,
@@ -123,7 +122,6 @@ func resourceSysdigScanningPolicyCreate(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-// TODO
 func resourceSysdigScanningPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, err := meta.(SysdigClients).sysdigSecureClient()
 	if err != nil {

--- a/sysdig/resource_sysdig_secure_scanningpolicies.go
+++ b/sysdig/resource_sysdig_secure_scanningpolicies.go
@@ -131,7 +131,6 @@ func resourceSysdigScanningPolicyUpdate(ctx context.Context, d *schema.ResourceD
 	scanningPolicy := scanningPolicyFromResourceData(d)
 	id, _ := d.Get("id").(string)
 	scanningPolicy.ID = id
-	fmt.Println(scanningPolicy)
 	_, err = client.UpdateScanningPolicyById(ctx, scanningPolicy)
 	if err != nil {
 		return diag.FromErr(err)

--- a/sysdig/resource_sysdig_secure_scanningpolicies.go
+++ b/sysdig/resource_sysdig_secure_scanningpolicies.go
@@ -1,0 +1,253 @@
+package sysdig
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig/internal/client/secure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceSysdigSecureScanningPolicy() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		CreateContext: resourceSysdigScanningPolicyCreate,
+		ReadContext:   resourceSysdigScanningPolicyRead,
+		UpdateContext: resourceSysdigScanningPolicyUpdate,
+		DeleteContext: resourceSysdigScanningPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"comment": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"isdefault": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "1_0",
+			},
+			"policy_bundle_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+			},
+			"rules": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gate": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validateDiagFunc(validation.StringInSlice([]string{"always", "dockerfile", "files", "licenses", "metadata", "npms", "packages", "passwd_file", "retrieved_files", "vulnerabilities", "secret_scans", "ruby_gems"}, false)),
+						},
+						"trigger": {
+							Type:     schema.TypeString,
+							Required: true,
+							// ValidateDiagFunc: TODO: create inline func to validate each trigger options depending on gate https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors
+						},
+						"action": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validateDiagFunc(validation.StringInSlice([]string{"WARN", "STOP"}, false)),
+						},
+						"params": {
+							Type:     schema.TypeSet,
+							Required: true,
+							// ValidateDiagFunc: TODO: function to validate name is valid for the given trigger,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceSysdigScanningPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scanningPolicy := scanningPolicyFromResourceData(d)
+	scanningPolicy, err = client.CreateScanningPolicy(ctx, scanningPolicy)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scanningPolicyToResourceData(&scanningPolicy, d)
+
+	return nil
+}
+
+// TODO
+func resourceSysdigScanningPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scanningPolicy := scanningPolicyFromResourceData(d)
+	id, _ := d.Get("id").(string)
+	scanningPolicy.ID = id
+	fmt.Println(scanningPolicy)
+	_, err = client.UpdateScanningPolicyById(ctx, scanningPolicy)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceSysdigScanningPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, _ := d.Get("id").(string)
+	scanningPolicy, err := client.GetScanningPolicyById(ctx, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scanningPolicyToResourceData(&scanningPolicy, d)
+
+	return nil
+}
+
+func resourceSysdigScanningPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, _ := d.Get("id").(string)
+	err = client.DeleteScanningPolicyById(ctx, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func scanningPolicyToResourceData(scanningPolicy *secure.ScanningPolicy, d *schema.ResourceData) {
+
+	d.SetId(scanningPolicy.ID)
+	_ = d.Set("name", scanningPolicy.Name)
+	_ = d.Set("version", scanningPolicy.Version)
+	_ = d.Set("comment", scanningPolicy.Comment)
+	_ = d.Set("isdefault", scanningPolicy.IsDefault)
+	_ = d.Set("policy_bundle_id", scanningPolicy.PolicyBundleId)
+
+	var rules []map[string]interface{}
+	for _, rule := range scanningPolicy.Rules {
+		ruleInfo := scanningPolicyRulesToResourceData(rule)
+
+		rules = append(rules, ruleInfo)
+	}
+
+	_ = d.Set("rules", rules)
+
+}
+
+func scanningPolicyRulesToResourceData(scanningPolicyRule secure.ScanningGate) map[string]interface{} {
+	rule := map[string]interface{}{
+		"id":      scanningPolicyRule.ID,
+		"gate":    scanningPolicyRule.Gate,
+		"trigger": scanningPolicyRule.Trigger,
+		"action":  scanningPolicyRule.Action,
+	}
+
+	var params []map[string]interface{}
+	for _, param := range scanningPolicyRule.Params {
+		params = append(params, map[string]interface{}{
+			"name":  param.Name,
+			"value": param.Value,
+		})
+	}
+	rule["params"] = params
+
+	return rule
+}
+
+func scanningPolicyFromResourceData(d *schema.ResourceData) secure.ScanningPolicy {
+	scanningPolicy := secure.ScanningPolicy{
+		Name:           d.Get("name").(string),
+		ID:             d.Get("id").(string),
+		Comment:        d.Get("comment").(string),
+		Version:        d.Get("version").(string),
+		IsDefault:      d.Get("isdefault").(bool),
+		PolicyBundleId: d.Get("policy_bundle_id").(string),
+	}
+	scanningPolicy.Rules = scanningPolicyRulesFromResourceData(d)
+
+	return scanningPolicy
+}
+
+func scanningPolicyRulesFromResourceData(d *schema.ResourceData) (rules []secure.ScanningGate) {
+	for _, ruleItr := range d.Get("rules").(*schema.Set).List() {
+		ruleInfo := ruleItr.(map[string]interface{})
+		rule := secure.ScanningGate{
+			Gate:    ruleInfo["gate"].(string),
+			ID:      ruleInfo["id"].(string),
+			Trigger: ruleInfo["trigger"].(string),
+			Action:  ruleInfo["action"].(string),
+		}
+		var params []secure.ScanningGateParam
+		for _, paramsItr := range ruleInfo["params"].(*schema.Set).List() {
+			paramsInfo := paramsItr.(map[string]interface{})
+			param := secure.ScanningGateParam{
+				Name:  paramsInfo["name"].(string),
+				Value: paramsInfo["value"].(string),
+			}
+			params = append(params, param)
+		}
+		rule.Params = params
+		rules = append(rules, rule)
+	}
+	return rules
+}

--- a/sysdig/resource_sysdig_secure_scanningpolicies.go
+++ b/sysdig/resource_sysdig_secure_scanningpolicies.go
@@ -2,7 +2,6 @@ package sysdig
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/draios/terraform-provider-sysdig/sysdig/internal/client/secure"

--- a/sysdig/resource_sysdig_secure_scanningpolicies_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpolicies_test.go
@@ -34,9 +34,6 @@ func TestAccScanningPolicy(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// {
-			// 	Config: scanningPolicyWithoutRules(rText()),
-			// },
 		},
 	})
 }

--- a/sysdig/resource_sysdig_secure_scanningpolicies_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpolicies_test.go
@@ -1,0 +1,65 @@
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccScanningPolicy(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: scanningPolicyWithName(rText()),
+			},
+			{
+				ResourceName:      "sysdig_secure_scanning_policy.sample",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// {
+			// 	Config: scanningPolicyWithoutRules(rText()),
+			// },
+		},
+	})
+}
+
+func scanningPolicyWithName(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_scanning_policy" "sample" {
+  name = "TERRAFORM TEST 1 %s"
+  comment = "TERRAFORM TEST %s"
+
+  rules {
+    gate = "dockerfile"
+    trigger = "effective_user"
+    action = "WARN"
+    params {
+        name = "users"
+        value = "docker"
+    }
+    params {
+        name = "type"
+        value = "blacklist"
+    }
+  }
+}
+`, name, name)
+}

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments.go
@@ -1,0 +1,289 @@
+package sysdig
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig/internal/client/secure"
+)
+
+func resourceSysdigSecureScanningPolicyAssignment() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		CreateContext: resourceSysdigScanningPolicyAssignmentCreate,
+		ReadContext:   resourceSysdigScanningPolicyAssignmentRead,
+		UpdateContext: resourceSysdigScanningPolicyAssignmentUpdate,
+		DeleteContext: resourceSysdigScanningPolicyAssignmentDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"items": { // todo: validate that at least there is one "default" with */*:*
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"image": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										Default:          "tag",
+										ValidateDiagFunc: validateDiagFunc(validation.StringInSlice([]string{"tag"}, false)),
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"policy_ids": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"registry": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"repository": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"whitelist_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"policy_bundle_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+			},
+		},
+	}
+}
+
+func resourceSysdigScanningPolicyAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scanningPolicyAssignmentList := scanningPolicyAssignmentListFromResourceData(d)
+
+	validation := validateScanningPolicyAssignment(scanningPolicyAssignmentList)
+	if validation != nil {
+		return validation
+	}
+
+	scanningPolicyAssignmentList, err = client.CreateScanningPolicyAssignmentList(ctx, scanningPolicyAssignmentList)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scanningPolicyAssignmentListToResourceData(&scanningPolicyAssignmentList, d)
+
+	return nil
+}
+
+func resourceSysdigScanningPolicyAssignmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scanningPolicyAssignmentList, err := client.GetScanningPolicyAssignmentList(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scanningPolicyAssignmentListToResourceData(&scanningPolicyAssignmentList, d)
+
+	return nil
+}
+
+func resourceSysdigScanningPolicyAssignmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	scanningPolicyAssignmentList := scanningPolicyAssignmentListFromResourceData(d)
+
+	validation := validateScanningPolicyAssignment(scanningPolicyAssignmentList)
+	if validation != nil {
+		return validation
+	}
+
+	scanningPolicyAssignmentList, err = client.CreateScanningPolicyAssignmentList(ctx, scanningPolicyAssignmentList) // As policy assignments is a list, update is the same than create
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scanningPolicyAssignmentListToResourceData(&scanningPolicyAssignmentList, d)
+
+	return nil
+}
+
+// As Policy Assignments cannot be empty (default assignment cannot be deleted), pushing the default one
+func resourceSysdigScanningPolicyAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(SysdigClients).sysdigSecureClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	defaultImage := secure.ScanningPolicyAssignmentImage{
+		Type:  "tag",
+		Value: "*",
+	}
+	defaultItem := secure.ScanningPolicyAssignment{
+		Name:         "default",
+		Registry:     "*",
+		Repository:   "*",
+		Image:        defaultImage,
+		PolicyIDs:    []string{"default"},
+		WhitelistIDs: []string{},
+	}
+
+	scanningPolicyAssignmentList := secure.ScanningPolicyAssignmentList{
+		PolicyBundleId: "default", // this is forced because there is no other possible value
+		Items:          []secure.ScanningPolicyAssignment{defaultItem},
+	}
+
+	err = client.DeleteScanningPolicyAssignmentList(ctx, scanningPolicyAssignmentList)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func scanningPolicyAssignmentListToResourceData(scanningPolicyAssignmentList *secure.ScanningPolicyAssignmentList, d *schema.ResourceData) {
+	d.SetId(scanningPolicyAssignmentList.PolicyBundleId)
+	_ = d.Set("policy_bundle_id", scanningPolicyAssignmentList.PolicyBundleId)
+	var items []map[string]interface{}
+
+	for _, item := range scanningPolicyAssignmentList.Items {
+		itemInfo := scanningPolicyAssignmentToResourceData(item)
+
+		items = append(items, itemInfo)
+	}
+
+	_ = d.Set("items", items)
+}
+
+func scanningPolicyAssignmentToResourceData(scanningPolicyAssignment secure.ScanningPolicyAssignment) map[string]interface{} {
+	item := map[string]interface{}{
+		"id":            scanningPolicyAssignment.ID,
+		"name":          scanningPolicyAssignment.Name,
+		"registry":      scanningPolicyAssignment.Registry,
+		"repository":    scanningPolicyAssignment.Repository,
+		"policy_ids":    scanningPolicyAssignment.PolicyIDs,
+		"whitelist_ids": scanningPolicyAssignment.WhitelistIDs,
+	}
+
+	image := []map[string]interface{}{{
+		"type":  scanningPolicyAssignment.Image.Type,
+		"value": scanningPolicyAssignment.Image.Value,
+	}}
+
+	item["image"] = image
+
+	return item
+}
+
+func scanningPolicyAssignmentListFromResourceData(d *schema.ResourceData) secure.ScanningPolicyAssignmentList {
+	scanningPolicyAssignmentList := secure.ScanningPolicyAssignmentList{
+		PolicyBundleId: "default", // this is forced because there is no other possible value
+	}
+
+	scanningPolicyAssignmentList.Items = scanningPolicyAssignmentFromResourceData(d)
+
+	return scanningPolicyAssignmentList
+
+}
+
+func scanningPolicyAssignmentFromResourceData(d *schema.ResourceData) (scanningPolicyAssignmentItems []secure.ScanningPolicyAssignment) {
+	for _, item := range d.Get("items").([]interface{}) {
+		assignmentInfo := item.(map[string]interface{})
+		assignment := secure.ScanningPolicyAssignment{
+			Name:       assignmentInfo["name"].(string),
+			Registry:   assignmentInfo["registry"].(string),
+			Repository: assignmentInfo["repository"].(string),
+		}
+
+		assignment.PolicyIDs = []string{}
+		policyIDsSet := assignmentInfo["policy_ids"].([]interface{})
+		for _, policy := range policyIDsSet {
+			assignment.PolicyIDs = append(assignment.PolicyIDs, policy.(string))
+		}
+
+		assignment.WhitelistIDs = []string{}
+		whitelistIDsSet := assignmentInfo["whitelist_ids"].([]interface{})
+		for _, policy := range whitelistIDsSet {
+			assignment.WhitelistIDs = append(assignment.WhitelistIDs, policy.(string))
+		}
+		imageSet := assignmentInfo["image"].([]interface{})
+		if len(imageSet) == 0 {
+			return
+		}
+		for _, image := range imageSet {
+			assignment.Image = secure.ScanningPolicyAssignmentImage{
+				Type:  image.(map[string]interface{})["type"].(string),
+				Value: image.(map[string]interface{})["value"].(string),
+			}
+		}
+
+		scanningPolicyAssignmentItems = append(scanningPolicyAssignmentItems, assignment)
+	}
+	return scanningPolicyAssignmentItems
+}
+
+// Validate during creation as ValidateFunc is not supported in TypeList/TypeSet https://github.com/hashicorp/terraform-plugin-sdk/issues/156
+// This function validates the last Item from the assignment list applies to all (*/*:*) and the list of policies is not empty in any assignment
+func validateScanningPolicyAssignment(scanningPolicyAssignmentList secure.ScanningPolicyAssignmentList) diag.Diagnostics {
+	for _, item := range scanningPolicyAssignmentList.Items {
+		if len(item.PolicyIDs) == 0 {
+			return diag.FromErr(errors.New("'policy_ids' list can not be empty"))
+		}
+	}
+
+	// validate default assignment
+	lastItem := scanningPolicyAssignmentList.Items[len(scanningPolicyAssignmentList.Items)-1]
+	if lastItem.Image.Value != "*" || lastItem.Registry != "*" || lastItem.Repository != "*" {
+		return diag.FromErr(errors.New("Default policy assignment has to be registry='*', repository='*' and image.tag='*?"))
+	}
+
+	return nil
+}

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -29,11 +29,6 @@ func TestAccScanningPolicyAssignment(t *testing.T) {
 			{
 				Config: scanningPolicyAssignmentWithWhitelistIDs(rText()),
 			},
-			{
-				ResourceName:      "sysdig_secure_scanning_policy_assignment.sample",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -27,8 +27,7 @@ func TestAccScanningPolicyAssignment(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:             scanningPolicyAssignmentWithWhitelistIDs(rText()),
-				ExpectNonEmptyPlan: true,
+				Config: scanningPolicyAssignmentWithWhitelistIDs(rText()),
 			},
 			{
 				ResourceName:      "sysdig_secure_scanning_policy_assignment.sample",

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -46,7 +46,6 @@ func scanningPolicyAssignmentWithoutName() string {
 %s
 resource "sysdig_secure_scanning_policy_assignment" "sample" {
   items {
-    name = ""
     image {
       type = "tag"
       value = "*"

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -1,0 +1,125 @@
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccScanningPolicyAssignment(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: scanningPolicyAssignmentWithoutName(),
+			},
+			{
+				ResourceName:      "sysdig_secure_scanning_policy_assignment.sample",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: scanningPolicyAssignmentWithName(rText()),
+			},
+		},
+	})
+}
+
+func scanningPolicyAssignmentWithoutName() string {
+	return fmt.Sprintf(`
+%s
+resource "sysdig_secure_scanning_policy_assignment" "sample" {
+  items {
+    name = ""
+    image {
+      type = "tag"
+      value = "*"
+    }
+    registry = "*"
+    repository = "*"
+
+    policy_ids = [sysdig_secure_scanning_policy.sample.id]
+  }
+}
+`, scanningPolicyWithName("sample"))
+}
+
+func scanningPolicyAssignmentWithName(name string) string {
+	return fmt.Sprintf(`
+%s
+resource "sysdig_secure_scanning_policy_assignment" "sample" {
+  items {
+    name = "example %s"
+    image {
+      type = "tag"
+      value = "latest"
+    }
+    registry = "icr.io"
+    repository = "example"
+
+    policy_ids = [sysdig_secure_scanning_policy.sample.id]
+  }
+
+  items {
+    name = ""
+    image {
+      type = "tag"
+      value = "*"
+    }
+    registry = "*"
+    repository = "*"
+
+    policy_ids = ["default"]
+  }
+}
+`, scanningPolicyWithName("sample"), name)
+}
+
+func scanningPolicyAssignmentWithWhitelistIDs(name string) string {
+	return fmt.Sprintf(`
+%s
+%s
+resource "sysdig_secure_scanning_policy_assignment" "sample" {
+  items {
+    name = "example %s"
+    image {
+      type = "tag"
+      value = "latest"
+    }
+    registry = "icr.io"
+    repository = "example"
+
+    policy_ids = [sysdig_secure_scanning_policy.sample.id]
+  }
+
+  items {
+    name = ""
+    image {
+      type = "tag"
+      value = "*"
+    }
+    registry = "*"
+    repository = "*"
+
+    policy_ids = ["default"]
+	whitelist_ids = []
+  }
+}
+`, scanningPolicyWithName("sample"), vulnerabilityException(name), name)
+}

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestAccScanningPolicyAssignment(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
-	rText2 := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -28,77 +27,22 @@ func TestAccScanningPolicyAssignment(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: scanningPolicyAssignmentWithoutName(rText()),
+				Config: scanningPolicyAssignmentWithWhitelistIDs(rText()),
 			},
 			{
 				ResourceName:      "sysdig_secure_scanning_policy_assignment.sample",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config: scanningPolicyAssignmentWithName(rText2()),
-			},
-			// {
-			// 	Config: scanningPolicyAssignmentWithWhitelistIDs(rText()),
-			// },
 		},
 	})
-}
-
-func scanningPolicyAssignmentWithoutName(name string) string {
-	return fmt.Sprintf(`
-%s
-resource "sysdig_secure_scanning_policy_assignment" "sample" {
-  items {
-    image {
-      type = "tag"
-      value = "*"
-    }
-    registry = "*"
-    repository = "*"
-
-    policy_ids = [sysdig_secure_scanning_policy.sample.id]
-  }
-}
-`, scanningPolicyWithName(name))
-}
-
-func scanningPolicyAssignmentWithName(name string) string {
-	return fmt.Sprintf(`
-%s
-resource "sysdig_secure_scanning_policy_assignment" "sample_2" {
-  items {
-    name = "example %s"
-    image {
-      type = "tag"
-      value = "latest"
-    }
-    registry = "icr.io"
-    repository = "example"
-
-    policy_ids = [sysdig_secure_scanning_policy.sample.id]
-  }
-
-  items {
-    name = ""
-    image {
-      type = "tag"
-      value = "*"
-    }
-    registry = "*"
-    repository = "*"
-
-    policy_ids = ["default"]
-  }
-}
-`, scanningPolicyWithName(name), name)
 }
 
 func scanningPolicyAssignmentWithWhitelistIDs(name string) string {
 	return fmt.Sprintf(`
 %s
 %s
-resource "sysdig_secure_scanning_policy_assignment" "sample_3" {
+resource "sysdig_secure_scanning_policy_assignment" "sample" {
   items {
     name = "example %s"
     image {
@@ -124,5 +68,5 @@ resource "sysdig_secure_scanning_policy_assignment" "sample_3" {
 	  whitelist_ids = [sysdig_secure_vulnerability_exception_list.sample.id]
   }
 }
-`, scanningPolicyWithName(name), vulnerabilityException(name), name)
+`, scanningPolicyWithName(name), vulnerabilityExceptionList(name), name)
 }

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccScanningPolicyAssignment(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+	rText2 := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -27,7 +28,7 @@ func TestAccScanningPolicyAssignment(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: scanningPolicyAssignmentWithoutName(),
+				Config: scanningPolicyAssignmentWithoutName(rText()),
 			},
 			{
 				ResourceName:      "sysdig_secure_scanning_policy_assignment.sample",
@@ -35,13 +36,16 @@ func TestAccScanningPolicyAssignment(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: scanningPolicyAssignmentWithName(rText()),
+				Config: scanningPolicyAssignmentWithName(rText2()),
 			},
+			// {
+			// 	Config: scanningPolicyAssignmentWithWhitelistIDs(rText()),
+			// },
 		},
 	})
 }
 
-func scanningPolicyAssignmentWithoutName() string {
+func scanningPolicyAssignmentWithoutName(name string) string {
 	return fmt.Sprintf(`
 %s
 resource "sysdig_secure_scanning_policy_assignment" "sample" {
@@ -56,13 +60,13 @@ resource "sysdig_secure_scanning_policy_assignment" "sample" {
     policy_ids = [sysdig_secure_scanning_policy.sample.id]
   }
 }
-`, scanningPolicyWithName("sample"))
+`, scanningPolicyWithName(name))
 }
 
 func scanningPolicyAssignmentWithName(name string) string {
 	return fmt.Sprintf(`
 %s
-resource "sysdig_secure_scanning_policy_assignment" "sample" {
+resource "sysdig_secure_scanning_policy_assignment" "sample_2" {
   items {
     name = "example %s"
     image {
@@ -87,14 +91,14 @@ resource "sysdig_secure_scanning_policy_assignment" "sample" {
     policy_ids = ["default"]
   }
 }
-`, scanningPolicyWithName("sample"), name)
+`, scanningPolicyWithName(name), name)
 }
 
 func scanningPolicyAssignmentWithWhitelistIDs(name string) string {
 	return fmt.Sprintf(`
 %s
 %s
-resource "sysdig_secure_scanning_policy_assignment" "sample" {
+resource "sysdig_secure_scanning_policy_assignment" "sample_3" {
   items {
     name = "example %s"
     image {
@@ -117,8 +121,8 @@ resource "sysdig_secure_scanning_policy_assignment" "sample" {
     repository = "*"
 
     policy_ids = ["default"]
-	whitelist_ids = []
+	  whitelist_ids = [sysdig_secure_vulnerability_exception_list.sample.id]
   }
 }
-`, scanningPolicyWithName("sample"), vulnerabilityException(name), name)
+`, scanningPolicyWithName(name), vulnerabilityException(name), name)
 }

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -27,7 +27,8 @@ func TestAccScanningPolicyAssignment(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: scanningPolicyAssignmentWithWhitelistIDs(rText()),
+				Config:             scanningPolicyAssignmentWithWhitelistIDs(rText()),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				ResourceName:      "sysdig_secure_scanning_policy_assignment.sample",

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -40,8 +40,6 @@ func TestAccScanningPolicyAssignment(t *testing.T) {
 
 func scanningPolicyAssignmentWithWhitelistIDs(name string) string {
 	return fmt.Sprintf(`
-%s
-%s
 resource "sysdig_secure_scanning_policy_assignment" "sample" {
   items {
     name = "example %s"
@@ -52,7 +50,7 @@ resource "sysdig_secure_scanning_policy_assignment" "sample" {
     registry = "icr.io"
     repository = "example"
 
-    policy_ids = [sysdig_secure_scanning_policy.sample.id]
+    policy_ids = ["default"]
   }
 
   items {
@@ -65,8 +63,8 @@ resource "sysdig_secure_scanning_policy_assignment" "sample" {
     repository = "*"
 
     policy_ids = ["default"]
-	  whitelist_ids = [sysdig_secure_vulnerability_exception_list.sample.id]
+	  whitelist_ids = []
   }
 }
-`, scanningPolicyWithName(name), vulnerabilityExceptionList(name), name)
+`, name)
 }

--- a/website/docs/r/secure_scanning_policy.md
+++ b/website/docs/r/secure_scanning_policy.md
@@ -1,0 +1,92 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_scanning_policy"
+description: |-
+  Creates a Sysdig Secure Scanning Policy for Legacy Scanning Engine.
+---
+
+# Resource: sysdig_secure_scanning_policy
+
+Creates a Sysdig Secure Policy.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.  
+
+## Example Usage
+
+```terraform
+resource "sysdig_secure_scanning_policy" "scanning_policy_example" {
+  name = "Scanning Policy Name"
+  comment = "Scanning Policy Description"
+
+  // Scanning Policy Rules (gates) and parameters for configuration
+  rules {
+    gate = "dockerfile"
+    trigger = "effective_user"
+    action = "WARN"
+    params {
+        name = "users"
+        value = "docker"
+    }
+    params {
+        name = "type"
+        value = "blacklist"
+    }
+  }
+
+  rules {
+    gate = "files"
+    trigger = "attribute_match"
+    action = "WARN"
+    params {
+        name = "filename"
+        value = "/etc/passwd"
+    }
+  }
+
+  rules {
+    gate = "vulnerabilities"
+    trigger = "package"
+    action = "WARN"
+    params {
+      name = "package_type"
+      value = "all"
+    }
+    params {
+      name = "severity"
+      value = "medium"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Secure policy. It must be unique.
+
+* `comment` - (Required) The description of Secure scanning policy.
+
+* `rules` - (Optional) Define all rules included in the Policy for scanning detection.
+
+- - -
+
+### Rules block
+
+* `gate` - (Required) Must be one of `always`, `dockerfile`, `files`, `licenses`, `metadata`, `npms`, `packages`, `passwd_file`, `retrieved_files`, `vulnerabilities`, `secret_scans`, `ruby_gems`. You can see the description of each gate in this [link](https://docs.sysdig.com/en/docs/sysdig-secure/scanning/manage-scanning-policies/scanning-policy-gates-and-triggers/).
+* `trigger` - (Required) Each gate have different trigger options and parameters. Check possible triggers per gate in the previous link.
+* `params` - (Required) Each gate and trigger options have different parameter configurations. Review the previous link to see all options.
+* `action` - (Required) define the action to take if one gate triggers what would affect the policy results. Must be `WARN` or `STOP`.
+
+- - -
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+Secure scanning policies can be imported using the ID, e.g.
+
+```
+$ terraform import sysdig_secure_scanning_policy.example policy_123456
+```

--- a/website/docs/r/secure_scanning_policy_assignment.md
+++ b/website/docs/r/secure_scanning_policy_assignment.md
@@ -1,0 +1,99 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_scanning_policy_assignment"
+description: |-
+  Creates a Sysdig Secure Scanning Policy Assignment for Legacy Scanning Engine.
+---
+
+# Resource: sysdig_secure_scanning_policy_assignment
+
+Creates a Sysdig Secure Policy Assignment.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.  
+
+## Example Usage
+
+```terraform
+resource "sysdig_secure_scanning_policy_assignment" "assignment_example" {
+  items {
+    name = "myassignment1"
+    image {
+      type = "tag"
+      value = "latest"
+    }
+    registry = "docker.io"
+    repository = "example"
+
+    policy_ids = ["default"]
+  }
+
+  items {
+    name = ""
+    image {
+      type = "tag"
+      value = "latest"
+    }
+    registry = "*"
+    repository = "*"
+
+    policy_ids = [sysdig_secure_scanning_policy.scanning_policy_example.id]
+    whitelist_ids = []
+  }
+
+  items {
+    name = "default"
+    image {
+      type = "tag"
+      value = "*"
+    }
+    registry = "*"
+    repository = "*"
+
+    policy_ids = [sysdig_secure_scanning_policy.scanning_policy_example.id, "default"]
+  }
+  
+}
+```
+
+## Argument Reference
+
+* `items` - (Required) List of scanning policy assignments. **Priority is defined from top to bottom with the order of the items**.
+
+* `policy_bundle_id` - (Optional) Bundle for the policy assignment. The only value accepted is "default".
+
+## Items block
+
+* `name` - (Optional) The name of the Secure scanning policy assignment.
+
+* `registry` - (Required) Any registry domain (e.g. quay.io). Wildcards are supported; an asterisk * specifies any registry.
+
+* `repository` - (Required) Any repository (typically = name of the image). Wildcards are supported; an asterisk * specifies any repository.
+
+* `image` - (Required) Block to define the image tag.
+
+* `policy_ids` - (Required) Scanning policy IDs assigned to the given Registry/Repository:tag. At least 1 required.
+
+* `whitelist_ids` - (Optional) List of vulnerability exception list associated with the assignment.
+
+- - -
+
+### Image block
+
+* `type` - equal always to "tag"
+
+* `value` - Image tag, any tag. Wildcards are supported; an asterisk * specifies any tag.
+
+- - -
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+Secure scanning policies can be imported using the ID, e.g.
+
+```
+$ terraform import sysdig_secure_scanning_policy_assignment.example default
+```


### PR DESCRIPTION
This PR adds support for scanning policy and scanning policy assignments for Legacy Engine.

Note: As scanning policy assignments (/mappings) only support GET/PUT, the destroy action returns the mapping to the default configuration (*/*:* assigned to Default policy)