### PR TITLE
fix(serverless-agent): mark the access key as optional

### DIFF
--- a/sysdig/data_source_sysdig_fargate_workload_agent.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent.go
@@ -50,7 +50,7 @@ func dataSourceSysdigFargateWorkloadAgent() *schema.Resource {
 			"sysdig_access_key": {
 				Type:        schema.TypeString,
 				Description: "the Sysdig access key",
-				Required:    true,
+				Optional:    true,
 			},
 			"workload_agent_image": {
 				Type:        schema.TypeString,

--- a/sysdig/data_source_sysdig_fargate_workload_agent_test.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/draios/terraform-provider-sysdig/sysdig"
 )
 
-func TestAccSysdigFargateWorkloadAgent(t *testing.T) {
+// Direct connection mode has been deprecated in Prod envs
+func TestAccSysdigFargateWorkloadAgentDirectConnection(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"sysdig": func() (*schema.Provider, error) {
@@ -20,13 +21,13 @@ func TestAccSysdigFargateWorkloadAgent(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: getFargateWorkloadAgent(),
+				Config: getFargateWorkloadAgentDirectConnection(),
 			},
 		},
 	})
 }
 
-func getFargateWorkloadAgent() string {
+func getFargateWorkloadAgentDirectConnection() string {
 	return `
 data "sysdig_fargate_workload_agent" "test" {
 	container_definitions = "[]"
@@ -36,6 +37,34 @@ data "sysdig_fargate_workload_agent" "test" {
 	collector_port = 1234
 	sysdig_access_key = "abcdef"
 	workload_agent_image = "busybox"
+	sysdig_logging = "info"
+}
+`
+}
+
+func TestAccSysdigFargateWorkloadAgentOrchestrated(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: getFargateWorkloadAgentOrchestrated(),
+			},
+		},
+	})
+}
+
+func getFargateWorkloadAgentOrchestrated() string {
+	return `
+data "sysdig_fargate_workload_agent" "test" {
+	container_definitions = "[]"
+
+	orchestrator_host = "sysdig.orchestrator.agent.com"
+	orchestrator_port = 6667
+	workload_agent_image = "quay.io/sysdig/workload-agent:latest"
 	sysdig_logging = "info"
 }
 `

--- a/website/docs/d/fargate_workload_agent.md
+++ b/website/docs/d/fargate_workload_agent.md
@@ -22,8 +22,7 @@ data "sysdig_fargate_workload_agent" "instrumented_containers" {
 
   image_auth_secret    = ""
   workload_agent_image = "quay.io/sysdig/workload-agent:latest"
-
-  sysdig_access_key = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  
   orchestrator_host    = module.fargate-orchestrator-agent.orchestrator_host
   orchestrator_port    = module.fargate-orchestrator-agent.orchestrator_port
 }
@@ -32,7 +31,6 @@ data "sysdig_fargate_workload_agent" "instrumented_containers" {
 ## Argument Reference
 
 * `container_definitions` - (Required) The input Fargate container definitions to instrument with the Sysdig workload agent.
-* `sysdig_access_key` - (Required) The Sysdig Access Key (Agent token).
 * `orchestrator_host` - (Required) The orchestrator host to connect to.
 * `orchestrator_port` - (Required) The orchestrator port to connect to.
 * `workload_agent_image` - (Required) The Sysdig workload agent image.


### PR DESCRIPTION
# Scope
Serverless Agent

# Description
This PR marks the access key as optional in the fargate workload agent data source.
Note that:
 - the direct connection mode has been deprecated,
 - and the workload agent does not require the access key to connect to the orchestrator agent.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->