### PR TITLE
feat(policies): data source for "container" rules

### DIFF
--- a/sysdig/data_source_sysdig_secure_rule.go
+++ b/sysdig/data_source_sysdig_secure_rule.go
@@ -1,0 +1,51 @@
+package sysdig
+
+import (
+	"strconv"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Creates a schema with a default schema that a Secure Rule data source should have
+// Additional fields will be passed in via the parameter
+func createRuleDataSourceSchema(original map[string]*schema.Schema) map[string]*schema.Schema {
+	ruleSchema := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"id": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"tags": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"version": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+	}
+
+	for k, v := range original {
+		ruleSchema[k] = v
+	}
+
+	return ruleSchema
+}
+
+func ruleDataSourceToResourceData(rule v2.Rule, d *schema.ResourceData) {
+	d.SetId(strconv.Itoa(rule.ID))
+
+	_ = d.Set("name", rule.Name)
+	_ = d.Set("description", rule.Description)
+	_ = d.Set("tags", rule.Tags)
+	_ = d.Set("version", rule.Version)
+}

--- a/sysdig/data_source_sysdig_secure_rule_container.go
+++ b/sysdig/data_source_sysdig_secure_rule_container.go
@@ -1,0 +1,68 @@
+package sysdig
+
+import (
+	"context"
+	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSysdigSecureRuleContainer() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		ReadContext: dataSourceSysdigRuleContainerRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: createRuleDataSourceSchema(map[string]*schema.Schema{
+			"matching": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"containers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		}),
+	}
+}
+
+func dataSourceSysdigRuleContainerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecureRuleClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ruleName := d.Get("name").(string)
+	ruleType := v2.RuleTypeContainer
+
+	rules, err := client.GetRuleGroup(ctx, ruleName, ruleType)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(rules) == 0 {
+		return diag.Errorf("unable to find rule")
+	}
+
+	if len(rules) > 1 {
+		return diag.Errorf("more than one rule with that name was found")
+	}
+
+	rule := rules[0]
+
+	ruleDataSourceToResourceData(rule, d)
+
+	_ = d.Set("matching", rule.Details.Containers.MatchItems)
+	_ = d.Set("containers", rule.Details.Containers.Items)
+
+	return nil
+}

