### PR TITLE
feat(teams): add ibm platform metrics in teams

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,5 +64,5 @@ jobs:
         env:
           SYSDIG_IBM_MONITOR_API_KEY: ${{ secrets.TERRAFORM_IBM_API_KEY }}
           SYSDIG_IBM_MONITOR_INSTANCE_ID: ${{ secrets.TERRAFORM_IBM_MONITOR_INSTANCE_ID }}
-          SYSDIG_IBM_MONITOR_URL: "https://us-south.monitoring.test.cloud.ibm.com"
           SYSDIG_IBM_MONITOR_IAM_URL: "https://iam.test.cloud.ibm.com"
+          SYSDIG_MONITOR_URL: "https://us-south.monitoring.test.cloud.ibm.com"

--- a/sysdig/internal/client/v2/client.go
+++ b/sysdig/internal/client/v2/client.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	SysdigTeamIDHeader        = "SysdigTeamID"
 	AuthorizationHeader       = "Authorization"
 	ContentTypeHeader         = "Content-Type"
 	ContentTypeJSON           = "application/json"

--- a/sysdig/internal/client/v2/config.go
+++ b/sysdig/internal/client/v2/config.go
@@ -5,7 +5,6 @@ type config struct {
 	token         string
 	insecure      bool
 	extraHeaders  map[string]string
-	teamID        string
 	ibmInstanceID string
 	ibmAPIKey     string
 	ibmIamURL     string

--- a/sysdig/internal/client/v2/config.go
+++ b/sysdig/internal/client/v2/config.go
@@ -37,12 +37,6 @@ func WithExtraHeaders(headers map[string]string) ClientOption {
 	}
 }
 
