### PR TITLE
feat(policies): Data Source for managed policies

### DIFF
--- a/sysdig/data_source_sysdig_secure_managed_policy.go
+++ b/sysdig/data_source_sysdig_secure_managed_policy.go
@@ -32,6 +32,9 @@ func dataSourceSysdigManagedPolicyRead(ctx context.Context, d *schema.ResourceDa
 	policyType := d.Get("type").(string)
 
 	policy, err := getManagedPolicy(ctx, client, policyName, policyType)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	loadedPolicy, _, err := client.GetPolicyByID(ctx, policy.ID)
 	if err != nil {

--- a/sysdig/data_source_sysdig_secure_managed_policy.go
+++ b/sysdig/data_source_sysdig_secure_managed_policy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -29,27 +28,10 @@ func dataSourceSysdigManagedPolicyRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	policies, _, err := client.GetPolicies(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
 	policyName := d.Get("name").(string)
 	policyType := d.Get("type").(string)
 
-	var policy v2.Policy
-	for _, existingPolicy := range policies {
-		if existingPolicy.Name == policyName && existingPolicy.Type == policyType {
-			if !existingPolicy.IsDefault {
-				return diag.Errorf("policy is not a managed policy - use `resource_sysdig_secure_policy`")
-			}
-			policy = existingPolicy
-		}
-	}
-
-	if policy.ID == 0 {
-		return diag.Errorf("unable to find managed policy")
-	}
+	policy, err := getManagedPolicy(ctx, client, policyName, policyType)
 
 	loadedPolicy, _, err := client.GetPolicyByID(ctx, policy.ID)
 	if err != nil {

--- a/sysdig/data_source_sysdig_secure_managed_policy.go
+++ b/sysdig/data_source_sysdig_secure_managed_policy.go
@@ -1,0 +1,62 @@
+package sysdig
+
+import (
+	"context"
+	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSysdigSecureManagedPolicy() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		ReadContext: dataSourceSysdigManagedPolicyRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: createPolicyDataSourceSchema(),
+	}
+}
+
+func dataSourceSysdigManagedPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	policies, _, err := client.GetPolicies(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	policyName := d.Get("name").(string)
+	policyType := d.Get("type").(string)
+
+	var policy v2.Policy
+	for _, existingPolicy := range policies {
+		if existingPolicy.Name == policyName && existingPolicy.Type == policyType {
+			if !existingPolicy.IsDefault {
+				return diag.Errorf("policy is not a managed policy - use `resource_sysdig_secure_policy`")
+			}
+			policy = existingPolicy
+		}
+	}
+
+	if policy.ID == 0 {
+		return diag.Errorf("unable to find managed policy")
+	}
+
+	loadedPolicy, _, err := client.GetPolicyByID(ctx, policy.ID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	policyDataSourceToResourceData(loadedPolicy, d)
+
+	return nil
+}

--- a/sysdig/data_source_sysdig_secure_managed_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_managed_policy_test.go
@@ -1,0 +1,32 @@
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+
+package sysdig_test
+
+func TestAccManagedPolicyDataSource(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: managedPolicyDataSource(),
+			},
+		},
+	})
+}
+
+func managedPolicyDataSource() string {
+	return `
+data "sysdig_secure_managed_policy" "example" {
+	name = "Sysdig Runtime Threat Detection"
+	type = "falco"
+}
+`
+}

--- a/sysdig/data_source_sysdig_secure_managed_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_managed_policy_test.go
@@ -2,6 +2,16 @@
 
 package sysdig_test
 
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
 func TestAccManagedPolicyDataSource(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/sysdig/data_source_sysdig_secure_policy.go
+++ b/sysdig/data_source_sysdig_secure_policy.go
@@ -119,7 +119,6 @@ func policyDataSourceToResourceData(policy v2.Policy, d *schema.ResourceData) {
 	_ = d.Set("severity", policy.Severity)
 	_ = d.Set("enabled", policy.Enabled)
 	_ = d.Set("scope", policy.Scope)
-	_ = d.Set("version", policy.Version)
 	_ = d.Set("notification_channels", policy.NotificationChannelIds)
 	_ = d.Set("runbook", policy.Runbook)
 

--- a/sysdig/data_source_sysdig_secure_policy.go
+++ b/sysdig/data_source_sysdig_secure_policy.go
@@ -1,0 +1,153 @@
+package sysdig
+
+import (
+	"strconv"
+	"strings"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func createPolicyDataSourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"type": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          "falco",
+			ValidateDiagFunc: validateDiagFunc(validatePolicyType),
+		},
+		"id": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"severity": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"enabled": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"runbook": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"scope": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"rules": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"enabled": {
+						Type:     schema.TypeBool,
+						Computed: true,
+					},
+				},
+			},
+		},
+		"notification_channels": {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeInt,
+			},
+		},
+		"actions": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"container": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"capture": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Computed: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"seconds_after_event": {
+									Type:     schema.TypeInt,
+									Computed: true,
+								},
+								"seconds_before_event": {
+									Type:     schema.TypeInt,
+									Computed: true,
+								},
+								"name": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func policyDataSourceToResourceData(policy v2.Policy, d *schema.ResourceData) {
+	d.SetId(strconv.Itoa(policy.ID))
+
+	_ = d.Set("name", policy.Name)
+	if policy.Type != "" {
+		_ = d.Set("type", policy.Type)
+	} else {
+		_ = d.Set("type", "falco")
+	}
+
+	_ = d.Set("description", policy.Description)
+	_ = d.Set("severity", policy.Severity)
+	_ = d.Set("enabled", policy.Enabled)
+	_ = d.Set("scope", policy.Scope)
+	_ = d.Set("version", policy.Version)
+	_ = d.Set("notification_channels", policy.NotificationChannelIds)
+	_ = d.Set("runbook", policy.Runbook)
+
+	actions := []map[string]interface{}{{}}
+	for _, action := range policy.Actions {
+		if action.Type != "POLICY_ACTION_CAPTURE" {
+			action := strings.Replace(action.Type, "POLICY_ACTION_", "", 1)
+			actions[0]["container"] = strings.ToLower(action)
+			//d.Set("actions.0.container", strings.ToLower(action))
+		} else {
+			actions[0]["capture"] = []map[string]interface{}{{
+				"seconds_after_event":  action.AfterEventNs / 1000000000,
+				"seconds_before_event": action.BeforeEventNs / 1000000000,
+				"name":                 action.Name,
+			}}
+		}
+	}
+
+	_ = d.Set("actions", actions)
+
+	rules := []map[string]interface{}{}
+
+	for _, rule := range policy.Rules {
+		rules = append(rules, map[string]interface{}{
+			"name":    rule.Name,
+			"enabled": rule.Enabled,
+		})
+	}
+
+	_ = d.Set("rules", rules)
+}

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -125,9 +125,11 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"sysdig_secure_trusted_cloud_identity": dataSourceSysdigSecureTrustedCloudIdentity(),
 			"sysdig_secure_notification_channel":   dataSourceSysdigSecureNotificationChannel(),
