### PR TITLE
refactor(tests): add tf_acc_sysdig and unit tags for tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,14 +31,14 @@ sweep:
 	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS)
 
 test: fmtcheck
-	go test $(TEST) -timeout=30s -parallel=4
+	go test $(TEST) -tags=unit -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -race
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race
 
 junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -race 2>&1 | go-junit-report -iocopy -out junit-report.xml
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race 2>&1 | go-junit-report -iocopy -out junit-report.xml
 
 vet:
 	@echo "go vet ."

--- a/sysdig/data_source_sysdig_current_user_test.go
+++ b/sysdig/data_source_sysdig_current_user_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/data_source_sysdig_fargate_ECS_test.go
+++ b/sysdig/data_source_sysdig_fargate_ECS_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package sysdig
 
 import (

--- a/sysdig/data_source_sysdig_fargate_workload_agent_test.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/data_source_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_email_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/data_source_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/data_source_sysdig_secure_current_connection_test.go
+++ b/sysdig/data_source_sysdig_secure_current_connection_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/data_source_sysdig_secure_notification_channel_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/data_source_sysdig_secure_trusted_cloud_identity_test.go
+++ b/sysdig/data_source_sysdig_secure_trusted_cloud_identity_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/data_source_sysdig_user_test.go
+++ b/sysdig/data_source_sysdig_user_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/internal/client/v2/client_test.go
+++ b/sysdig/internal/client/v2/client_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package v2
 
 import (

--- a/sysdig/internal/client/v2/ibm_test.go
+++ b/sysdig/internal/client/v2/ibm_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package v2
 
 import (

--- a/sysdig/internal/client/v2/sysdig_test.go
+++ b/sysdig/internal/client/v2/sysdig_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package v2
 
 import (

--- a/sysdig/provider_test.go
+++ b/sysdig/provider_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_group_mapping_test.go
+++ b/sysdig/resource_sysdig_group_mapping_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_downtime_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_downtime_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_event_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_event_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_group_outlier_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_group_outlier_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_metric_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_promql_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_promql_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_v2_event_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_event_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_cloud_account_test.go
+++ b/sysdig/resource_sysdig_monitor_cloud_account_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_dashboard_test.go
+++ b/sysdig/resource_sysdig_monitor_dashboard_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_cloud_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_account_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_list_test.go
+++ b/sysdig/resource_sysdig_secure_list_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_macro_test.go
+++ b/sysdig/resource_sysdig_secure_macro_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_email_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_rule_container_test.go
+++ b/sysdig/resource_sysdig_secure_rule_container_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_rule_filesystem_test.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_rule_network_test.go
+++ b/sysdig/resource_sysdig_secure_rule_network_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_rule_process_test.go
+++ b/sysdig/resource_sysdig_secure_rule_process_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_rule_syscall_test.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_scanningpolicies_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpolicies_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_team_test.go
+++ b/sysdig/resource_sysdig_secure_team_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_vulnerability_exception_list_test.go
+++ b/sysdig/resource_sysdig_secure_vulnerability_exception_list_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_secure_vulnerability_exception_test.go
+++ b/sysdig/resource_sysdig_secure_vulnerability_exception_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (

--- a/sysdig/resource_sysdig_user_test.go
+++ b/sysdig/resource_sysdig_user_test.go
@@ -1,3 +1,5 @@
+//go:build tf_acc_sysdig
+
 package sysdig_test
 
 import (


### PR DESCRIPTION
We added build tags on tests so we can distinct which battery of tests to run. This will allow us to run specific tests on the specific environment in the future.
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->