-func WithTeamID(teamID string) ClientOption {
-	return func(c *config) {
-		c.teamID = teamID
-	}
-}
-
 func WithIBMInstanceID(instanceID string) ClientOption {
 	return func(c *config) {
 		c.ibmInstanceID = instanceID

--- a/sysdig/internal/client/v2/ibm.go
+++ b/sysdig/internal/client/v2/ibm.go
@@ -87,9 +87,6 @@ func (ir *IBMRequest) Request(ctx context.Context, method string, url string, pa
 	}
 
 	r = r.WithContext(ctx)
-	if ir.config.teamID != "" {
-		r.Header.Set(SysdigTeamIDHeader, ir.config.teamID)
-	}
 	r.Header.Set(IBMInstanceIDHeader, ir.config.ibmInstanceID)
 	r.Header.Set(AuthorizationHeader, fmt.Sprintf("Bearer %s", token))
 	r.Header.Set(ContentTypeHeader, ContentTypeJSON)

--- a/sysdig/internal/client/v2/ibm_test.go
+++ b/sysdig/internal/client/v2/ibm_test.go
@@ -69,7 +69,6 @@ func TestIBMClient_DoIBMRequest(t *testing.T) {
 			WithIBMAPIKey(apiKey),
 			WithIBMIamURL(server.URL),
 			WithURL(server.URL),
-			WithTeamID(teamID),
 		)
 
 		url := fmt.Sprintf("%s/foo/bar", server.URL)

--- a/sysdig/internal/client/v2/ibm_test.go
+++ b/sysdig/internal/client/v2/ibm_test.go
@@ -33,7 +33,6 @@ func TestIBMClient_DoIBMRequest(t *testing.T) {
 		instanceID := "instance ID"
 		apiKey := "api key"
 		token := "token"
-		teamID := "team ID"
 		iamEndpointCalled := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == IBMIAMPath {
@@ -58,9 +57,6 @@ func TestIBMClient_DoIBMRequest(t *testing.T) {
 			}
 			if value := r.Header.Get(IBMInstanceIDHeader); value != instanceID {
 				t.Errorf("expected instance id %v, got %v", instanceID, value)
-			}
-			if value := r.Header.Get(SysdigTeamIDHeader); value != teamID {
-				t.Errorf("expected team id %v, got %v", teamID, value)
 			}
 		}))
 

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -1,27 +1,32 @@
 package v2
 
 type Team struct {
-	UserRoles           []UserRoles `json:"userRoles,omitempty"`
-	Description         string      `json:"description"`
-	Name                string      `json:"name"`
-	ID                  int         `json:"id,omitempty"`
-	Version             int         `json:"version,omitempty"`
-	Origin              string      `json:"origin,omitempty"`
-	LastUpdated         int64       `json:"lastUpdated,omitempty"`
-	EntryPoint          *EntryPoint `json:"entryPoint,omitempty"`
-	Theme               string      `json:"theme"`
-	CustomerID          int         `json:"customerId,omitempty"`
-	DateCreated         int64       `json:"dateCreated,omitempty"`
-	Products            []string    `json:"products,omitempty"`
-	Show                string      `json:"show,omitempty"`
-	Immutable           bool        `json:"immutable,omitempty"`
-	CanUseSysdigCapture *bool       `json:"canUseSysdigCapture,omitempty"`
-	CanUseCustomEvents  *bool       `json:"canUseCustomEvents,omitempty"`
-	CanUseAwsMetrics    *bool       `json:"canUseAwsMetrics,omitempty"`
-	CanUseBeaconMetrics *bool       `json:"canUseBeaconMetrics,omitempty"`
-	UserCount           int         `json:"userCount,omitempty"`
-	Filter              string      `json:"filter,omitempty"`
-	DefaultTeam         bool        `json:"default,omitempty"`
+	UserRoles           []UserRoles       `json:"userRoles,omitempty"`
+	Description         string            `json:"description"`
+	Name                string            `json:"name"`
+	ID                  int               `json:"id,omitempty"`
+	Version             int               `json:"version,omitempty"`
+	Origin              string            `json:"origin,omitempty"`
+	LastUpdated         int64             `json:"lastUpdated,omitempty"`
+	EntryPoint          *EntryPoint       `json:"entryPoint,omitempty"`
+	Theme               string            `json:"theme"`
+	CustomerID          int               `json:"customerId,omitempty"`
+	DateCreated         int64             `json:"dateCreated,omitempty"`
+	Products            []string          `json:"products,omitempty"`
+	Show                string            `json:"show,omitempty"`
+	Immutable           bool              `json:"immutable,omitempty"`
+	CanUseSysdigCapture *bool             `json:"canUseSysdigCapture,omitempty"`
+	CanUseCustomEvents  *bool             `json:"canUseCustomEvents,omitempty"`
+	CanUseAwsMetrics    *bool             `json:"canUseAwsMetrics,omitempty"`
+	CanUseBeaconMetrics *bool             `json:"canUseBeaconMetrics,omitempty"`
+	UserCount           int               `json:"userCount,omitempty"`
+	Filter              string            `json:"filter,omitempty"`
+	NamespaceFilters    *NamespaceFilters `json:"namespaceFilters,omitempty"`
+	DefaultTeam         bool              `json:"default,omitempty"`
+}
+
+type NamespaceFilters struct {
+	IBMPlatformMetrics *string `json:"ibmPlatformMetrics"`
 }
 
 type UserRoles struct {

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -8,7 +8,6 @@ import (
 )
 
 func Provider() *schema.Provider {
-	undocumentedCodeMsg := "You are using undocumented provider argument which can change in future releases. Please do not use it."
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"sysdig_secure_api_token": {
@@ -48,41 +47,20 @@ func Provider() *schema.Provider {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"ibm_monitor_url": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_IBM_MONITOR_URL", nil),
-				Deprecated:  undocumentedCodeMsg,
-			},
 			"ibm_monitor_iam_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_IBM_MONITOR_IAM_URL", nil),
-				Deprecated:  undocumentedCodeMsg,
 			},
 			"ibm_monitor_instance_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_IBM_MONITOR_INSTANCE_ID", nil),
-				Deprecated:  undocumentedCodeMsg,
 			},
 			"ibm_monitor_api_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_IBM_MONITOR_API_KEY", nil),
