### PR TITLE
fix[tests]: Fix secure connection tests when run against secure-staging instead of prod

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,7 +41,7 @@ testacc-ibm: fmtcheck
 
 junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race 2>&1 | go-junit-report -iocopy -out junit-report.xml
+	CGO_ENABLED=1 TF_ACC=1 go test -p 1 $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race 2>&1 | go-junit-report -iocopy -out junit-report.xml
 
 vet:
 	@echo "go vet ."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,7 +37,7 @@ testacc: fmtcheck
 	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race -parallel=1
 
 testacc-ibm: fmtcheck
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_ibm -timeout 120m -race
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_ibm -timeout 120m -race -parallel=1
 
 junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,7 +41,7 @@ testacc-ibm: fmtcheck
 
 junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest
-	CGO_ENABLED=1 TF_ACC=1 go test -p 1 $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race 2>&1 | go-junit-report -iocopy -out junit-report.xml
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race 2>&1 | go-junit-report -iocopy -out junit-report.xml
 
 vet:
 	@echo "go vet ."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,14 +34,14 @@ test: fmtcheck
 	go test $(TEST) -tags=unit -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race -parallel=1
 
 testacc-ibm: fmtcheck
 	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_ibm -timeout 120m -race
 
 junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race 2>&1 | go-junit-report -iocopy -out junit-report.xml
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_sysdig -timeout 120m -race 2>&1 -parallel=1 | go-junit-report -iocopy -out junit-report.xml
 
 vet:
 	@echo "go vet ."

--- a/sysdig/data_source_sysdig_secure_current_connection_test.go
+++ b/sysdig/data_source_sysdig_secure_current_connection_test.go
@@ -18,9 +18,9 @@ func TestAccSecureConnection(t *testing.T) {
 
 	apiToken := os.Getenv("SYSDIG_SECURE_API_TOKEN")
 	secureUrl := os.Getenv("SYSDIG_SECURE_URL")
-    if secureUrl == "" {
-            secureUrl := "https://secure.sysdig.com"
-    }
+	if secureUrl == "" {
+		secureUrl := "https://secure.sysdig.com"
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 

--- a/sysdig/data_source_sysdig_secure_current_connection_test.go
+++ b/sysdig/data_source_sysdig_secure_current_connection_test.go
@@ -17,6 +17,7 @@ func TestAccSecureConnection(t *testing.T) {
 	dataSourceResourceName := "data.sysdig_secure_connection.current"
 
 	apiToken := os.Getenv("SYSDIG_SECURE_API_TOKEN")
+    secureUrl := os.Getenv("SYSDIG_SECURE_URL")
 
 	resource.ParallelTest(t, resource.TestCase{
 
@@ -34,7 +35,7 @@ func TestAccSecureConnection(t *testing.T) {
 			{
 				Config: getSysdigSecureCurrentConnection(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceResourceName, "secure_url", "https://secure.sysdig.com"),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "secure_url", secureUrl),
 					resource.TestCheckResourceAttr(dataSourceResourceName, "secure_api_token", apiToken),
 				),
 			},

--- a/sysdig/data_source_sysdig_secure_current_connection_test.go
+++ b/sysdig/data_source_sysdig_secure_current_connection_test.go
@@ -17,7 +17,7 @@ func TestAccSecureConnection(t *testing.T) {
 	dataSourceResourceName := "data.sysdig_secure_connection.current"
 
 	apiToken := os.Getenv("SYSDIG_SECURE_API_TOKEN")
-    secureUrl := os.Getenv("SYSDIG_SECURE_URL")
+	secureUrl := os.Getenv("SYSDIG_SECURE_URL")
 
 	resource.ParallelTest(t, resource.TestCase{
 

--- a/sysdig/data_source_sysdig_secure_current_connection_test.go
+++ b/sysdig/data_source_sysdig_secure_current_connection_test.go
@@ -19,7 +19,7 @@ func TestAccSecureConnection(t *testing.T) {
 	apiToken := os.Getenv("SYSDIG_SECURE_API_TOKEN")
 	secureUrl := os.Getenv("SYSDIG_SECURE_URL")
 	if secureUrl == "" {
-		secureUrl := "https://secure.sysdig.com"
+		secureUrl = "https://secure.sysdig.com"
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/sysdig/data_source_sysdig_secure_current_connection_test.go
+++ b/sysdig/data_source_sysdig_secure_current_connection_test.go
@@ -18,6 +18,9 @@ func TestAccSecureConnection(t *testing.T) {
 
 	apiToken := os.Getenv("SYSDIG_SECURE_API_TOKEN")
 	secureUrl := os.Getenv("SYSDIG_SECURE_URL")
+    if secureUrl == "" {
+            secureUrl := "https://secure.sysdig.com"
+    }
 
 	resource.ParallelTest(t, resource.TestCase{
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->