### PR TITLE
tests: Fix test execution param order

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 SWEEP?=us-east-1,us-west-2
 TEST?=./...
-TEST_SUITE?=tf_acc_sysdig
+TEST_SUITE?=tf_acc_ibm_monitor
 PKG_NAME=sysdig
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 VERSION=$(shell [ ! -z `git tag -l --contains HEAD` ] && git tag -l --contains HEAD || git rev-parse --short HEAD)
@@ -42,7 +42,8 @@ testacc: fmtcheck
 
 junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=$(TEST_SUITE) -timeout 120m -race 2>&1 -parallel=1 | go-junit-report -iocopy -out junit-report.xml
+	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=$(TEST_SUITE) -timeout 120m -race -parallel=1 2>&1 > output.txt
+	go-junit-report -in output.txt -out junit-report.xml
 
 vet:
 	@echo "go vet ."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 SWEEP?=us-east-1,us-west-2
 TEST?=./...
-TEST_SUITE?=tf_acc_ibm_monitor
+TEST_SUITE?=tf_acc_sysdig
 PKG_NAME=sysdig
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 VERSION=$(shell [ ! -z `git tag -l --contains HEAD` ] && git tag -l --contains HEAD || git rev-parse --short HEAD)


### PR DESCRIPTION
Fix the order of QA test execution order. It was causing some failures in the executions to be markes as passed when it was not true. 