### PR TITLE
add detection backend team members to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,4 @@
 *monitor*groupmapping* @filiptubic
 
 # policies/rules
-*secure*policy* @jacklongsd @kmvachhani @ben-m-lucas @ombellare @miguelgordo @ivanlysiuk-sysdig
+*secure*policy* @jacklongsd @kmvachhani @ben-m-lucas @ombellare @ivanlysiuk-sysdig

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,4 @@
 *monitor*groupmapping* @filiptubic
 
 # policies/rules
-*secure*policy* @jacklongsd @kmvachhani @ben-m-lucas
+*secure*policy* @jacklongsd @kmvachhani @ben-m-lucas @ombellare @miguelgordo @ivanlysiuk-sysdig


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->

Adding more members of the detection backend team as code owners for policies/rules