### PR TITLE
fix actions so that it is truly starts as an empty map

### DIFF
--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -162,7 +162,7 @@ func policyToResourceData(policy *secure.Policy, d *schema.ResourceData) {
 
 	}
 
-	actions := []map[string]interface{}{{}}
+	actions := []map[string]interface{}{}
 	for _, action := range policy.Actions {
 		if action.Type != "POLICY_ACTION_CAPTURE" {
 			action := strings.Replace(action.Type, "POLICY_ACTION_", "", 1)

--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -163,6 +163,9 @@ func policyToResourceData(policy *secure.Policy, d *schema.ResourceData) {
 	}
 
 	actions := []map[string]interface{}{}
+	if len(policy.Actions) > 0 {
+		actions = append(actions, map[string]interface{}{})
+	}
 	for _, action := range policy.Actions {
 		if action.Type != "POLICY_ACTION_CAPTURE" {
 			action := strings.Replace(action.Type, "POLICY_ACTION_", "", 1)


### PR DESCRIPTION
When running `terraform plan` with a policy that has no actions defined, it always shows up as having a change and needing to remove the actions.

This PR adjusts the actions map to make sure that it is empty so it is not reported as a change.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->