### PR TITLE
tag order should not matter when comparing rules

### DIFF
--- a/sysdig/resource_sysdig_secure_rule.go
+++ b/sysdig/resource_sysdig_secure_rule.go
@@ -72,14 +72,14 @@ func updateResourceDataForRule(d *schema.ResourceData, rule secure.Rule) {
 }
 
 func getTagsFromResourceData(d *schema.ResourceData) []string {
-	tags := []string{}
+	result := []string{}
 	if tags, ok := d.Get("tags").([]interface{}); ok {
 		for _, rawTag := range tags {
 			if tag, ok := rawTag.(string); ok {
-				tags = append(tags, tag)
+				result = append(result, tag)
 			}
 		}
 	}
 
-	return tags
+	return result
 }


### PR DESCRIPTION
If the tags are all the same, but happen to be in a different order, we should not consider that a change to the rule.