-			"sysdig_current_user":                  dataSourceSysdigCurrentUser(),
-			"sysdig_user":                          dataSourceSysdigUser(),
-			"sysdig_secure_connection":             dataSourceSysdigSecureConnection(),
+			"sysdig_secure_managed_policy":         dataSourceSysdigSecureManagedPolicy(),
+
+			"sysdig_current_user":      dataSourceSysdigCurrentUser(),
+			"sysdig_user":              dataSourceSysdigUser(),
+			"sysdig_secure_connection": dataSourceSysdigSecureConnection(),
 
 			"sysdig_fargate_workload_agent":                 dataSourceSysdigFargateWorkloadAgent(),
 			"sysdig_monitor_notification_channel_pagerduty": dataSourceSysdigMonitorNotificationChannelPagerduty(),

--- a/website/docs/d/secure_managed_policy.md
+++ b/website/docs/d/secure_managed_policy.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_managed_policy"
+description: |-
+  Retrieves a Sysdig Secure Managed Policy.
+---
+
+# sysdig_secure_managed_policy
+
+Retrieves the information of an existing Sysdig Secure Managed Policy.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+data "sysdig_secure_notification_channel" "sample-email" {
+  name                 = "Sysdig Runtime Threat Detection"
+  type                 = "falco"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Secure managed policy.
+
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The id for the managed policy.
+
+* `description` - The description for the managed policy.
+
+* `severity` -  The severity of Secure policy. The accepted values
+    are: 0, 1, 2, 3 (High), 4, 5 (Medium), 6 (Low) and 7 (Info).
+
+* `enabled` - Whether the policy is enabled or not.
+
+* `runbook` - Customer provided url that provides a runbook for a given policy.
+
+* `scope` - The application scope for the policy.
+
+* `rules` - An array of rules with the properties `name` and `enabled` to identify the rule name and whether it is enabled.
+
+* `notification_channels` - IDs of the notification channels to send alerts to
+    when the policy is fired.
+
+### Actions block
+
+The actions block is optional and supports:
+
+* `container` - (Optional) The action applied to container when this Policy is
+    triggered. Can be *stop*, *pause* or *kill*. If this is not specified,
+    no action will be applied at the container level.
+
+* `capture` - (Optional) Captures with Sysdig the stream of system calls:
+    * `seconds_before_event` - (Required) Captures the system calls during the
+    amount of seconds before the policy was triggered.
+    * `seconds_after_event` - (Required) Captures the system calls for the amount
+    of seconds after the policy was triggered.
+    * `name` - (Optional) The name of the capture file

--- a/website/docs/r/secure_managed_policy.md
+++ b/website/docs/r/secure_managed_policy.md
@@ -46,7 +46,8 @@ resource "sysdig_secure_managed_policy" "sysdig_runtime_threat_detection" {
 
 * `name` - (Required) The name of the Secure managed policy. It must match the name of an existing managed policy.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`, `aws_cloudtrail`. By default it is `falco`.
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
 
 * `enabled` - (Optional) Will secure process with this policy?. By default this is true.
 

--- a/website/docs/r/secure_policy.md
+++ b/website/docs/r/secure_policy.md
@@ -52,7 +52,8 @@ resource "sysdig_secure_policy" "write_apt_database" {
 
 * `enabled` - (Optional) Will secure process with this rule?. By default this is true.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`, `aws_cloudtrail`. By default it is `falco`.
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
 
 * `runbook` - (Optional) Customer provided url that provides a runbook for a given policy. 
 - - -


### PR DESCRIPTION
This PR adds a new data source `sysdig_secure_managed_policy` that can be used for getting data from managed policies.
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->