### PR TITLE
test: Add build labels to properly group monitor resources as well as ibm ones

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,7 +38,7 @@ testacc: fmtcheck
 	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=$(TEST_SUITE) -timeout 120m -race -parallel=4
 
 testacc-ibm: fmtcheck
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_ibm -timeout 120m -race -parallel=4
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_monitor,tf_acc_ibm -timeout 120m -race -parallel=4
 
 junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -35,14 +35,14 @@ test: fmtcheck
 	go test $(TEST) -tags=unit -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=$(TEST_SUITE) -timeout 120m -race -parallel=1
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=$(TEST_SUITE) -timeout 120m -race -parallel=4
 
 testacc-ibm: fmtcheck
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_ibm -timeout 120m -race -parallel=1
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=tf_acc_ibm -timeout 120m -race -parallel=4
 
 junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=$(TEST_SUITE) -timeout 120m -race 2>&1 -parallel=1 | go-junit-report -iocopy -out junit-report.xml
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=$(TEST_SUITE) -timeout 120m -race 2>&1 -parallel=4 | go-junit-report -iocopy -out junit-report.xml
 
 vet:
 	@echo "go vet ."

--- a/sysdig/data_source_sysdig_current_user_test.go
+++ b/sysdig/data_source_sysdig_current_user_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_user_test.go
+++ b/sysdig/data_source_sysdig_user_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_downtime_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_downtime_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_event_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_event_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_group_outlier_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_group_outlier_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_metric_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_promql_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_promql_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_event_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_event_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_cloud_account_test.go
+++ b/sysdig/resource_sysdig_monitor_cloud_account_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_dashboard_test.go
+++ b/sysdig/resource_sysdig_monitor_dashboard_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_team_ibm_test.go
+++ b/sysdig/resource_sysdig_monitor_team_ibm_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_ibm
+//go:build tf_acc_ibm || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_team_shared_test.go
+++ b/sysdig/resource_sysdig_monitor_team_shared_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_ibm
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_team_test.go
+++ b/sysdig/resource_sysdig_monitor_team_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_policies
+//go:build tf_acc_sysdig || tf_acc_policies || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_monitor 
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor 
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig
+//go:build tf_acc_sysdig || tf_acc_monitor
 
 package sysdig_test
 


### PR DESCRIPTION
* Adding proper labels to the monitor resources
* Marking ibm only resources with label tf_acc_ibm
* Setting parallelization over testacc 