### PR TITLE
feat(policies): resource for custom policies

### DIFF
--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -77,6 +77,7 @@ func Provider() *schema.Provider {
 			"sysdig_user":          resourceSysdigUser(),
 			"sysdig_group_mapping": resourceSysdigGroupMapping(),
 
+			"sysdig_secure_custom_policy":                  resourceSysdigSecureCustomPolicy(),
 			"sysdig_secure_managed_policy":                 resourceSysdigSecureManagedPolicy(),
 			"sysdig_secure_managed_ruleset":                resourceSysdigSecureManagedRuleset(),
 			"sysdig_secure_policy":                         resourceSysdigSecurePolicy(),

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -1,0 +1,184 @@
+package sysdig
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceSysdigSecureCustomPolicy() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		CreateContext: resourceSysdigCustomPolicyCreate,
+		ReadContext:   resourceSysdigCustomPolicyRead,
+		UpdateContext: resourceSysdigCustomPolicyUpdate,
+		DeleteContext: resourceSysdigCustomPolicyDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
+		},
+
+		Schema: createPolicySchema(map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "falco",
+				ValidateDiagFunc: validateDiagFunc(validatePolicyType),
+			},
+			"severity": {
+				Type:             schema.TypeInt,
+				Default:          4,
+				Optional:         true,
+				ValidateDiagFunc: validateDiagFunc(validation.IntBetween(0, 7)),
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+					},
+				},
+			},
+		}),
+	}
+}
+
+func resourceSysdigCustomPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	policy := customPolicyFromResourceData(d)
+	policy, err = client.CreatePolicy(ctx, policy)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	customPolicyToResourceData(&policy, d)
+
+	return nil
+}
+
+func customPolicyFromResourceData(d *schema.ResourceData) v2.Policy {
+	policy := &v2.Policy{}
+	commonPolicyFromResourceData(policy, d)
+
+	policy.Description = d.Get("description").(string)
+	policy.Severity = d.Get("severity").(int)
+	policy.Type = d.Get("type").(string)
+
+	policy.Rules = []*v2.PolicyRule{}
+
+	rules := d.Get("rules").([]interface{})
+	for index, _ := range rules {
+		rule := &v2.PolicyRule{
+			Name:    d.Get(fmt.Sprintf("rules.%d.name", index)).(string),
+			Enabled: d.Get(fmt.Sprintf("rules.%d.enabled", index)).(bool),
+		}
+		policy.Rules = append(policy.Rules, rule)
+	}
+
+	return *policy
+}
+
+func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
+	commonPolicyToResourceData(policy, d)
+
+	_ = d.Set("description", policy.Description)
+	_ = d.Set("severity", policy.Severity)
+	if policy.Type != "" {
+		_ = d.Set("type", policy.Type)
+	} else {
+		_ = d.Set("type", "falco")
+	}
+
+	rules := []map[string]interface{}{}
+	for _, rule := range policy.Rules {
+		rules = append(rules, map[string]interface{}{
+			"name":    rule.Name,
+			"enabled": rule.Enabled,
+		})
+	}
+	_ = d.Set("rules", rules)
+}
+
+func resourceSysdigCustomPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, _ := strconv.Atoi(d.Id())
+	policy, statusCode, err := client.GetPolicyByID(ctx, id)
+
+	if err != nil {
+		d.SetId("")
+		if statusCode == http.StatusNotFound {
+			return diag.FromErr(err)
+		}
+	}
+
+	customPolicyToResourceData(&policy, d)
+
+	return nil
+}
+
+func resourceSysdigCustomPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, _ := strconv.Atoi(d.Id())
+
+	err = client.DeletePolicy(ctx, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceSysdigCustomPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	policy := customPolicyFromResourceData(d)
+	policy.Version = d.Get("version").(int)
+
+	id, _ := strconv.Atoi(d.Id())
+	policy.ID = id
+
+	_, err = client.UpdatePolicy(ctx, policy)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -95,7 +95,7 @@ func customPolicyFromResourceData(d *schema.ResourceData) v2.Policy {
 	policy.Rules = []*v2.PolicyRule{}
 
 	rules := d.Get("rules").([]interface{})
-	for index, _ := range rules {
+	for index := range rules {
 		rule := &v2.PolicyRule{
 			Name:    d.Get(fmt.Sprintf("rules.%d.name", index)).(string),
 			Enabled: d.Get(fmt.Sprintf("rules.%d.enabled", index)).(bool),

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -25,7 +25,7 @@ func TestAccCustomPolicy(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: policyWithName(rText()),
+				Config: customPolicyWithName(rText()),
 			},
 			{
 				ResourceName:      "sysdig_secure_custom_policy.sample",
@@ -33,37 +33,37 @@ func TestAccCustomPolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: policyWithoutActions(rText()),
+				Config: customPolicyWithoutActions(rText()),
 			},
 			{
-				Config: policyWithoutNotificationChannels(rText()),
+				Config: customPolicyWithoutNotificationChannels(rText()),
 			},
 			{
-				Config: policyWithMinimumConfiguration(rText()),
+				Config: customPolicyWithMinimumConfiguration(rText()),
 			},
 			{
-				Config: policiesWithDifferentSeverities(rText()),
+				Config: customPoliciesWithDifferentSeverities(rText()),
 			},
 			{
-				Config: policiesWithKillAction(rText()),
+				Config: customPoliciesWithKillAction(rText()),
 			},
 			{
-				Config: policiesForAWSCloudtrail(rText()),
+				Config: customPoliciesForAWSCloudtrail(rText()),
 			},
 			{
-				Config: policiesForGCPAuditLog(rText()),
+				Config: customPoliciesForGCPAuditLog(rText()),
 			},
 			{
-				Config: policiesForAzurePlatformlogs(rText()),
+				Config: customPoliciesForAzurePlatformlogs(rText()),
 			},
 			{
-				Config: policiesWithDisabledRules(rText()),
+				Config: customPoliciesWithDisabledRules(rText()),
 			},
 		},
 	})
 }
 
-func policyWithName(name string) string {
+func customPolicyWithName(name string) string {
 	return fmt.Sprintf(`
 %s
 %s
@@ -94,7 +94,7 @@ resource "sysdig_secure_custom_policy" "sample" {
 `, secureNotificationChannelEmailWithName(name), ruleFalcoTerminalShell(name), name, name)
 }
 
-func policyWithoutActions(name string) string {
+func customPolicyWithoutActions(name string) string {
 	return fmt.Sprintf(`
 %s
 %s
@@ -117,7 +117,7 @@ resource "sysdig_secure_custom_policy" "sample2" {
 `, secureNotificationChannelEmailWithName(name), ruleFalcoTerminalShell(name), name, name)
 }
 
-func policyWithoutNotificationChannels(name string) string {
+func customPolicyWithoutNotificationChannels(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_custom_policy" "sample3" {
   name = "TERRAFORM TEST 3 %s"
@@ -135,7 +135,7 @@ resource "sysdig_secure_custom_policy" "sample3" {
 `, name, name)
 }
 
-func policyWithMinimumConfiguration(name string) string {
+func customPolicyWithMinimumConfiguration(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_custom_policy" "sample4" {
   name = "TERRAFORM TEST 4 %s"
@@ -145,7 +145,7 @@ resource "sysdig_secure_custom_policy" "sample4" {
 `, name, name)
 }
 
-func policiesWithDifferentSeverities(name string) (res string) {
+func customPoliciesWithDifferentSeverities(name string) (res string) {
 	for i := 0; i <= 7; i++ {
 		res += fmt.Sprintf(`
 resource "sysdig_secure_custom_policy" "sample_%d" {
@@ -174,7 +174,7 @@ resource "sysdig_secure_custom_policy" "sample_%d" {
 	return
 }
 
-func policiesWithKillAction(name string) (res string) {
+func customPoliciesWithKillAction(name string) (res string) {
 	return fmt.Sprintf(`
 resource "sysdig_secure_custom_policy" "sample" {
   name = "TERRAFORM TEST 1 %s"
@@ -195,7 +195,7 @@ resource "sysdig_secure_custom_policy" "sample" {
 `, name, name)
 }
 
-func policiesForAWSCloudtrail(name string) string {
+func customPoliciesForAWSCloudtrail(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_custom_policy" "sample4" {
   name = "TERRAFORM TEST 4 %s"
@@ -206,7 +206,7 @@ resource "sysdig_secure_custom_policy" "sample4" {
 `, name, name)
 }
 
-func policiesForGCPAuditLog(name string) string {
+func customPoliciesForGCPAuditLog(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_custom_policy" "sample5" {
   name = "TERRAFORM TEST %s"
@@ -217,7 +217,7 @@ resource "sysdig_secure_custom_policy" "sample5" {
 `, name, name)
 }
 
-func policiesForAzurePlatformlogs(name string) string {
+func customPoliciesForAzurePlatformlogs(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_custom_policy" "sample6" {
   name = "TERRAFORM TEST %s"
@@ -228,7 +228,7 @@ resource "sysdig_secure_custom_policy" "sample6" {
 `, name, name)
 }
 
-func policiesWithDisabledRules(name string) string {
+func customPoliciesWithDisabledRules(name string) string {
 	return fmt.Sprintf(`
 %s
 %s

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -76,8 +76,8 @@ resource "sysdig_secure_custom_policy" "sample" {
   runbook = "https://sysdig.com"
 
   rules {
-	name = sysdig_secure_rule_falco.terminal_shell.name
-	enabled = true
+    name = sysdig_secure_rule_falco.terminal_shell.name
+    enabled = true
   }
 
   actions {
@@ -108,8 +108,8 @@ resource "sysdig_secure_custom_policy" "sample2" {
   notification_channels = [sysdig_secure_notification_channel_email.sample_email.id]
 
   rules {
-	name = sysdig_secure_rule_falco.terminal_shell.name
-	enabled = true
+    name = sysdig_secure_rule_falco.terminal_shell.name
+    enabled = true
   }
 
   actions {}
@@ -119,6 +119,7 @@ resource "sysdig_secure_custom_policy" "sample2" {
 
 func customPolicyWithoutNotificationChannels(name string) string {
 	return fmt.Sprintf(`
+%s
 resource "sysdig_secure_custom_policy" "sample3" {
   name = "TERRAFORM TEST 3 %s"
   description = "TERRAFORM TEST %s"
@@ -127,12 +128,12 @@ resource "sysdig_secure_custom_policy" "sample3" {
   scope = "container.id != \"\""
 
   rules {
-	name = sysdig_secure_rule_falco.terminal_shell.name
-	enabled = true
+    name = sysdig_secure_rule_falco.terminal_shell.name
+    enabled = true
   }
   actions {}
 }
-`, name, name)
+`, ruleFalcoTerminalShell(name), name, name)
 }
 
 func customPolicyWithMinimumConfiguration(name string) string {
@@ -155,8 +156,8 @@ resource "sysdig_secure_custom_policy" "sample_%d" {
   severity = %d
   scope = "container.id != \"\""
   rules {
-	name = "Terminal shell in container"
-	enabled = true
+    name = "Terminal shell in container"
+    enabled = true
   }
 
   actions {
@@ -184,8 +185,8 @@ resource "sysdig_secure_custom_policy" "sample" {
   scope = "container.id != \"\""
 
   rules {
-	name = "Terminal shell in container"
-	enabled = true
+    name = "Terminal shell in container"
+    enabled = true
   }
 
   actions {
@@ -241,8 +242,8 @@ resource "sysdig_secure_custom_policy" "sample" {
   runbook = "https://sysdig.com"
 
   rules {
-	name = sysdig_secure_rule_falco.terminal_shell.name
-	enabled = false
+    name = sysdig_secure_rule_falco.terminal_shell.name
+    enabled = false
   }
 
   actions {

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -58,7 +58,7 @@ func TestAccCustomPolicy(t *testing.T) {
 			},
 			{
 				Config: policiesWithDisabledRules(rText()),
-			}
+			},
 		},
 	})
 }

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -1,0 +1,260 @@
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+
+package sysdig_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccCustomPolicy(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: preCheckAnyEnv(t, SysdigSecureApiTokenEnv),
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: policyWithName(rText()),
+			},
+			{
+				ResourceName:      "sysdig_secure_custom_policy.sample",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: policyWithoutActions(rText()),
+			},
+			{
+				Config: policyWithoutNotificationChannels(rText()),
+			},
+			{
+				Config: policyWithMinimumConfiguration(rText()),
+			},
+			{
+				Config: policiesWithDifferentSeverities(rText()),
+			},
+			{
+				Config: policiesWithKillAction(rText()),
+			},
+			{
+				Config: policiesForAWSCloudtrail(rText()),
+			},
+			{
+				Config: policiesForGCPAuditLog(rText()),
+			},
+			{
+				Config: policiesForAzurePlatformlogs(rText()),
+			},
+			{
+				Config: policiesWithDisabledRules(rText()),
+			}
+		},
+	})
+}
+
+func policyWithName(name string) string {
+	return fmt.Sprintf(`
+%s
+%s
+resource "sysdig_secure_custom_policy" "sample" {
+  name = "TERRAFORM TEST 1 %s"
+  description = "TERRAFORM TEST %s"
+  enabled = true
+  severity = 4
+  scope = "container.id != \"\""
+  runbook = "https://sysdig.com"
+
+  rules {
+	name = sysdig_secure_rule_falco.terminal_shell.name
+	enabled = true
+  }
+
+  actions {
+    container = "stop"
+    capture {
+      seconds_before_event = 5
+      seconds_after_event = 10
+      name = "testcapture"
+    }
+  }
+
+  notification_channels = [sysdig_secure_notification_channel_email.sample_email.id]
+}
+`, secureNotificationChannelEmailWithName(name), ruleFalcoTerminalShell(name), name, name)
+}
+
+func policyWithoutActions(name string) string {
+	return fmt.Sprintf(`
+%s
+%s
+resource "sysdig_secure_custom_policy" "sample2" {
+  name = "TERRAFORM TEST 2 %s"
+  description = "TERRAFORM TEST %s"
+  enabled = true
+  severity = 4
+  scope = "container.id != \"\""
+
+  notification_channels = [sysdig_secure_notification_channel_email.sample_email.id]
+
+  rules {
+	name = sysdig_secure_rule_falco.terminal_shell.name
+	enabled = true
+  }
+
+  actions {}
+}
+`, secureNotificationChannelEmailWithName(name), ruleFalcoTerminalShell(name), name, name)
+}
+
+func policyWithoutNotificationChannels(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_custom_policy" "sample3" {
+  name = "TERRAFORM TEST 3 %s"
+  description = "TERRAFORM TEST %s"
+  enabled = true
+  severity = 4
+  scope = "container.id != \"\""
+
+  rules {
+	name = sysdig_secure_rule_falco.terminal_shell.name
+	enabled = true
+  }
+  actions {}
+}
+`, name, name)
+}
+
+func policyWithMinimumConfiguration(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_custom_policy" "sample4" {
+  name = "TERRAFORM TEST 4 %s"
+  description = "TERRAFORM TEST %s"
+  actions {}
+}
+`, name, name)
+}
+
+func policiesWithDifferentSeverities(name string) (res string) {
+	for i := 0; i <= 7; i++ {
+		res += fmt.Sprintf(`
+resource "sysdig_secure_custom_policy" "sample_%d" {
+  name = "TERRAFORM TEST 1 %s-%d"
+  description = "TERRAFORM TEST %s-%d"
+  enabled = true
+  severity = %d
+  scope = "container.id != \"\""
+  rules {
+	name = "Terminal shell in container"
+	enabled = true
+  }
+
+  actions {
+    container = "stop"
+    capture {
+      seconds_before_event = 5
+      seconds_after_event = 10
+      name = "capture_name"
+    }
+  }
+}
+
+`, i, name, i, name, i, i)
+	}
+	return
+}
+
+func policiesWithKillAction(name string) (res string) {
+	return fmt.Sprintf(`
+resource "sysdig_secure_custom_policy" "sample" {
+  name = "TERRAFORM TEST 1 %s"
+  description = "TERRAFORM TEST %s"
+  enabled = true
+  severity = 4
+  scope = "container.id != \"\""
+
+  rules {
+	name = "Terminal shell in container"
+	enabled = true
+  }
+
+  actions {
+    container = "kill"
+  }
+}
+`, name, name)
+}
+
+func policiesForAWSCloudtrail(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_custom_policy" "sample4" {
+  name = "TERRAFORM TEST 4 %s"
+  description = "TERRAFORM TEST %s"
+  type = "aws_cloudtrail"
+  actions {}
+}
+`, name, name)
+}
+
+func policiesForGCPAuditLog(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_custom_policy" "sample5" {
+  name = "TERRAFORM TEST %s"
+  description = "TERRAFORM TEST %s"
+  type = "gcp_auditlog"
+  actions {}
+}
+`, name, name)
+}
+
+func policiesForAzurePlatformlogs(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_custom_policy" "sample6" {
+  name = "TERRAFORM TEST %s"
+  description = "TERRAFORM TEST %s"
+  type = "azure_platformlogs"
+  actions {}
+}
+`, name, name)
+}
+
+func policiesWithDisabledRules(name string) string {
+	return fmt.Sprintf(`
+%s
+%s
+resource "sysdig_secure_custom_policy" "sample" {
+  name = "TERRAFORM TEST 1 %s"
+  description = "TERRAFORM TEST %s"
+  enabled = true
+  severity = 4
+  scope = "container.id != \"\""
+  runbook = "https://sysdig.com"
+
+  rules {
+	name = sysdig_secure_rule_falco.terminal_shell.name
+	enabled = false
+  }
+
+  actions {
+    container = "stop"
+    capture {
+      seconds_before_event = 5
+      seconds_after_event = 10
+      name = "testcapture"
+    }
+  }
+
+  notification_channels = [sysdig_secure_notification_channel_email.sample_email.id]
+}
+`, secureNotificationChannelEmailWithName(name), ruleFalcoTerminalShell(name), name, name)
+}

--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -114,6 +114,9 @@ func resourceSysdigSecurePolicy() *schema.Resource {
 			Read:   schema.DefaultTimeout(timeout),
 		},
 
+		DeprecationMessage: "The sysdig_secure_policy resource is being replaced by sysdig_secure_custom_policy, " +
+			"sysdig_secure_managed_policy, and sysdig_secure_managed_ruleset depending on the type of policy.",
+
 		Schema: createPolicySchema(map[string]*schema.Schema{
 			"description": {
 				Type:     schema.TypeString,

--- a/website/docs/r/secure_custom_policy.md
+++ b/website/docs/r/secure_custom_policy.md
@@ -1,0 +1,115 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_custom_policy"
+description: |-
+  Creates a Sysdig Secure Custom Policy.
+---
+
+# Resource: sysdig_secure_custom_policy
+
+Creates a Sysdig Secure Custom Policy.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+resource "sysdig_secure_custom_policy" "write_apt_database" {
+  name = "Write apt database"
+  description = "an attempt to write to the dpkg database by any non-dpkg related program"
+  severity = 4
+  enabled = true
+  runbook = "https://runbook.com"
+  
+  // Scope selection
+  scope = "container.id != \"\""
+
+  // Rule selection
+
+  rules {
+    name = "Terminal shell in container"
+    enabled = true
+  }
+
+  actions {
+    container = "stop"
+    capture {
+      seconds_before_event = 5
+      seconds_after_event = 10
+    }
+  }
+
+  notification_channels = [10000]
+
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Secure policy. It must be unique.
+
+* `description` - (Required) The description of Secure policy.
+
+* `severity` - (Optional) The severity of Secure policy. The accepted values
+    are: 0, 1, 2, 3 (High), 4, 5 (Medium), 6 (Low) and 7 (Info). The default value is 4 (Medium).
+
+* `enabled` - (Optional) Will secure process with this rule?. By default this is true.
+
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
+
+* `runbook` - (Optional) Customer provided url that provides a runbook for a given policy. 
+- - -
+
+### Scope selection
+
+* `scope` - (Optional) Limit application scope based in one expression. For
+    example: "host.ip.private = \\"10.0.23.1\\"". By default the rule won't be scoped
+    and will target the entire infrastructure.
+
+- - -
+
+### Actions block
+
+The actions block is optional and supports:
+
+* `container` - (Optional) The action applied to container when this Policy is
+    triggered. Can be *stop*, *pause* or *kill*. If this is not specified,
+    no action will be applied at the container level.
+
+* `capture` - (Optional) Captures with Sysdig the stream of system calls:
+    * `seconds_before_event` - (Required) Captures the system calls during the
+    amount of seconds before the policy was triggered.
+    * `seconds_after_event` - (Required) Captures the system calls for the amount
+    of seconds after the policy was triggered.
+    * `name` - (Optional) The name of the capture file
+
+- - -
+
+### Falco rule selection - Rules block
+
+The rules block can be repeated for each rule in the policy and supports:
+
+* `name` - (Required) The name of the rule to include in the policy.
+
+* `enabled` - (Optional) Whether the rule is enabled or not. The default is true.
+
+- - -
+
+### Notification
+
+* `notification_channels` - (Optional) IDs of the notification channels to send alerts to
+    when the policy is fired.
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+Secure custom policies can be imported using the ID, e.g.
+
+```
+$ terraform import sysdig_secure_custom_policy.example 12345
+```

--- a/website/docs/r/secure_policy.md
+++ b/website/docs/r/secure_policy.md
@@ -10,7 +10,11 @@ description: |-
 
 Creates a Sysdig Secure Policy.
 
--> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.  
+~> **Deprecation Notice:** The `sysdig_secure_policy` resource has been deprecated and is being replaced by
+`sysdig_secure_custom_policy`, `sysdig_secure_managed_policy`, and `sysdig_secure_managed_ruleset` depending on the type
+of policy.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage
 


### PR DESCRIPTION
This PR adds a new resource for `sysdig_secure_custom_policy` and adds a deprecation notice to `sysdig_secure_policy`.  `sysdig_secure_policy` will still work, but usage should be replaced with one of the more specific policy types:

* `sysdig_secure_custom_policy`
* `sysdig_secure_managed_policy`
* `sysdig_secure_managed_ruleset`

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->