### PR TITLE
GCP and Azure Falco rule support

### DIFF
--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -56,7 +56,7 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Default:          "",
-				ValidateDiagFunc: validateDiagFunc(validation.StringInSlice([]string{"syscall", "k8s_audit", "aws_cloudtrail"}, false)),
+				ValidateDiagFunc: validateDiagFunc(validation.StringInSlice([]string{"syscall", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", "azure_platformlogs"}, false)),
 			},
 			"append": {
 				Type:     schema.TypeBool,

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -155,6 +155,34 @@ resource "sysdig_secure_rule_falco" "kube_audit" {
 }`, name, name)
 }
 
+func ruleFalcoGcpAuditlog(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_rule_falco" "gcp_audit" {
+  name = "TERRAFORM TEST %s - GCP Audit"
+  description = "TERRAFORM TEST %s"
+  tags = ["gcp"]
+
+  condition = "gcp.serviceName"
+  output = "GCP Audit Event received (%%gcp.serviceName, %%gcp.methodName)"
+  priority = "debug"
+  source = "gcp_auditlog" // syscall or k8s_audit
+}`, name, name)
+}
+
+func ruleFalcoAzureAuditlog(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_rule_falco" "azure_audit" {
+  name = "TERRAFORM TEST %s - Azure Audit"
+  description = "TERRAFORM TEST %s"
+  tags = ["azure"]
+
+  condition = "jevt.value[/operationName] = "DeleteBlob""
+  output = "GCP Audit Event received (%%jevt.value[/operationName])"
+  priority = "debug"
+  source = "azure_platformlogs" // syscall or k8s_audit
+}`, name, name)
+}
+
 func ruleFalcoTerminalShellWithAppend() string {
 	return `
 resource "sysdig_secure_rule_falco" "terminal_shell_append" {

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -54,6 +54,12 @@ func TestAccRuleFalco(t *testing.T) {
 				Config: ruleFalcoKubeAudit(rText()),
 			},
 			{
+				Config: ruleFalcoGcpAuditlog(rText()),
+			},
+			{
+				Config: ruleFalcoAzureAuditlog(rText()),
+			},
+			{
 				ResourceName:      "sysdig_secure_rule_falco.kube_audit",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -158,29 +164,29 @@ resource "sysdig_secure_rule_falco" "kube_audit" {
 func ruleFalcoGcpAuditlog(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "gcp_audit" {
-  name = "TERRAFORM TEST %s - GCP Audit"
-  description = "TERRAFORM TEST %s"
+  name = "TERRAFORM TEST %[1]s - GCP Audit"
+  description = "TERRAFORM TEST %[1]s"
   tags = ["gcp"]
 
   condition = "gcp.serviceName"
   output = "GCP Audit Event received (%%gcp.serviceName, %%gcp.methodName)"
   priority = "debug"
-  source = "gcp_auditlog" // syscall or k8s_audit
-}`, name, name)
+  source = "gcp_auditlog"
+}`, name)
 }
 
 func ruleFalcoAzureAuditlog(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "azure_audit" {
-  name = "TERRAFORM TEST %s - Azure Audit"
-  description = "TERRAFORM TEST %s"
+  name = "TERRAFORM TEST %[1]s - Azure Audit"
+  description = "TERRAFORM TEST %[1]s"
   tags = ["azure"]
 
   condition = "jevt.value[/operationName] = "DeleteBlob""
   output = "Azure Audit Event received (%%jevt.value[/operationName])"
   priority = "debug"
-  source = "azure_platformlogs" // syscall or k8s_audit
-}`, name, name)
+  source = "azure_platformlogs"
+}`, name)
 }
 
 func ruleFalcoTerminalShellWithAppend() string {

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -177,7 +177,7 @@ resource "sysdig_secure_rule_falco" "azure_audit" {
   tags = ["azure"]
 
   condition = "jevt.value[/operationName] = "DeleteBlob""
-  output = "GCP Audit Event received (%%jevt.value[/operationName])"
+  output = "Azure Audit Event received (%%jevt.value[/operationName])"
   priority = "debug"
   source = "azure_platformlogs" // syscall or k8s_audit
 }`, name, name)

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -51,13 +51,13 @@ func TestAccRuleFalco(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: ruleFalcoKubeAudit(rText()),
-			},
-			{
 				Config: ruleFalcoGcpAuditlog(rText()),
 			},
 			{
 				Config: ruleFalcoAzureAuditlog(rText()),
+			},
+			{
+				Config: ruleFalcoKubeAudit(rText()),
 			},
 			{
 				ResourceName:      "sysdig_secure_rule_falco.kube_audit",
@@ -168,7 +168,7 @@ resource "sysdig_secure_rule_falco" "gcp_audit" {
   description = "TERRAFORM TEST %[1]s"
   tags = ["gcp"]
 
-  condition = "gcp.serviceName"
+  condition = "gcp.serviceName=\"compute.googleapis.com\" and gcp.methodName endswith \".compute.instances.setMetadata\""
   output = "GCP Audit Event received (%%gcp.serviceName, %%gcp.methodName)"
   priority = "debug"
   source = "gcp_auditlog"
@@ -182,7 +182,7 @@ resource "sysdig_secure_rule_falco" "azure_audit" {
   description = "TERRAFORM TEST %[1]s"
   tags = ["azure"]
 
-  condition = "jevt.value[/operationName] = "DeleteBlob""
+  condition = "jevt.value[/operationName] = \"DeleteBlob\""
   output = "Azure Audit Event received (%%jevt.value[/operationName])"
   priority = "debug"
   source = "azure_platformlogs"

--- a/website/docs/r/secure_rule_falco.md
+++ b/website/docs/r/secure_rule_falco.md
@@ -23,7 +23,7 @@ resource "sysdig_secure_rule_falco" "example" {
   condition = "spawned_process and container and shell_procs and proc.tty != 0 and container_entrypoint"
   output    = "A shell was spawned in a container with an attached terminal (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository)"
   priority  = "notice"
-  source    = "syscall" // syscall or k8s_audit
+  source    = "syscall" // syscall or k8s_audit/syscall, k8s_audit, aws_cloudtrail, gcp_auditlog or azure_platformlogs
 
 
   exceptions {
@@ -64,7 +64,7 @@ The following arguments are supported:
 * `condition` - (Required) A [Falco condition](https://falco.org/docs/rules/) is simply a Boolean predicate on Sysdig events expressed using the Sysdig [filter syntax](http://www.sysdig.org/wiki/sysdig-user-guide/#filtering) and macro terms. 
 * `output` - (Optional) Add additional information to each Falco notification's output. Required if append is false.
 * `priority` - (Optional) The priority of the Falco rule. It can be: "emergency", "alert", "critical", "error", "warning", "notice", "info" or "debug". By default is "warning".
-* `source` - (Optional) The source of the event. It can be either "syscall", "k8s_audit" or "aws_cloudtrail". Required if append is false.
+* `source` - (Optional) The source of the event. It can be either "syscall", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", or "azure_platformlogs". Required if append is false.
 * `exceptions` - (Optional) The exceptions key is a list of identifier plus list of tuples of filtercheck fields. See below for details.
 * `append` - (Optional) This indicates that the rule being created appends the condition to an existing Sysdig-provided rule. By default this is false. Appending to user-created rules is not supported by the API.
 

--- a/website/docs/r/secure_rule_falco.md
+++ b/website/docs/r/secure_rule_falco.md
@@ -23,7 +23,7 @@ resource "sysdig_secure_rule_falco" "example" {
   condition = "spawned_process and container and shell_procs and proc.tty != 0 and container_entrypoint"
   output    = "A shell was spawned in a container with an attached terminal (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository)"
   priority  = "notice"
-  source    = "syscall" // syscall or k8s_audit/syscall, k8s_audit, aws_cloudtrail, gcp_auditlog or azure_platformlogs
+  source    = "syscall" // syscall, k8s_audit, aws_cloudtrail, gcp_auditlog or azure_platformlogs
 
 
   exceptions {


### PR DESCRIPTION
**It's a copied PR from https://github.com/sysdiglabs/terraform-provider-sysdig/pull/257 to solve test failed.**

I've added GCP and Azure data sources to the validation.

**Scope**
It affects `sysdig_secure_rule_falco` resource.

**Runbook**

with the current master  branch, when adding GCP rule,
```
resource "sysdig_secure_rule_falco" "gcp_example" {
  name = "Database Snapshot snake"
  source = "gcp_auditlog"
  condition = "gcp.serviceName = 'compute.googleapis.com"
  output = "%gcp.serviceName"
}
```

This terraform provider returns the below validation error

```
Error: expected [{pathStepImpl:{} Name:source}] to be one of [syscall k8s_audit aws_cloudtrail], got gcp_auditlog
  with sysdig_secure_rule_falco.gcp_example,
  on main.tf line 93, in resource "sysdig_secure_rule_falco" "gcp_example":
  93:   source = "gcp_auditlog"
```

So, I've added two data sources and modify the docs.

It works with the PR build

```
  # sysdig_secure_rule_falco.gcp_example will be created
  + resource "sysdig_secure_rule_falco" "gcp_example" {
      + append    = false
      + condition = "gcp.serviceName = 'compute.googleapis.com"
      + id        = (known after apply)
      + name      = "Database Snapshot snake"
      + output    = "%gcp.serviceName"
      + priority  = "warning"
      + source    = "gcp_auditlog"
      + version   = (known after apply)
    }

```

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->