-				Deprecated:  undocumentedCodeMsg,
-			},
-			"ibm_monitor_insecure_tls": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_IBM_MONITOR_INSECURE_TLS", nil),
-				Deprecated:  undocumentedCodeMsg,
-			},
-			"ibm_monitor_team_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_IBM_MONITOR_TEAM_ID", nil),
-				Deprecated:  undocumentedCodeMsg,
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/sysdig/resource_sysdig_monitor_team.go
+++ b/sysdig/resource_sysdig_monitor_team.go
@@ -54,14 +54,12 @@ func resourceSysdigMonitorTeam() *schema.Resource {
 				Optional: true,
 			},
 			"enable_ibm_platform_metrics": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable platform metrics on IBM Cloud Monitor.",
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 			"ibm_platform_metrics": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Define platform metrics on IBM Cloud Monitor.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"can_use_sysdig_capture": {
 				Type:     schema.TypeBool,

--- a/sysdig/resource_sysdig_monitor_team_ibm_test.go
+++ b/sysdig/resource_sysdig_monitor_team_ibm_test.go
@@ -39,6 +39,9 @@ func TestAccMonitorIBMTeam(t *testing.T) {
 				Config: monitorTeamWithFullConfigIBM(rText()),
 			},
 			{
+				Config: monitorTeamWithPlatformMetricsIBM(rText()),
+			},
+			{
 				ResourceName:      "sysdig_monitor_team.sample",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -61,4 +64,17 @@ resource "sysdig_monitor_team" "sample" {
 	type = "Dashboards"
   }
 }`, name, name)
+}
+
+func monitorTeamWithPlatformMetricsIBM(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_team" "sample" {
+  name = "sample-%s"
+  enable_ibm_platform_metrics = true
+  ibm_platform_metrics = "foo in (\"0\") and bar in (\"3\")"
+
+  entrypoint {
+	type = "Dashboards"
+  }
+}`, name)
 }

