### PR TITLE
feat(notificationchannels): add team option in provider, add share_with_current_team in notification channels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
   test-sysdig:
     name: Sysdig Acceptance Tests
     runs-on: ubuntu-latest
+    needs: test
 
     steps:
       - name: Check out code

--- a/sysdig/common_test.go
+++ b/sysdig/common_test.go
@@ -1,0 +1,18 @@
+//go:build tf_acc_sysdig || tf_acc_ibm || unit
+
+package sysdig_test
+
+import (
+	"os"
+	"testing"
+)
+
+func sysdigOrIBMMonitorPreCheck(t *testing.T) func() {
+	return func() {
+		monitor := os.Getenv("SYSDIG_MONITOR_API_TOKEN")
+		ibmMonitor := os.Getenv("SYSDIG_IBM_MONITOR_API_KEY")
+		if monitor == "" && ibmMonitor == "" {
+			t.Fatal("SYSDIG_MONITOR_API_TOKEN or SYSDIG_IBM_MONITOR_API_KEY must be set for acceptance tests")
+		}
+	}
+}

--- a/sysdig/internal/client/v2/client.go
+++ b/sysdig/internal/client/v2/client.go
@@ -18,6 +18,7 @@ import (
 )
 
 const (
+	GetMePath                 = "/api/users/me"
 	AuthorizationHeader       = "Authorization"
 	ContentTypeHeader         = "Content-Type"
 	ContentTypeJSON           = "application/json"
@@ -109,7 +110,7 @@ func request(httpClient *http.Client, cfg *config, request *http.Request) (*http
 func getMe(ctx context.Context, cfg *config, httpClient *http.Client, headers map[string]string) (*User, error) {
 	r, err := http.NewRequest(
 		http.MethodGet,
-		fmt.Sprintf("%s/api/users/me", cfg.url),
+		fmt.Sprintf("%s%s", cfg.url, GetMePath),
 		nil,
 	)
 	if err != nil {

--- a/sysdig/internal/client/v2/config.go
+++ b/sysdig/internal/client/v2/config.go
@@ -1,13 +1,15 @@
 package v2
 
 type config struct {
-	url           string
-	token         string
-	insecure      bool
-	extraHeaders  map[string]string
-	ibmInstanceID string
-	ibmAPIKey     string
-	ibmIamURL     string
+	url            string
+	token          string
+	insecure       bool
+	extraHeaders   map[string]string
+	ibmInstanceID  string
+	ibmAPIKey      string
+	ibmIamURL      string
+	sysdigTeamName string
+	sysdigTeamID   *int
 }
 
 type ClientOption func(c *config)
@@ -51,6 +53,18 @@ func WithIBMAPIKey(key string) ClientOption {
 func WithIBMIamURL(url string) ClientOption {
 	return func(c *config) {
 		c.ibmIamURL = url
+	}
+}
+
+func WithSysdigTeamID(teamID *int) ClientOption {
+	return func(c *config) {
+		c.sysdigTeamID = teamID
+	}
+}
+
+func WithSysdigTeamName(teamName string) ClientOption {
+	return func(c *config) {
+		c.sysdigTeamName = teamName
 	}
 }
 

--- a/sysdig/internal/client/v2/ibm.go
+++ b/sysdig/internal/client/v2/ibm.go
@@ -19,6 +19,7 @@ const (
 	IBMApiKeyFormValue    = "apikey"
 	IBMAPIKeyGrantType    = "urn:ibm:params:oauth:grant-type:apikey"
 	SysdigTeamIDHeader    = "SysdigTeamID"
+	GetTeamByNamePath     = "/api/v2/teams/light/name/"
 )
 
 type IBMCommon interface {
@@ -89,7 +90,7 @@ func (ir *IBMRequest) getIBMIAMToken() (IBMAccessToken, error) {
 func (ir *IBMRequest) getTeamIDByName(ctx context.Context, name string, token IBMAccessToken) (int, error) {
 	r, err := http.NewRequest(
 		http.MethodGet,
-		fmt.Sprintf("%s/api/v2/teams/light/name/%s", ir.config.url, name),
+		fmt.Sprintf("%s%s%s", ir.config.url, GetTeamByNamePath, name),
 		nil,
 	)
 	if err != nil {

--- a/sysdig/internal/client/v2/ibm.go
+++ b/sysdig/internal/client/v2/ibm.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -16,6 +18,7 @@ const (
 	IBMGrantTypeFormValue = "grant_type"
 	IBMApiKeyFormValue    = "apikey"
 	IBMAPIKeyGrantType    = "urn:ibm:params:oauth:grant-type:apikey"
+	SysdigTeamIDHeader    = "SysdigTeamID"
 )
 
 type IBMCommon interface {
@@ -30,10 +33,15 @@ type IBMAccessToken string
 type UnixTimestamp int64
 
 type IBMRequest struct {
-	config          *config
-	httpClient      *http.Client
+	config     *config
+	httpClient *http.Client
+
+	tokenLock       *sync.Mutex
 	tokenExpiration UnixTimestamp
 	token           IBMAccessToken
+
+	teamIDLock *sync.Mutex
+	teamID     *int
 }
 
 type IAMTokenResponse struct {
@@ -42,6 +50,9 @@ type IAMTokenResponse struct {
 }
 
 func (ir *IBMRequest) getIBMIAMToken() (IBMAccessToken, error) {
+	ir.tokenLock.Lock()
+	defer ir.tokenLock.Unlock()
+
 	if UnixTimestamp(time.Now().Unix()) < ir.tokenExpiration {
 		return ir.token, nil
 	}
@@ -75,6 +86,72 @@ func (ir *IBMRequest) getIBMIAMToken() (IBMAccessToken, error) {
 	return ir.token, nil
 }
 
+func (ir *IBMRequest) getTeamIDByName(ctx context.Context, name string, token IBMAccessToken) (int, error) {
+	r, err := http.NewRequest(
+		http.MethodGet,
+		fmt.Sprintf("%s/api/v2/teams/light/name/%s", ir.config.url, name),
+		nil,
+	)
+	if err != nil {
+		return -1, err
+	}
+
+	r = r.WithContext(ctx)
+	r.Header.Set(IBMInstanceIDHeader, ir.config.ibmInstanceID)
+	r.Header.Set(AuthorizationHeader, fmt.Sprintf("Bearer %s", token))
+
+	resp, err := request(ir.httpClient, ir.config, r)
+	if err != nil {
+		return -1, err
+	}
+	defer resp.Body.Close()
+
+	wrapper, err := Unmarshal[teamWrapper](resp.Body)
+	if err != nil {
+		return -1, err
+	}
+
+	return wrapper.Team.ID, nil
+}
+
+func (ir *IBMRequest) CurrentTeamID(ctx context.Context) (int, error) {
+	ir.teamIDLock.Lock()
+	defer ir.teamIDLock.Unlock()
+
+	if ir.teamID != nil {
+		return *ir.teamID, nil
+	}
+
+	token, err := ir.getIBMIAMToken()
+	if err != nil {
+		return -1, err
+	}
+
+	if ir.config.sysdigTeamName != "" {
+		teamID, err := ir.getTeamIDByName(ctx, ir.config.sysdigTeamName, token)
+		if err != nil {
+			return -1, err
+		}
+
+		ir.teamID = &teamID
+		return *ir.teamID, nil
+	}
+
+	// use default current team
+	user, err := getMe(ctx, ir.config, ir.httpClient, map[string]string{
+		IBMInstanceIDHeader: ir.config.ibmInstanceID,
+		AuthorizationHeader: fmt.Sprintf("Bearer %s", token),
+		ContentTypeHeader:   ContentTypeJSON,
+	})
+	if err != nil {
+		return -1, err
+	}
+
+	ir.teamID = &user.CurrentTeam
+
+	return *ir.teamID, nil
+}
+
 func (ir *IBMRequest) Request(ctx context.Context, method string, url string, payload io.Reader) (*http.Response, error) {
 	r, err := http.NewRequest(method, url, payload)
 	if err != nil {
@@ -86,9 +163,15 @@ func (ir *IBMRequest) Request(ctx context.Context, method string, url string, pa
 		return nil, err
 	}
 
+	teamID, err := ir.CurrentTeamID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	r = r.WithContext(ctx)
 	r.Header.Set(IBMInstanceIDHeader, ir.config.ibmInstanceID)
 	r.Header.Set(AuthorizationHeader, fmt.Sprintf("Bearer %s", token))
+	r.Header.Set(SysdigTeamIDHeader, strconv.Itoa(teamID))
 	r.Header.Set(ContentTypeHeader, ContentTypeJSON)
 
 	return request(ir.httpClient, ir.config, r)
@@ -99,8 +182,11 @@ func newIBMClient(opts ...ClientOption) *Client {
 	return &Client{
 		config: cfg,
 		requester: &IBMRequest{
+			tokenLock:  &sync.Mutex{},
+			teamIDLock: &sync.Mutex{},
 			config:     cfg,
 			httpClient: newHTTPClient(cfg),
+			teamID:     cfg.sysdigTeamID,
 		},
 	}
 }

--- a/sysdig/internal/client/v2/ibm.go
+++ b/sysdig/internal/client/v2/ibm.go
@@ -142,7 +142,6 @@ func (ir *IBMRequest) CurrentTeamID(ctx context.Context) (int, error) {
 	user, err := getMe(ctx, ir.config, ir.httpClient, map[string]string{
 		IBMInstanceIDHeader: ir.config.ibmInstanceID,
 		AuthorizationHeader: fmt.Sprintf("Bearer %s", token),
-		ContentTypeHeader:   ContentTypeJSON,
 	})
 	if err != nil {
 		return -1, err

--- a/sysdig/internal/client/v2/ibm_test.go
+++ b/sysdig/internal/client/v2/ibm_test.go
@@ -60,11 +60,13 @@ func TestIBMClient_DoIBMRequest(t *testing.T) {
 			}
 		}))
 
+		var teamID int
 		c := newIBMClient(
 			WithIBMInstanceID(instanceID),
 			WithIBMAPIKey(apiKey),
 			WithIBMIamURL(server.URL),
 			WithURL(server.URL),
+			WithSysdigTeamID(&teamID),
 		)
 
 		url := fmt.Sprintf("%s/foo/bar", server.URL)

--- a/sysdig/internal/client/v2/ibm_test.go
+++ b/sysdig/internal/client/v2/ibm_test.go
@@ -96,23 +96,37 @@ func TestIBMClient_CurrentTeamID(t *testing.T) {
 
 	testTable := []struct {
 		name           string
-		opt            ClientOption
+		opts           []ClientOption
 		expectedTeamID int
 	}{
 		{
-			name:           "use current team id from user",
-			opt:            WithSysdigTeamID(nil),
+			name: "use current team id from user",
+			opts: []ClientOption{
+				WithSysdigTeamID(nil),
+			},
 			expectedTeamID: teamID1,
 		},
 		{
-			name:           "use specified team id",
-			opt:            WithSysdigTeamID(&teamID2),
+			name: "use specified team id",
+			opts: []ClientOption{
+				WithSysdigTeamID(&teamID2),
+			},
 			expectedTeamID: teamID2,
 		},
 		{
-			name:           "get team id from team name",
-			opt:            WithSysdigTeamName(teamName),
+			name: "get team id from team name",
+			opts: []ClientOption{
+				WithSysdigTeamName(teamName),
+			},
 			expectedTeamID: teamID3,
+		},
+		{
+			name: "team id has priority over team name",
+			opts: []ClientOption{
+				WithSysdigTeamID(&teamID2),
+				WithSysdigTeamName(teamName),
+			},
+			expectedTeamID: teamID2,
 		},
 	}
 
@@ -156,13 +170,14 @@ func TestIBMClient_CurrentTeamID(t *testing.T) {
 
 	for _, testCase := range testTable {
 		t.Run(testCase.name, func(t *testing.T) {
-			c := newIBMClient(
+			opts := []ClientOption{
 				WithIBMInstanceID(instanceID),
 				WithIBMAPIKey(apiKey),
 				WithIBMIamURL(server.URL),
 				WithURL(server.URL),
-				testCase.opt,
-			)
+			}
+			opts = append(opts, testCase.opts...)
+			c := newIBMClient(opts...)
 
 			id, err := c.CurrentTeamID(context.Background())
 			if err != nil {

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -1,5 +1,14 @@
 package v2
 
+type User struct {
+	ID          int `json:"id"`
+	CurrentTeam int `json:"currentTeam"`
+}
+
+type userWrapper struct {
+	User User `json:"user"`
+}
+
 type Team struct {
 	UserRoles           []UserRoles       `json:"userRoles,omitempty"`
 	Description         string            `json:"description"`

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -78,6 +78,7 @@ type NotificationChannel struct {
 	Type    string                     `json:"type"`
 	Name    string                     `json:"name"`
 	Enabled bool                       `json:"enabled"`
+	TeamID  *int                       `json:"teamId,omitempty"`
 	Options NotificationChannelOptions `json:"options"`
 }
 

--- a/sysdig/internal/client/v2/notification_channels.go
+++ b/sysdig/internal/client/v2/notification_channels.go
@@ -12,6 +12,7 @@ const (
 )
 
 type NotificationChannelInterface interface {
+	Base
 	GetNotificationChannelById(ctx context.Context, id int) (NotificationChannel, error)
 	GetNotificationChannelByName(ctx context.Context, name string) (NotificationChannel, error)
 	CreateNotificationChannel(ctx context.Context, channel NotificationChannel) (NotificationChannel, error)

--- a/sysdig/internal/client/v2/sysdig.go
+++ b/sysdig/internal/client/v2/sysdig.go
@@ -70,7 +70,6 @@ func (sr *SysdigRequest) CurrentTeamID(ctx context.Context) (int, error) {
 
 	user, err := getMe(ctx, sr.config, sr.httpClient, map[string]string{
 		AuthorizationHeader: fmt.Sprintf("Bearer %s", sr.config.token),
-		ContentTypeHeader:   ContentTypeJSON,
 	})
 	if err != nil {
 		return -1, err

--- a/sysdig/internal/client/v2/sysdig_test.go
+++ b/sysdig/internal/client/v2/sysdig_test.go
@@ -4,6 +4,7 @@ package v2
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -52,5 +53,40 @@ func TestSysdigRequest(t *testing.T) {
 	_, err = c.requester.Request(context.Background(), http.MethodPost, server.URL, payload)
 	if err != nil {
 		t.Errorf("got error while sending request, err: %v", err)
+	}
+}
+
+func TestSysdigClient_CurrentTeamID(t *testing.T) {
+	token := "token"
+	teamID := 1
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := json.Marshal(userWrapper{
+			User: User{
+				CurrentTeam: teamID,
+			},
+		})
+		if err != nil {
+			t.Errorf("failed to create user response, err: %v", err)
+		}
+
+		_, err = w.Write(data)
+		if err != nil {
+			t.Errorf("failed to create response, err: %v", err)
+		}
+	}))
+
+	c := newSysdigClient(
+		WithURL(server.URL),
+		WithToken(token),
+	)
+
+	id, err := c.CurrentTeamID(context.Background())
+	if err != nil {
+		t.Errorf("failed to get current team id, %v", err)
+	}
+
+	if id != teamID {
+		t.Errorf("expecting team id %d, got %d", teamID, id)
 	}
 }

--- a/sysdig/internal/client/v2/teams.go
+++ b/sysdig/internal/client/v2/teams.go
@@ -13,6 +13,7 @@ const (
 )
 
 type TeamInterface interface {
+	Base
 	GetUserIDByEmail(ctx context.Context, userRoles []UserRoles) ([]UserRoles, error)
 	GetTeamById(ctx context.Context, id int) (t Team, err error)
 	CreateTeam(ctx context.Context, tRequest Team) (t Team, err error)

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -47,6 +47,16 @@ func Provider() *schema.Provider {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"sysdig_monitor_team_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_MONITOR_TEAM_ID", nil),
+			},
+			"sysdig_monitor_team_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_MONITOR_TEAM_NAME", nil),
+			},
 			"ibm_monitor_iam_url": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/sysdig/resource_sysdig_monitor_notification_channel_common.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_common.go
@@ -16,6 +16,10 @@ func createMonitorNotificationChannelSchema(original map[string]*schema.Schema) 
 			Optional: true,
 			Default:  true,
 		},
+		"share_with": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
 		"notify_when_ok": {
 			Type:     schema.TypeBool,
 			Optional: true,
@@ -45,9 +49,16 @@ func createMonitorNotificationChannelSchema(original map[string]*schema.Schema) 
 }
 
 func monitorNotificationChannelFromResourceData(d *schema.ResourceData) (nc v2.NotificationChannel, err error) {
+	var teamID *int
+	if v, ok := d.GetOk("share_with"); ok {
+		tmp := v.(int)
+		teamID = &tmp
+	}
+
 	nc = v2.NotificationChannel{
 		Name:    d.Get("name").(string),
 		Enabled: d.Get("enabled").(bool),
+		TeamID:  teamID,
 		Options: v2.NotificationChannelOptions{
 			NotifyOnOk:           d.Get("notify_when_ok").(bool),
 			NotifyOnResolve:      d.Get("notify_when_resolved").(bool),
@@ -61,6 +72,10 @@ func monitorNotificationChannelToResourceData(nc *v2.NotificationChannel, data *
 	_ = data.Set("version", nc.Version)
 	_ = data.Set("name", nc.Name)
 	_ = data.Set("enabled", nc.Enabled)
+	err = data.Set("share_with", nc.TeamID)
+	if err != nil {
+		return err
+	}
 	_ = data.Set("notify_when_ok", nc.Options.NotifyOnOk)
 	_ = data.Set("notify_when_resolved", nc.Options.NotifyOnResolve)
 	_ = data.Set("send_test_notification", nc.Options.SendTestNotification)

--- a/sysdig/resource_sysdig_monitor_notification_channel_common.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_common.go
@@ -16,7 +16,7 @@ func createMonitorNotificationChannelSchema(original map[string]*schema.Schema) 
 			Optional: true,
 			Default:  true,
 		},
-		"share_with_all_teams": {
+		"share_with_current_team": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
@@ -51,8 +51,8 @@ func createMonitorNotificationChannelSchema(original map[string]*schema.Schema) 
 
 func monitorNotificationChannelFromResourceData(d *schema.ResourceData, teamID int) (nc v2.NotificationChannel, err error) {
 	var tID *int
-	shareAllTeams := d.Get("share_with_all_teams").(bool)
-	if !shareAllTeams {
+	shareWithCurrentTeam := d.Get("share_with_current_team").(bool)
+	if shareWithCurrentTeam {
 		tID = &teamID
 	}
 
@@ -73,12 +73,12 @@ func monitorNotificationChannelToResourceData(nc *v2.NotificationChannel, data *
 	_ = data.Set("version", nc.Version)
 	_ = data.Set("name", nc.Name)
 	_ = data.Set("enabled", nc.Enabled)
-	shareWithAllTeams := false
-	if nc.TeamID == nil {
-		shareWithAllTeams = true
+	var shareWithCurrentTeam bool
+	if nc.TeamID != nil {
+		shareWithCurrentTeam = true
 	}
 
-	err = data.Set("share_with_all_teams", shareWithAllTeams)
+	err = data.Set("share_with_current_team", shareWithCurrentTeam)
 	if err != nil {
 		return err
 	}

--- a/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
@@ -31,9 +31,6 @@ func TestAccMonitorNotificationChannelEmail(t *testing.T) {
 				Config: monitorNotificationChannelEmailWithNameInReverseOrder(rText()),
 			},
 			{
-				Config: monitorNotificationChannelEmailWithTeam(rText()),
-			},
-			{
 				ResourceName:      "sysdig_monitor_notification_channel_email.sample_email",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -60,27 +57,6 @@ resource "sysdig_monitor_notification_channel_email" "sample_email" {
 	name = "%s"
 	recipients = ["bar@localhost.com", "root@localhost.com"]
 	enabled = false
-	notify_when_ok = false
-	notify_when_resolved = false
-	send_test_notification = false
-}`, name)
-}
-
-func monitorNotificationChannelEmailWithTeam(name string) string {
-	return fmt.Sprintf(`
-resource "sysdig_monitor_team" "sample_team" {
-  name = "team-%[1]s"
-
-  entrypoint {
-    type = "Explore"
-  }
-}
-
-resource "sysdig_monitor_notification_channel_email" "sample_email" {
-	name = "%[1]s"
-    share_with = sysdig_monitor_team.sample_team.id
-	recipients = ["root@localhost.com", "bar@localhost.com"]
-	enabled = true
 	notify_when_ok = false
 	notify_when_resolved = false
 	send_test_notification = false

--- a/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
@@ -4,7 +4,6 @@ package sysdig_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -15,18 +14,10 @@ import (
 )
 
 func TestAccMonitorNotificationChannelEmail(t *testing.T) {
-	//var ncBefore, ncAfter monitor.NotificationChannel
-
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			monitor := os.Getenv("SYSDIG_MONITOR_API_TOKEN")
-			ibmMonitor := os.Getenv("SYSDIG_IBM_MONITOR_API_KEY")
-			if monitor == "" && ibmMonitor == "" {
-				t.Fatal("SYSDIG_MONITOR_API_TOKEN or SYSDIG_IBM_MONITOR_API_KEY must be set for acceptance tests")
-			}
-		},
+		PreCheck: sysdigOrIBMMonitorPreCheck(t),
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"sysdig": func() (*schema.Provider, error) {
 				return sysdig.Provider(), nil
@@ -38,6 +29,9 @@ func TestAccMonitorNotificationChannelEmail(t *testing.T) {
 			},
 			{
 				Config: monitorNotificationChannelEmailWithNameInReverseOrder(rText()),
+			},
+			{
+				Config: monitorNotificationChannelEmailWithTeam(rText()),
 			},
 			{
 				ResourceName:      "sysdig_monitor_notification_channel_email.sample_email",
@@ -66,6 +60,27 @@ resource "sysdig_monitor_notification_channel_email" "sample_email" {
 	name = "%s"
 	recipients = ["bar@localhost.com", "root@localhost.com"]
 	enabled = false
+	notify_when_ok = false
+	notify_when_resolved = false
+	send_test_notification = false
+}`, name)
+}
+
+func monitorNotificationChannelEmailWithTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_team" "sample_team" {
+  name = "team-%[1]s"
+
+  entrypoint {
+    type = "Explore"
+  }
+}
+
+resource "sysdig_monitor_notification_channel_email" "sample_email" {
+	name = "%[1]s"
+    share_with = sysdig_monitor_team.sample_team.id
+	recipients = ["root@localhost.com", "bar@localhost.com"]
+	enabled = true
 	notify_when_ok = false
 	notify_when_resolved = false
 	send_test_notification = false

--- a/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
@@ -31,6 +31,9 @@ func TestAccMonitorNotificationChannelEmail(t *testing.T) {
 				Config: monitorNotificationChannelEmailWithNameInReverseOrder(rText()),
 			},
 			{
+				Config: monitorNotificationChannelEmailSharedWithCurrentTeam(rText()),
+			},
+			{
 				ResourceName:      "sysdig_monitor_notification_channel_email.sample_email",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -55,6 +58,19 @@ func monitorNotificationChannelEmailWithNameInReverseOrder(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_email" "sample_email" {
 	name = "%s"
+	recipients = ["bar@localhost.com", "root@localhost.com"]
+	enabled = false
+	notify_when_ok = false
+	notify_when_resolved = false
+	send_test_notification = false
+}`, name)
+}
+
+func monitorNotificationChannelEmailSharedWithCurrentTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_notification_channel_email" "sample_email" {
+	name = "%s"
+    share_with_current_team = true
 	recipients = ["bar@localhost.com", "root@localhost.com"]
 	enabled = false
 	notify_when_ok = false

--- a/sysdig/resource_sysdig_monitor_notification_channel_opsgenie.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_opsgenie.go
@@ -47,12 +47,18 @@ func resourceSysdigMonitorNotificationChannelOpsGenie() *schema.Resource {
 }
 
 func resourceSysdigMonitorNotificationChannelOpsGenieCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getMonitorNotificationChannelClient(meta.(SysdigClients))
+	clients := meta.(SysdigClients)
+	client, err := getMonitorNotificationChannelClient(clients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	notificationChannel, err := monitorNotificationChannelOpsGenieFromResourceData(d)
+	teamID, err := client.CurrentTeamID(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	notificationChannel, err := monitorNotificationChannelOpsGenieFromResourceData(d, teamID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -63,12 +69,10 @@ func resourceSysdigMonitorNotificationChannelOpsGenieCreate(ctx context.Context,
 	}
 
 	d.SetId(strconv.Itoa(notificationChannel.ID))
-	_ = d.Set("version", notificationChannel.Version)
 
-	return nil
+	return resourceSysdigMonitorNotificationChannelOpsGenieRead(ctx, d, meta)
 }
 
-// Retrieves the information of a resource form the file and loads it in Terraform
 func resourceSysdigMonitorNotificationChannelOpsGenieRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, err := getMonitorNotificationChannelClient(meta.(SysdigClients))
 	if err != nil {
@@ -80,6 +84,7 @@ func resourceSysdigMonitorNotificationChannelOpsGenieRead(ctx context.Context, d
 
 	if err != nil {
 		d.SetId("")
+		return diag.FromErr(err)
 	}
 
 	err = monitorNotificationChannelOpsGenieToResourceData(&nc, d)
@@ -91,12 +96,18 @@ func resourceSysdigMonitorNotificationChannelOpsGenieRead(ctx context.Context, d
 }
 
 func resourceSysdigMonitorNotificationChannelOpsGenieUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getMonitorNotificationChannelClient(meta.(SysdigClients))
+	clients := meta.(SysdigClients)
+	client, err := getMonitorNotificationChannelClient(clients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	nc, err := monitorNotificationChannelOpsGenieFromResourceData(d)
+	teamID, err := client.CurrentTeamID(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	nc, err := monitorNotificationChannelOpsGenieFromResourceData(d, teamID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -128,10 +139,8 @@ func resourceSysdigMonitorNotificationChannelOpsGenieDelete(ctx context.Context,
 	return nil
 }
 
-// Channel type for Notification Channels
-
-func monitorNotificationChannelOpsGenieFromResourceData(d *schema.ResourceData) (nc v2.NotificationChannel, err error) {
-	nc, err = monitorNotificationChannelFromResourceData(d)
+func monitorNotificationChannelOpsGenieFromResourceData(d *schema.ResourceData, teamID int) (nc v2.NotificationChannel, err error) {
+	nc, err = monitorNotificationChannelFromResourceData(d, teamID)
 	if err != nil {
 		return
 	}

--- a/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
@@ -41,6 +41,14 @@ func TestAccMonitorNotificationChannelOpsGenie(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: monitorNotificationChannelOpsGenieSharedWithCurrentTeam(rText()),
+			},
+			{
+				ResourceName:      "sysdig_monitor_notification_channel_opsgenie.sample-opsgenie-3",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -61,6 +69,19 @@ func monitorNotificationChannelOpsGenieWithNameAndRegion(name string) string {
 resource "sysdig_monitor_notification_channel_opsgenie" "sample-opsgenie-2" {
 	name = "Example Channel %s - OpsGenie - 2"
 	enabled = true
+	api_key = "2349324-342354353-5324-23"
+	notify_when_ok = false
+	notify_when_resolved = false
+	region = "EU"
+}`, name)
+}
+
+func monitorNotificationChannelOpsGenieSharedWithCurrentTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_notification_channel_opsgenie" "sample-opsgenie-3" {
+	name = "Example Channel %s - OpsGenie - 3"
+	enabled = true
+    share_with_current_team = true
 	api_key = "2349324-342354353-5324-23"
 	notify_when_ok = false
 	notify_when_resolved = false

--- a/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
@@ -4,7 +4,6 @@ package sysdig_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -16,18 +15,10 @@ import (
 )
 
 func TestAccMonitorNotificationChannelOpsGenie(t *testing.T) {
-	//var ncBefore, ncAfter monitor.NotificationChannel
-
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			monitor := os.Getenv("SYSDIG_MONITOR_API_TOKEN")
-			ibmMonitor := os.Getenv("SYSDIG_IBM_MONITOR_API_KEY")
-			if monitor == "" && ibmMonitor == "" {
-				t.Fatal("SYSDIG_MONITOR_API_TOKEN or SYSDIG_IBM_MONITOR_API_KEY must be set for acceptance tests")
-			}
-		},
+		PreCheck: sysdigOrIBMMonitorPreCheck(t),
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"sysdig": func() (*schema.Provider, error) {
 				return sysdig.Provider(), nil
@@ -44,6 +35,9 @@ func TestAccMonitorNotificationChannelOpsGenie(t *testing.T) {
 			},
 			{
 				Config: monitorNotificationChannelOpsGenieWithNameAndRegion(rText()),
+			},
+			{
+				Config: monitorNotificationChannelOpsGenieWithTeam(rText()),
 			},
 			{
 				ResourceName:      "sysdig_monitor_notification_channel_opsgenie.sample-opsgenie-2",
@@ -74,5 +68,25 @@ resource "sysdig_monitor_notification_channel_opsgenie" "sample-opsgenie-2" {
 	notify_when_ok = false
 	notify_when_resolved = false
 	region = "EU"
+}`, name)
+}
+
+func monitorNotificationChannelOpsGenieWithTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_team" "sample_team" {
+  name = "team-%[1]s"
+
+  entrypoint {
+    type = "Explore"
+  }
+}
+
+resource "sysdig_monitor_notification_channel_opsgenie" "sample-opsgenie" {
+	name = "Example Channel %[1]s - OpsGenie"
+    share_with = sysdig_monitor_team.sample_team.id
+	enabled = true
+	api_key = "2349324-342354353-5324-23"
+	notify_when_ok = false
+	notify_when_resolved = false
 }`, name)
 }

--- a/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
@@ -37,9 +37,6 @@ func TestAccMonitorNotificationChannelOpsGenie(t *testing.T) {
 				Config: monitorNotificationChannelOpsGenieWithNameAndRegion(rText()),
 			},
 			{
-				Config: monitorNotificationChannelOpsGenieWithTeam(rText()),
-			},
-			{
 				ResourceName:      "sysdig_monitor_notification_channel_opsgenie.sample-opsgenie-2",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -68,25 +65,5 @@ resource "sysdig_monitor_notification_channel_opsgenie" "sample-opsgenie-2" {
 	notify_when_ok = false
 	notify_when_resolved = false
 	region = "EU"
-}`, name)
-}
-
-func monitorNotificationChannelOpsGenieWithTeam(name string) string {
-	return fmt.Sprintf(`
-resource "sysdig_monitor_team" "sample_team" {
-  name = "team-%[1]s"
-
-  entrypoint {
-    type = "Explore"
-  }
-}
-
-resource "sysdig_monitor_notification_channel_opsgenie" "sample-opsgenie" {
-	name = "Example Channel %[1]s - OpsGenie"
-    share_with = sysdig_monitor_team.sample_team.id
-	enabled = true
-	api_key = "2349324-342354353-5324-23"
-	notify_when_ok = false
-	notify_when_resolved = false
 }`, name)
 }

--- a/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -29,6 +29,9 @@ func TestAccMonitorNotificationChannelPagerduty(t *testing.T) {
 				Config: monitorNotificationChannelPagerdutyWithName(rText()),
 			},
 			{
+				Config: monitorNotificationChannelPagerdutySharedWithCurrentTeam(rText()),
+			},
+			{
 				ResourceName:      "sysdig_monitor_notification_channel_pagerduty.sample-pagerduty",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -41,6 +44,21 @@ func monitorNotificationChannelPagerdutyWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_pagerduty" "sample-pagerduty" {
 	name = "Example Channel %s - Pagerduty"
+	enabled = true
+	account = "account"
+	service_key = "XXXXXXXXXX"
+	service_name = "sysdig"
+	notify_when_ok = true
+	notify_when_resolved = true
+	send_test_notification = false
+}`, name)
+}
+
+func monitorNotificationChannelPagerdutySharedWithCurrentTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_notification_channel_pagerduty" "sample-pagerduty" {
+	name = "Example Channel %s - Pagerduty"
+    share_with_current_team = true
 	enabled = true
 	account = "account"
 	service_key = "XXXXXXXXXX"

--- a/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -29,9 +29,6 @@ func TestAccMonitorNotificationChannelPagerduty(t *testing.T) {
 				Config: monitorNotificationChannelPagerdutyWithName(rText()),
 			},
 			{
-				Config: monitorNotificationChannelPagerdutyWithTeam(rText()),
-			},
-			{
 				ResourceName:      "sysdig_monitor_notification_channel_pagerduty.sample-pagerduty",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -44,29 +41,6 @@ func monitorNotificationChannelPagerdutyWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_pagerduty" "sample-pagerduty" {
 	name = "Example Channel %s - Pagerduty"
-	enabled = true
-	account = "account"
-	service_key = "XXXXXXXXXX"
-	service_name = "sysdig"
-	notify_when_ok = true
-	notify_when_resolved = true
-	send_test_notification = false
-}`, name)
-}
-
-func monitorNotificationChannelPagerdutyWithTeam(name string) string {
-	return fmt.Sprintf(`
-resource "sysdig_monitor_team" "sample_team" {
-  name = "team-%[1]s"
-
-  entrypoint {
-    type = "Explore"
-  }
-}
-
-resource "sysdig_monitor_notification_channel_pagerduty" "sample-pagerduty" {
-	name = "Example Channel %[1]s - Pagerduty"
-    share_with = sysdig_monitor_team.sample_team.id
 	enabled = true
 	account = "account"
 	service_key = "XXXXXXXXXX"

--- a/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -4,7 +4,6 @@ package sysdig_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -19,13 +18,7 @@ func TestAccMonitorNotificationChannelPagerduty(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			monitor := os.Getenv("SYSDIG_MONITOR_API_TOKEN")
-			ibmMonitor := os.Getenv("SYSDIG_IBM_MONITOR_API_KEY")
-			if monitor == "" && ibmMonitor == "" {
-				t.Fatal("SYSDIG_MONITOR_API_TOKEN or SYSDIG_IBM_MONITOR_API_KEY must be set for acceptance tests")
-			}
-		},
+		PreCheck: sysdigOrIBMMonitorPreCheck(t),
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"sysdig": func() (*schema.Provider, error) {
 				return sysdig.Provider(), nil
@@ -34,6 +27,9 @@ func TestAccMonitorNotificationChannelPagerduty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: monitorNotificationChannelPagerdutyWithName(rText()),
+			},
+			{
+				Config: monitorNotificationChannelPagerdutyWithTeam(rText()),
 			},
 			{
 				ResourceName:      "sysdig_monitor_notification_channel_pagerduty.sample-pagerduty",
@@ -48,6 +44,29 @@ func monitorNotificationChannelPagerdutyWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_pagerduty" "sample-pagerduty" {
 	name = "Example Channel %s - Pagerduty"
+	enabled = true
+	account = "account"
+	service_key = "XXXXXXXXXX"
+	service_name = "sysdig"
+	notify_when_ok = true
+	notify_when_resolved = true
+	send_test_notification = false
+}`, name)
+}
+
+func monitorNotificationChannelPagerdutyWithTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_team" "sample_team" {
+  name = "team-%[1]s"
+
+  entrypoint {
+    type = "Explore"
+  }
+}
+
+resource "sysdig_monitor_notification_channel_pagerduty" "sample-pagerduty" {
+	name = "Example Channel %[1]s - Pagerduty"
+    share_with = sysdig_monitor_team.sample_team.id
 	enabled = true
 	account = "account"
 	service_key = "XXXXXXXXXX"

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
@@ -28,6 +28,9 @@ func TestAccMonitorNotificationChannelSlack(t *testing.T) {
 				Config: monitorNotificationChannelSlackWithName(rText()),
 			},
 			{
+				Config: monitorNotificationChannelSlackSharedWithCurrentTeam(rText()),
+			},
+			{
 				ResourceName:      "sysdig_monitor_notification_channel_slack.sample-slack",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -40,6 +43,19 @@ func monitorNotificationChannelSlackWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
 	name = "Example Channel %s - Slack"
+	enabled = true
+	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	channel = "#sysdig"
+	notify_when_ok = true
+	notify_when_resolved = true
+}`, name)
+}
+
+func monitorNotificationChannelSlackSharedWithCurrentTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
+	name = "Example Channel %s - Slack"
+    share_with_current_team = true
 	enabled = true
 	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
@@ -28,9 +28,6 @@ func TestAccMonitorNotificationChannelSlack(t *testing.T) {
 				Config: monitorNotificationChannelSlackWithName(rText()),
 			},
 			{
-				Config: monitorNotificationChannelSlackWithTeam(rText()),
-			},
-			{
 				ResourceName:      "sysdig_monitor_notification_channel_slack.sample-slack",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -43,27 +40,6 @@ func monitorNotificationChannelSlackWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
 	name = "Example Channel %s - Slack"
-	enabled = true
-	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
-	channel = "#sysdig"
-	notify_when_ok = true
-	notify_when_resolved = true
-}`, name)
-}
-
-func monitorNotificationChannelSlackWithTeam(name string) string {
-	return fmt.Sprintf(`
-resource "sysdig_monitor_team" "sample_team" {
-  name = "team-%[1]s"
-
-  entrypoint {
-    type = "Explore"
-  }
-}
-
-resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
-	name = "Example Channel %[1]s - Slack"
-    share_with = sysdig_monitor_team.sample_team.id
 	enabled = true
 	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"

--- a/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
@@ -28,6 +28,9 @@ func TestAccMonitorNotificationChannelSNS(t *testing.T) {
 				Config: monitorNotificationChannelAmazonSNSWithName(rText()),
 			},
 			{
+				Config: monitorNotificationChannelAmazonSNSShareWithCurrentTeam(rText()),
+			},
+			{
 				ResourceName:      "sysdig_monitor_notification_channel_sns.sample-amazon-sns",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -40,6 +43,19 @@ func monitorNotificationChannelAmazonSNSWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_sns" "sample-amazon-sns" {
 	name = "Example Channel %s - Amazon SNS"
+	enabled = true
+	topics = ["arn:aws:sns:us-east-1:273489009834:my-alerts2", "arn:aws:sns:us-east-1:279948934544:my-alerts"]
+	notify_when_ok = false
+	notify_when_resolved = false
+	send_test_notification = false
+}`, name)
+}
+
+func monitorNotificationChannelAmazonSNSShareWithCurrentTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_notification_channel_sns" "sample-amazon-sns" {
+	name = "Example Channel %s - Amazon SNS"
+    share_with_current_team = true
 	enabled = true
 	topics = ["arn:aws:sns:us-east-1:273489009834:my-alerts2", "arn:aws:sns:us-east-1:279948934544:my-alerts"]
 	notify_when_ok = false

--- a/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
@@ -28,9 +28,6 @@ func TestAccMonitorNotificationChannelSNS(t *testing.T) {
 				Config: monitorNotificationChannelAmazonSNSWithName(rText()),
 			},
 			{
-				Config: monitorNotificationChannelAmazonSNSWithTeam(rText()),
-			},
-			{
 				ResourceName:      "sysdig_monitor_notification_channel_sns.sample-amazon-sns",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -43,27 +40,6 @@ func monitorNotificationChannelAmazonSNSWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_sns" "sample-amazon-sns" {
 	name = "Example Channel %s - Amazon SNS"
-	enabled = true
-	topics = ["arn:aws:sns:us-east-1:273489009834:my-alerts2", "arn:aws:sns:us-east-1:279948934544:my-alerts"]
-	notify_when_ok = false
-	notify_when_resolved = false
-	send_test_notification = false
-}`, name)
-}
-
-func monitorNotificationChannelAmazonSNSWithTeam(name string) string {
-	return fmt.Sprintf(`
-resource "sysdig_monitor_team" "sample_team" {
-  name = "team-%[1]s"
-
-  entrypoint {
-    type = "Explore"
-  }
-}
-
-resource "sysdig_monitor_notification_channel_sns" "sample-amazon-sns" {
-	name = "Example Channel %[1]s - Amazon SNS"
-    share_with = sysdig_monitor_team.sample_team.id
 	enabled = true
 	topics = ["arn:aws:sns:us-east-1:273489009834:my-alerts2", "arn:aws:sns:us-east-1:279948934544:my-alerts"]
 	notify_when_ok = false

--- a/sysdig/resource_sysdig_monitor_notification_channel_victorops.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_victorops.go
@@ -43,12 +43,18 @@ func resourceSysdigMonitorNotificationChannelVictorOps() *schema.Resource {
 }
 
 func resourceSysdigMonitorNotificationChannelVictorOpsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getMonitorNotificationChannelClient(meta.(SysdigClients))
+	clients := meta.(SysdigClients)
+	client, err := getMonitorNotificationChannelClient(clients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	notificationChannel, err := monitorNotificationChannelVictorOpsFromResourceData(d)
+	teamID, err := client.CurrentTeamID(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	notificationChannel, err := monitorNotificationChannelVictorOpsFromResourceData(d, teamID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -59,12 +65,10 @@ func resourceSysdigMonitorNotificationChannelVictorOpsCreate(ctx context.Context
 	}
 
 	d.SetId(strconv.Itoa(notificationChannel.ID))
-	_ = d.Set("version", notificationChannel.Version)
 
-	return nil
+	return resourceSysdigMonitorNotificationChannelVictorOpsRead(ctx, d, meta)
 }
 
-// Retrieves the information of a resource form the file and loads it in Terraform
 func resourceSysdigMonitorNotificationChannelVictorOpsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, err := getMonitorNotificationChannelClient(meta.(SysdigClients))
 	if err != nil {
@@ -76,6 +80,7 @@ func resourceSysdigMonitorNotificationChannelVictorOpsRead(ctx context.Context, 
 
 	if err != nil {
 		d.SetId("")
+		return diag.FromErr(err)
 	}
 
 	err = monitorNotificationChannelVictorOpsToResourceData(&nc, d)
@@ -87,12 +92,18 @@ func resourceSysdigMonitorNotificationChannelVictorOpsRead(ctx context.Context, 
 }
 
 func resourceSysdigMonitorNotificationChannelVictorOpsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getMonitorNotificationChannelClient(meta.(SysdigClients))
+	clients := meta.(SysdigClients)
+	client, err := getMonitorNotificationChannelClient(clients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	nc, err := monitorNotificationChannelVictorOpsFromResourceData(d)
+	teamID, err := client.CurrentTeamID(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	nc, err := monitorNotificationChannelVictorOpsFromResourceData(d, teamID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -123,8 +134,8 @@ func resourceSysdigMonitorNotificationChannelVictorOpsDelete(ctx context.Context
 	return nil
 }
 
-func monitorNotificationChannelVictorOpsFromResourceData(d *schema.ResourceData) (nc v2.NotificationChannel, err error) {
-	nc, err = monitorNotificationChannelFromResourceData(d)
+func monitorNotificationChannelVictorOpsFromResourceData(d *schema.ResourceData, teamID int) (nc v2.NotificationChannel, err error) {
+	nc, err = monitorNotificationChannelFromResourceData(d, teamID)
 	if err != nil {
 		return
 	}

--- a/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
@@ -28,6 +28,9 @@ func TestAccMonitorNotificationChannelVictorOps(t *testing.T) {
 				Config: monitorNotificationChannelVictorOpsWithName(rText()),
 			},
 			{
+				Config: monitorNotificationChannelVictorOpsShareWithCurrentTeam(rText()),
+			},
+			{
 				ResourceName:      "sysdig_monitor_notification_channel_victorops.sample-victorops",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -40,6 +43,20 @@ func monitorNotificationChannelVictorOpsWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_victorops" "sample-victorops" {
 	name = "Example Channel %s - VictorOps"
+	enabled = true
+	api_key = "1234342-4234243-4234-2"
+	routing_key = "My team"
+	notify_when_ok = false
+	notify_when_resolved = false
+	send_test_notification = false
+}`, name)
+}
+
+func monitorNotificationChannelVictorOpsShareWithCurrentTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_notification_channel_victorops" "sample-victorops" {
+	name = "Example Channel %s - VictorOps"
+    share_with_current_team = true
 	enabled = true
 	api_key = "1234342-4234243-4234-2"
 	routing_key = "My team"

--- a/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
@@ -28,9 +28,6 @@ func TestAccMonitorNotificationChannelVictorOps(t *testing.T) {
 				Config: monitorNotificationChannelVictorOpsWithName(rText()),
 			},
 			{
-				Config: monitorNotificationChannelVictorOpsWithTeam(rText()),
-			},
-			{
 				ResourceName:      "sysdig_monitor_notification_channel_victorops.sample-victorops",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -43,28 +40,6 @@ func monitorNotificationChannelVictorOpsWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_victorops" "sample-victorops" {
 	name = "Example Channel %s - VictorOps"
-	enabled = true
-	api_key = "1234342-4234243-4234-2"
-	routing_key = "My team"
-	notify_when_ok = false
-	notify_when_resolved = false
-	send_test_notification = false
-}`, name)
-}
-
-func monitorNotificationChannelVictorOpsWithTeam(name string) string {
-	return fmt.Sprintf(`
-resource "sysdig_monitor_team" "sample_team" {
-  name = "team-%[1]s"
-
-  entrypoint {
-    type = "Explore"
-  }
-}
-
-resource "sysdig_monitor_notification_channel_victorops" "sample-victorops" {
-	name = "Example Channel %[1]s - VictorOps"
-    share_with = sysdig_monitor_team.sample_team.id
 	enabled = true
 	api_key = "1234342-4234243-4234-2"
 	routing_key = "My team"

--- a/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
@@ -4,7 +4,6 @@ package sysdig_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -15,18 +14,10 @@ import (
 )
 
 func TestAccMonitorNotificationChannelVictorOps(t *testing.T) {
-	//var ncBefore, ncAfter monitor.NotificationChannel
-
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			monitor := os.Getenv("SYSDIG_MONITOR_API_TOKEN")
-			ibmMonitor := os.Getenv("SYSDIG_IBM_MONITOR_API_KEY")
-			if monitor == "" && ibmMonitor == "" {
-				t.Fatal("SYSDIG_MONITOR_API_TOKEN or SYSDIG_IBM_MONITOR_API_KEY must be set for acceptance tests")
-			}
-		},
+		PreCheck: sysdigOrIBMMonitorPreCheck(t),
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"sysdig": func() (*schema.Provider, error) {
 				return sysdig.Provider(), nil
@@ -35,6 +26,9 @@ func TestAccMonitorNotificationChannelVictorOps(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: monitorNotificationChannelVictorOpsWithName(rText()),
+			},
+			{
+				Config: monitorNotificationChannelVictorOpsWithTeam(rText()),
 			},
 			{
 				ResourceName:      "sysdig_monitor_notification_channel_victorops.sample-victorops",
@@ -49,6 +43,28 @@ func monitorNotificationChannelVictorOpsWithName(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_victorops" "sample-victorops" {
 	name = "Example Channel %s - VictorOps"
+	enabled = true
+	api_key = "1234342-4234243-4234-2"
+	routing_key = "My team"
+	notify_when_ok = false
+	notify_when_resolved = false
+	send_test_notification = false
+}`, name)
+}
+
+func monitorNotificationChannelVictorOpsWithTeam(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_team" "sample_team" {
+  name = "team-%[1]s"
+
+  entrypoint {
+    type = "Explore"
+  }
+}
+
+resource "sysdig_monitor_notification_channel_victorops" "sample-victorops" {
+	name = "Example Channel %[1]s - VictorOps"
+    share_with = sysdig_monitor_team.sample_team.id
 	enabled = true
 	api_key = "1234342-4234243-4234-2"
 	routing_key = "My team"

--- a/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
@@ -28,13 +28,23 @@ func TestAccMonitorNotificationChannelWebhook(t *testing.T) {
 				Config: monitorNotificationChannelWebhookWithName(rText()),
 			},
 			{
+				ResourceName:      "sysdig_monitor_notification_channel_webhook.sample-webhook",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: monitorNotificationChannelWebhookWithNameWithAdditionalheaders(rText()),
+			},
+			{
+				ResourceName:      "sysdig_monitor_notification_channel_webhook.sample-webhook2",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: monitorNotificationChannelWebhookSharedWithCurrentTeam(rText()),
 			},
 			{
-				ResourceName:      "sysdig_monitor_notification_channel_webhook.sample-webhook",
+				ResourceName:      "sysdig_monitor_notification_channel_webhook.sample-webhook3",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -71,7 +81,7 @@ func monitorNotificationChannelWebhookWithNameWithAdditionalheaders(name string)
 
 func monitorNotificationChannelWebhookSharedWithCurrentTeam(name string) string {
 	return fmt.Sprintf(`
-	resource "sysdig_monitor_notification_channel_webhook" "sample-webhook2" {
+	resource "sysdig_monitor_notification_channel_webhook" "sample-webhook3" {
 		name = "Example Channel %s - Webhook With Additional Headers"
         share_with_current_team = true
 		enabled = true
@@ -79,8 +89,5 @@ func monitorNotificationChannelWebhookSharedWithCurrentTeam(name string) string 
 		notify_when_ok = false
 		notify_when_resolved = false
 		send_test_notification = false
-		additional_headers = {
-			"Webhook-Header": "TestHeader"
-		}
 	}`, name)
 }

--- a/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
@@ -28,12 +28,15 @@ func TestAccMonitorNotificationChannelWebhook(t *testing.T) {
 				Config: monitorNotificationChannelWebhookWithName(rText()),
 			},
 			{
+				Config: monitorNotificationChannelWebhookWithNameWithAdditionalheaders(rText()),
+			},
+			{
+				Config: monitorNotificationChannelWebhookSharedWithCurrentTeam(rText()),
+			},
+			{
 				ResourceName:      "sysdig_monitor_notification_channel_webhook.sample-webhook",
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-			{
-				Config: monitorNotificationChannelWebhookWithNameWithAdditionalheaders(rText()),
 			},
 		},
 	})
@@ -55,6 +58,22 @@ func monitorNotificationChannelWebhookWithNameWithAdditionalheaders(name string)
 	return fmt.Sprintf(`
 	resource "sysdig_monitor_notification_channel_webhook" "sample-webhook2" {
 		name = "Example Channel %s - Webhook With Additional Headers"
+		enabled = true
+		url = "https://example.com/"
+		notify_when_ok = false
+		notify_when_resolved = false
+		send_test_notification = false
+		additional_headers = {
+			"Webhook-Header": "TestHeader"
+		}
+	}`, name)
+}
+
+func monitorNotificationChannelWebhookSharedWithCurrentTeam(name string) string {
+	return fmt.Sprintf(`
+	resource "sysdig_monitor_notification_channel_webhook" "sample-webhook2" {
+		name = "Example Channel %s - Webhook With Additional Headers"
+        share_with_current_team = true
 		enabled = true
 		url = "https://example.com/"
 		notify_when_ok = false

--- a/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
@@ -28,9 +28,6 @@ func TestAccMonitorNotificationChannelWebhook(t *testing.T) {
 				Config: monitorNotificationChannelWebhookWithName(rText()),
 			},
 			{
-				Config: monitorNotificationChannelWebhookWithTeam(rText()),
-			},
-			{
 				ResourceName:      "sysdig_monitor_notification_channel_webhook.sample-webhook",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -67,25 +64,4 @@ func monitorNotificationChannelWebhookWithNameWithAdditionalheaders(name string)
 			"Webhook-Header": "TestHeader"
 		}
 	}`, name)
-}
-
-func monitorNotificationChannelWebhookWithTeam(name string) string {
-	return fmt.Sprintf(`
-resource "sysdig_monitor_team" "sample_team" {
-  name = "team-%[1]s"
-
-  entrypoint {
-    type = "Explore"
-  }
-}
-
-resource "sysdig_monitor_notification_channel_webhook" "sample-webhook" {
-	name = "Example Channel %[1]s - Webhook"
-    share_with = sysdig_monitor_team.sample_team.id
-	enabled = true
-	url = "https://example.com/"
-	notify_when_ok = false
-	notify_when_resolved = false
-	send_test_notification = false
-}`, name)
 }

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -81,6 +81,8 @@ resource "sysdig_secure_policy" "unexpected_inbound_tcp_connection_traefik" {
 
 ```terraform
 provider "sysdig" {
+  sysdig_team_id = 1234
+  sysdig_team_name = "My team" # or use this as alternative to `sysdig_team_id`
   sysdig_monitor_url = "https://us-south.monitoring.test.cloud.ibm.com"
   ibm_monitor_iam_url = "https://iam.test.cloud.ibm.com"
   ibm_monitor_instance_id = "xxxxxx"
@@ -158,6 +160,12 @@ When IBM Cloud Monitoring resources are to be created, this authentication must 
   the use of invalid HTTPS certificates in the IBM Monitoring Cloud API.
   <br/> It can also be sourced from the `SYSDIG_MONITOR_INSECURE_TLS`
   environment variable. By default, this is false.<br/><br/>
+* `sysdig_monitor_team_id` - (Optional) Use this argument to specify team in which you will be logged in. 
+  If not specified, default team will be used. This argument has precedence over `sysdig_monitor_team_name` if both are specified.<br/>
+  It can also be configured from the `SYSDIG_MONITOR_TEAM_ID` environment variable.<br/><br/>
+* `sysdig_monitor_team_name` - (Optional) This argument is the alternative way of specifying team in which you will be logged in. 
+  It has exactly the same meaning as `sysdig_monitor_team_id`, but instead of specifying team ID you are specifying a team name.</br>
+  It can also be configured from the `SYSDIG_MONITOR_TEAM_NAME` environment variable.<br/><br/>
 
 > **Note**
 > Enabling this way of authentication is under active development.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -81,8 +81,8 @@ resource "sysdig_secure_policy" "unexpected_inbound_tcp_connection_traefik" {
 
 ```terraform
 provider "sysdig" {
-  sysdig_team_id = 1234
-  sysdig_team_name = "My team" # or use this as alternative to `sysdig_team_id`
+  sysdig_monitor_team_id = 1234
+  sysdig_monitor_team_name = "My team" # or use this as alternative to `sysdig_monitor_team_id`
   sysdig_monitor_url = "https://us-south.monitoring.test.cloud.ibm.com"
   ibm_monitor_iam_url = "https://iam.test.cloud.ibm.com"
   ibm_monitor_instance_id = "xxxxxx"

--- a/website/docs/r/monitor_notification_channel_email.md
+++ b/website/docs/r/monitor_notification_channel_email.md
@@ -50,7 +50,9 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - (Computed) The ID of the Notification Channel.
 
 * `version` - (Computed) The current version of the Notification Channel.
- 
+
+* `share_with_current_team` - (Optional) If set to `true` it will share notification channel only with current team (in which user is logged in).
+  Otherwise, it will share it with all teams, which is the default behaviour.
 
 ## Import
 

--- a/website/docs/r/monitor_notification_channel_opsgenie.md
+++ b/website/docs/r/monitor_notification_channel_opsgenie.md
@@ -51,6 +51,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `version` - (Computed) The current version of the Notification Channel.
 
+* `share_with_current_team` - (Optional) If set to `true` it will share notification channel only with current team (in which user is logged in).
+  Otherwise, it will share it with all teams, which is the default behaviour.
+
 ## Import
 
 Opsgenie notification channels for Monitor can be imported using the ID, e.g.

--- a/website/docs/r/monitor_notification_channel_pagerduty.md
+++ b/website/docs/r/monitor_notification_channel_pagerduty.md
@@ -56,6 +56,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `version` - (Computed) The current version of the Notification Channel.
 
+* `share_with_current_team` - (Optional) If set to `true` it will share notification channel only with current team (in which user is logged in).
+  Otherwise, it will share it with all teams, which is the default behaviour.
+
 ## Import
 
 Pagerduty notification channels for Monitor can be imported using the ID, e.g.

--- a/website/docs/r/monitor_notification_channel_slack.md
+++ b/website/docs/r/monitor_notification_channel_slack.md
@@ -52,6 +52,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `version` - (Computed) The current version of the Notification Channel.
 
+* `share_with_current_team` - (Optional) If set to `true` it will share notification channel only with current team (in which user is logged in).
+  Otherwise, it will share it with all teams, which is the default behaviour.
+
 ## Import
 
 Slack notification channels for Monitor can be imported using the ID, e.g.

--- a/website/docs/r/monitor_notification_channel_sns.md
+++ b/website/docs/r/monitor_notification_channel_sns.md
@@ -50,6 +50,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `version` - (Computed) The current version of the Notification Channel.
 
+* `share_with_current_team` - (Optional) If set to `true` it will share notification channel only with current team (in which user is logged in).
+  Otherwise, it will share it with all teams, which is the default behaviour.
+
 ## Import
 
 Amazon SNS notification channels for Monitor can be imported using the ID, e.g.

--- a/website/docs/r/monitor_notification_channel_victorops.md
+++ b/website/docs/r/monitor_notification_channel_victorops.md
@@ -53,6 +53,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `version` - (Computed) The current version of the Notification Channel.
 
+* `share_with_current_team` - (Optional) If set to `true` it will share notification channel only with current team (in which user is logged in).
+  Otherwise, it will share it with all teams, which is the default behaviour.
+
 ## Import
 
 VictorOPS notification channels for Monitor can be imported using the ID, e.g.

--- a/website/docs/r/monitor_notification_channel_webhook.md
+++ b/website/docs/r/monitor_notification_channel_webhook.md
@@ -52,6 +52,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `version` - (Computed) The current version of the Notification Channel.
 
+* `share_with_current_team` - (Optional) If set to `true` it will share notification channel only with current team (in which user is logged in).
+  Otherwise, it will share it with all teams, which is the default behaviour.
+
 ## Import
 
 Webhook notification channels for Monitor can be imported using the ID, e.g.


### PR DESCRIPTION
We added following:
- Ability on IBM client to login into certain team. Or, in other words to be in the context of certain team when using API.
- Ability to get current team using `CurrentTeamID` on both sysding and ibm clients.
- Using previous improvements, all notification channels now have ability to share itself to current team or with all teams.
- All docs (provider and notification channels) are updated.
- Notification tests regarding sharing are also included.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->