### PR TITLE
fix(client): revert sysdig provider header back

### DIFF
--- a/sysdig/common_test.go
+++ b/sysdig/common_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm || tf_acc_ibm_monitor || unit
+//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm || tf_acc_ibm_monitor || tf_acc_policies || unit
 
 package sysdig_test
 

--- a/sysdig/internal/client/v2/client.go
+++ b/sysdig/internal/client/v2/client.go
@@ -21,6 +21,8 @@ const (
 	GetMePath                 = "/api/users/me"
 	AuthorizationHeader       = "Authorization"
 	ContentTypeHeader         = "Content-Type"
+	SysdigProviderHeader      = "Sysdig-Provider"
+	SysdigProviderHeaderValue = "Terraform"
 	ContentTypeJSON           = "application/json"
 	ContentTypeFormURLEncoded = "x-www-form-urlencoded"
 )

--- a/sysdig/internal/client/v2/ibm.go
+++ b/sysdig/internal/client/v2/ibm.go
@@ -178,6 +178,7 @@ func (ir *IBMRequest) Request(ctx context.Context, method string, url string, pa
 	r.Header.Set(AuthorizationHeader, fmt.Sprintf("Bearer %s", token))
 	r.Header.Set(SysdigTeamIDHeader, strconv.Itoa(teamID))
 	r.Header.Set(ContentTypeHeader, ContentTypeJSON)
+	r.Header.Set(SysdigProviderHeader, SysdigProviderHeaderValue)
 
 	return request(ir.httpClient, ir.config, r)
 }

--- a/sysdig/internal/client/v2/ibm_test.go
+++ b/sysdig/internal/client/v2/ibm_test.go
@@ -58,6 +58,9 @@ func TestIBMClient_DoIBMRequest(t *testing.T) {
 			if value := r.Header.Get(IBMInstanceIDHeader); value != instanceID {
 				t.Errorf("expected instance id %v, got %v", instanceID, value)
 			}
+			if value := r.Header.Get(SysdigProviderHeader); value != SysdigProviderHeaderValue {
+				t.Errorf("expected sysdig provider %v, got %v", SysdigProviderHeaderValue, value)
+			}
 		}))
 
 		var teamID int

--- a/sysdig/internal/client/v2/sysdig.go
+++ b/sysdig/internal/client/v2/sysdig.go
@@ -50,6 +50,7 @@ func (sr *SysdigRequest) Request(ctx context.Context, method string, url string,
 	r = r.WithContext(ctx)
 	r.Header.Set(AuthorizationHeader, fmt.Sprintf("Bearer %s", sr.config.token))
 	r.Header.Set(ContentTypeHeader, ContentTypeJSON)
+	r.Header.Set(SysdigProviderHeader, SysdigProviderHeaderValue)
 
 	return request(sr.httpClient, sr.config, r)
 }

--- a/sysdig/internal/client/v2/sysdig_test.go
+++ b/sysdig/internal/client/v2/sysdig_test.go
@@ -27,6 +27,9 @@ func TestSysdigRequest(t *testing.T) {
 		if value := r.Header.Get(extraHeader); value != extraHeaderValue {
 			t.Errorf("invalid extra header %v", value)
 		}
+		if value := r.Header.Get(SysdigProviderHeader); value != SysdigProviderHeaderValue {
+			t.Errorf("expected sysdig provider %v, got %v", SysdigProviderHeaderValue, value)
+		}
 		unmarshalled, err := Unmarshal[foo](r.Body)
 		if err != nil {
 			t.Errorf("failed to unmarshal payload, err: %v", err)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->