--- a/sysdig/sysdig_clients.go
+++ b/sysdig/sysdig_clients.go
@@ -118,7 +118,7 @@ func getIBMMonitorVariables(data *schema.ResourceData) (*ibmVariables, error) {
 	var ok bool
 	var apiURL, iamURL, instanceID, apiKey interface{}
 
-	if apiURL, ok = data.GetOk("ibm_monitor_url"); !ok {
+	if apiURL, ok = data.GetOk("sysdig_monitor_url"); !ok {
 		return nil, errors.New("missing monitor IBM URL")
 	}
 
@@ -137,13 +137,12 @@ func getIBMMonitorVariables(data *schema.ResourceData) (*ibmVariables, error) {
 	return &ibmVariables{
 		globalVariables: &globalVariables{
 			apiURL:       apiURL.(string),
-			insecure:     data.Get("ibm_monitor_insecure_tls").(bool),
+			insecure:     data.Get("sysdig_monitor_insecure_tls").(bool),
 			extraHeaders: getExtraHeaders(data),
 		},
 		iamURL:     iamURL.(string),
 		instanceID: instanceID.(string),
 		apiKey:     apiKey.(string),
-		teamID:     data.Get("ibm_monitor_team_id").(string),
 	}, nil
 }
 

--- a/sysdig/sysdig_clients.go
+++ b/sysdig/sysdig_clients.go
@@ -67,7 +67,6 @@ type ibmVariables struct {
 	iamURL     string
 	instanceID string
 	apiKey     string
-	teamID     string
 }
 
 func getSysdigMonitorVariables(data *schema.ResourceData) (*sysdigVariables, error) {

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -17,6 +17,8 @@ optional.
 For either options, the corresponding **URL** and **API Token** must be configured.
 See options bellow.
 
+Sysdig provider can also be used to interact with [IBM Cloud Monitoring](https://cloud.ibm.com/docs/monitoring?topic=monitoring-getting-started). For more details check `IBM Cloud Monitoring Authentication` example and configuration reference below. 
+
 Use the navigation to the left to read about the available resources.
 
 ## Example Usage
@@ -75,6 +77,17 @@ resource "sysdig_secure_policy" "unexpected_inbound_tcp_connection_traefik" {
 }
 ```
 
+### IBM Cloud Monitoring Authentication
+
+```terraform
+provider "sysdig" {
+  sysdig_monitor_url = "https://us-south.monitoring.test.cloud.ibm.com"
+  ibm_monitor_iam_url = "https://iam.test.cloud.ibm.com"
+  ibm_monitor_instance_id = "xxxxxx"
+  ibm_monitor_api_key = "xxxxxx"
+}
+```
+
 ## Configuration Reference
 
 For Sysdig provider authentication **one of Monitor or Secure authentication is required**, being the other
@@ -121,6 +134,29 @@ When Secure resources are to be created, this authentication must be in place.
 * `sysdig_secure_insecure_tls` - (Optional) Defines if the HTTP client can ignore
   the use of invalid HTTPS certificates in the Secure API. It can be useful for 
   on-prem installations. It can also be sourced from the `SYSDIG_SECURE_INSECURE_TLS`
+  environment variable. By default, this is false.<br/><br/>
+
+
+### IBM Cloud Monitoring Authentication
+
+When IBM Cloud Monitoring resources are to be created, this authentication must be in place.
+
+* `sysdig_monitor_url` - (Required) This is the target IBM Cloud Monitoring API
+  endpoint. It can also be sourced from the `SYSDIG_MONITOR_URL` environment variable.
+  <br/>Notice: it should not be ended with a slash.<br/><br/>
+* `ibm_monitor_iam_url` - (Required) This is the target IAM endpoint used to issue IBM IAM token by consuming `ibm_monitor_api_key`. 
+  Provider will handle token expiration and refresh it when needed.
+  <br/>It can also be configured from the `SYSDIG_IBM_MONITOR_IAM_URL` environment variable.<br/><br/>
+* `ibm_monitor_instance_id` (Required) This is the target instance ID (GUID format) of IBM instance which is hosting IBM Cloud Monitoring.
+  <br/>It can also be configured from the `SYSDIG_IBM_MONITOR_INSTANCE_ID` environment variable.
+  <br/><br/>
+* `ibm_monitor_api_key` (Required) An API key is a unique code that is passed to an IBM IAM service to generate IAM token used for making HTTP request against IBM endpoints. 
+  This argument can be used to specify any kind of IBM API keys (User API key, Service ID, ...).
+  <br/>It can also be configured from the `SYSDIG_IBM_MONITOR_API_KEY` environment variable.
+  <br/><br/>
+* `sysdig_monitor_insecure_tls` - (Optional) Defines if the HTTP client can ignore
+  the use of invalid HTTPS certificates in the IBM Monitoring Cloud API.
+  <br/> It can also be sourced from the `SYSDIG_MONITOR_INSECURE_TLS`
   environment variable. By default, this is false.<br/><br/>
 
 ###  Others

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -159,6 +159,10 @@ When IBM Cloud Monitoring resources are to be created, this authentication must 
   <br/> It can also be sourced from the `SYSDIG_MONITOR_INSECURE_TLS`
   environment variable. By default, this is false.<br/><br/>
 
+> **Note**
+> Enabling this way of authentication is under active development. For now, you can manage following resources on IBM Cloud Monitoring:
+> - `sysdig_monitor_team`
+
 ###  Others
 * `extra_headers` - (Optional) Defines extra HTTP headers that will be added to the client
   while performing HTTP API calls.

--- a/website/docs/r/monitor_team.md
+++ b/website/docs/r/monitor_team.md
@@ -85,6 +85,8 @@ data "sysdig_current_user" "me" {
 
 In addition to all arguments above, the following attributes are exported:
 
+* `default_team` - (Optional) Mark team as default team. Users with no designated team will be added to this team by default.
+
 ### IBM Cloud Monitoring arguments
 
 * `enable_ibm_platform_metrics` - (Optional) Enable platform metrics on IBM Cloud Monitoring.

--- a/website/docs/r/monitor_team.md
+++ b/website/docs/r/monitor_team.md
@@ -64,7 +64,6 @@ data "sysdig_current_user" "me" {
                  Administrators of the account will be automatically added
                  to every new created team, so they don't need to be added as a
                  resource in the Terraform manifest.
-                 
 
 ### Entrypoint Argument Reference
 
@@ -84,7 +83,11 @@ data "sysdig_current_user" "me" {
 
 ## Attributes Reference
 
-No additional attributes are exported.
+### IBM Cloud Monitoring arguments
+
+* `enable_ibm_platform_metrics` - (Optional) Enable platform metrics on IBM Cloud Monitoring.
+
+* `ibm_platform_metrics` - (Optional) Define platform metrics on IBM Cloud Monitoring.
 
 ## Import
 

--- a/website/docs/r/monitor_team.md
+++ b/website/docs/r/monitor_team.md
@@ -83,6 +83,8 @@ data "sysdig_current_user" "me" {
 
 ## Attributes Reference
 
+In addition to all arguments above, the following attributes are exported:
+
 ### IBM Cloud Monitoring arguments
 
 * `enable_ibm_platform_metrics` - (Optional) Enable platform metrics on IBM Cloud Monitoring.


### PR DESCRIPTION
Added features:
- We are adding support for IBM Auth on IBM Cloud Monitoring. Provider is extended with IBM specific arguments (and doc is updated).
- Two new options are added  on monitor team resource (and doc is updated):
  - `enable_ibm_platform_metrics` - enables platform metrics on IBM Cloud Monitoring
  - `ibm_platform_metrics` - defines platform metrics on IBM Cloud Monitoring
- `ibm_monitor_team_id` provider argument is removed. We do not want to support it yet.
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->