### PR TITLE
fix: Remove tee comand from output as it was overrinding the final result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ website/vendor
 
 # Test reports
 junit-report.xml
-testacc-output.txt
 
 # Keep windows files with windows line endings
 *.winfile eol=crlf

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,11 +34,11 @@ test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -race 2>&1 | tee testacc-output.txt
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -race
 
-junit-report: testacc
+junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest
-	@go-junit-report -in testacc-output.txt -out junit-report.xml
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -race 2>&1 | go-junit-report -iocopy -out junit-report.xml
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
Remove tee comand from output as it was overrinding the final result