### PR TITLE
Default state in a policy actions block should not result in unexpected state change in terraform

### DIFF
--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -176,7 +176,14 @@ func policyToResourceData(policy *secure.Policy, d *schema.ResourceData) {
 			}}
 		}
 	}
-	_ = d.Set("actions", actions)
+
+	currentContainerAction := d.Get("actions.0.container").(string)
+	currentCaptureAction := d.Get("actions.0.capture").([]interface{})
+	// If the policy retrieved from service has no actions and the current state is default values,
+	// then do not set the "actions" key as it may cause terraform to think there has been a state change
+	if len(policy.Actions) > 0 || currentContainerAction != "" || len(currentCaptureAction) > 0 {
+		_ = d.Set("actions", actions)
+	}
 
 	_ = d.Set("notification_channels", policy.NotificationChannelIds)
 


### PR DESCRIPTION
When the actions block in a module is empty, this can result in a condition in which terraform is identifying the resource as having changed.  This PR changes this so it identifies the default state.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->