### PR TITLE
fix(policy): fix actions to not apply different schema on actions in state

### DIFF
--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -161,14 +161,12 @@ func policyToResourceData(policy *secure.Policy, d *schema.ResourceData) {
 		_ = d.Set("type", "falco")
 
 	}
-	_ = d.Set("actions", policy.Actions)
 
 	actions := []map[string]interface{}{{}}
 	for _, action := range policy.Actions {
 		if action.Type != "POLICY_ACTION_CAPTURE" {
 			action := strings.Replace(action.Type, "POLICY_ACTION_", "", 1)
 			actions[0]["container"] = strings.ToLower(action)
-			_ = d.Set("actions", actions)
 			//d.Set("actions.0.container", strings.ToLower(action))
 		} else {
 			actions[0]["capture"] = []map[string]interface{}{{
@@ -176,9 +174,9 @@ func policyToResourceData(policy *secure.Policy, d *schema.ResourceData) {
 				"seconds_before_event": action.BeforeEventNs / 1000000000,
 				"name":                 action.Name,
 			}}
-			_ = d.Set("actions", actions)
 		}
 	}
+	_ = d.Set("actions", actions)
 
 	_ = d.Set("notification_channels", policy.NotificationChannelIds)
 

--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -103,6 +103,8 @@ resource "sysdig_secure_policy" "sample2" {
   rule_names = [sysdig_secure_rule_falco.terminal_shell.name]
 
   notification_channels = [sysdig_secure_notification_channel_email.sample_email.id]
+
+  actions {}
 }
 `, secureNotificationChannelEmailWithName(name), ruleFalcoTerminalShell(name), name, name)
 }
@@ -116,6 +118,7 @@ resource "sysdig_secure_policy" "sample3" {
   severity = 4
   scope = "container.id != \"\""
   rule_names = ["Terminal shell in container"]
+  actions {}
 }
 `, name, name)
 }
@@ -125,6 +128,7 @@ func policyWithMinimumConfiguration(name string) string {
 resource "sysdig_secure_policy" "sample4" {
   name = "TERRAFORM TEST 4 %s"
   description = "TERRAFORM TEST %s"
+  actions {}
 }
 `, name, name)
 }
@@ -178,6 +182,7 @@ resource "sysdig_secure_policy" "sample4" {
   name = "TERRAFORM TEST 4 %s"
   description = "TERRAFORM TEST %s"
   type = "aws_cloudtrail"
+  actions {}
 }
 `, name, name)
 }
@@ -188,6 +193,7 @@ resource "sysdig_secure_policy" "sample5" {
   name = "TERRAFORM TEST %s"
   description = "TERRAFORM TEST %s"
   type = "gcp_auditlog"
+  actions {}
 }
 `, name, name)
 }
@@ -198,6 +204,7 @@ resource "sysdig_secure_policy" "sample6" {
   name = "TERRAFORM TEST %s"
   description = "TERRAFORM TEST %s"
   type = "azure_platformlogs"
+  actions {}
 }
 `, name, name)
 }


### PR DESCRIPTION
This fixes the issue when actions DTO schema from API is applied on terraform state schema (which is different).
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->