--- a/sysdig/data_source_sysdig_secure_rule_container_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_container_test.go
@@ -1,0 +1,48 @@
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccRuleContainerDataSource(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: managedPolicyDataSource(rText),
+			},
+		},
+	})
+}
+
+func ruleContainerDataSource(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sysdig_secure_rule_container" "data_sample" {
+	name = "TERRAFORM TEST %s"
+	depends_on = [ sysdig_secure_rule_container.sample ]
+}
+`, ruleContainerWithName(name), name)
+}

--- a/sysdig/data_source_sysdig_secure_rule_container_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_container_test.go
@@ -30,7 +30,7 @@ func TestAccRuleContainerDataSource(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: managedPolicyDataSource(rText),
+				Config: ruleContainerDataSource(rText()),
 			},
 		},
 	})

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -258,6 +258,10 @@ type Rule struct {
 	Version     int      `json:"version,omitempty"`
 }
 
+const (
+	RuleTypeContainer = "CONTAINER"
+)
+
 type Details struct {
 	// Containers
 	Containers *Containers `json:"containers,omitempty"`

--- a/sysdig/internal/client/v2/rules.go
+++ b/sysdig/internal/client/v2/rules.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 const (
-	CreateRulePath  = "%s/api/secure/rules"
-	GetRuleByIDPath = "%s/api/secure/rules/%d"
-	UpdateRulePath  = "%s/api/secure/rules/%d"
-	DeleteURLPath   = "%s/api/secure/rules/%d"
+	CreateRulePath   = "%s/api/secure/rules"
+	GetRuleByIDPath  = "%s/api/secure/rules/%d"
+	UpdateRulePath   = "%s/api/secure/rules/%d"
+	DeleteURLPath    = "%s/api/secure/rules/%d"
+	GetRuleGroupPath = "%s/api/secure/rules/groups?name=%s&type=%s"
 )
 
 type RuleInterface interface {
@@ -19,6 +21,7 @@ type RuleInterface interface {
 	GetRuleByID(ctx context.Context, ruleID int) (Rule, error)
 	UpdateRule(ctx context.Context, rule Rule) (Rule, error)
 	DeleteRule(ctx context.Context, ruleID int) error
+	GetRuleGroup(ctx context.Context, ruleName string, ruleType string) ([]Rule, error)
 }
 
 func (client *Client) CreateRule(ctx context.Context, rule Rule) (Rule, error) {
@@ -88,6 +91,21 @@ func (client *Client) DeleteRule(ctx context.Context, ruleID int) error {
 	return err
 }
 
+func (client *Client) GetRuleGroup(ctx context.Context, ruleName string, ruleType string) ([]Rule, error) {
+	response, err := client.requester.Request(ctx, http.MethodGet, client.GetRuleGroupURL(ruleName, ruleType), nil)
+	if err != nil {
+		return []Rule{}, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return []Rule{}, client.ErrorFromResponse(response)
+	}
+
+	return Unmarshal[[]Rule](response.Body)
+
+}
+
 func (client *Client) CreateRuleURL() string {
 	return fmt.Sprintf(CreateRulePath, client.config.url)
 }
@@ -102,4 +120,8 @@ func (client *Client) UpdateRuleURL(ruleID int) string {
 
 func (client *Client) DeleteRuleURL(ruleID int) string {
 	return fmt.Sprintf(DeleteURLPath, client.config.url, ruleID)
+}
+
+func (client *Client) GetRuleGroupURL(ruleName string, ruleType string) string {
+	return fmt.Sprintf(GetRuleGroupPath, client.config.url, url.QueryEscape(ruleName), url.QueryEscape(ruleType))
 }

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -127,6 +127,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_trusted_cloud_identity": dataSourceSysdigSecureTrustedCloudIdentity(),
 			"sysdig_secure_notification_channel":   dataSourceSysdigSecureNotificationChannel(),
 			"sysdig_secure_managed_policy":         dataSourceSysdigSecureManagedPolicy(),
+			"sysdig_secure_rule_container":         dataSourceSysdigSecureRuleContainer(),
 
 			"sysdig_current_user":      dataSourceSysdigCurrentUser(),
 			"sysdig_user":              dataSourceSysdigUser(),

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -2,9 +2,10 @@ package sysdig
 
 import (
 	"context"
-	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"strconv"
 	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -134,7 +135,7 @@ func resourceSysdigRuleContainerDelete(ctx context.Context, d *schema.ResourceDa
 
 func resourceSysdigRuleContainerFromResourceData(d *schema.ResourceData) v2.Rule {
 	rule := ruleFromResourceData(d)
-	rule.Details.RuleType = "CONTAINER"
+	rule.Details.RuleType = v2.RuleTypeContainer
 
 	rule.Details.Containers = &v2.Containers{}
 	rule.Details.Containers.MatchItems = d.Get("matching").(bool)

--- a/website/docs/d/secure_managed_policy.md
+++ b/website/docs/d/secure_managed_policy.md
@@ -6,7 +6,7 @@ description: |-
   Retrieves a Sysdig Secure Managed Policy.
 ---
 
-# sysdig_secure_managed_policy
+# Data Source: sysdig_secure_managed_policy
 
 Retrieves the information of an existing Sysdig Secure Managed Policy.
 

--- a/website/docs/d/secure_managed_ruleset.md
+++ b/website/docs/d/secure_managed_ruleset.md
@@ -6,7 +6,7 @@ description: |-
   Retrieves a Sysdig Secure Managed Ruleset.
 ---
 
-# sysdig_secure_managed_ruleset
+# Data Source: sysdig_secure_managed_ruleset
 
 Retrieves the information of an existing Sysdig Secure Managed Ruleset.
 

--- a/website/docs/d/secure_notification_channel.md
+++ b/website/docs/d/secure_notification_channel.md
@@ -6,7 +6,7 @@ description: |-
   Retrieves a Sysdig Secure Notification Channel.
 ---
 
-# sysdig_secure_notification_channel
+# Data Source: sysdig_secure_notification_channel
 
 Retrieves the information of an existing Sysdig Secure Notification Channel.
 

--- a/website/docs/d/secure_rule_container.md
+++ b/website/docs/d/secure_rule_container.md
@@ -1,0 +1,35 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_rule_container"
+description: |-
+  Retrieves a Sysdig Secure Container Rule.
+---
+
+# Data Source: sysdig_secure_rule_container
+
+Retrieves the information of an existing Sysdig Secure Container Rule.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+data "sysdig_secure_rule_container" "example" {
+    name = "Nginx container spawned"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Secure rule to retrieve.
+
+## Attributes Reference
+
+In addition to the argument above, the following attributes are exported:
+
+* `description` - The description of Secure rule.
+* `tags` - A list of tags for this rule.
+* `matching` - Defines if the image name matches or not with the provided list. Default is true.
+* `containers` - List of containers to match.
+* `version` - Current version of the resource in Sysdig Secure.


### PR DESCRIPTION
This PR adds a new data source for `sysdig_secure_rule_container` that can be used for getting data from "container" rules.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->