### PR TITLE
feat(policies): data source for custom policies

### DIFF
--- a/sysdig/data_source_sysdig_secure_custom_policy.go
+++ b/sysdig/data_source_sysdig_secure_custom_policy.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceSysdigSecureManagedRuleset() *schema.Resource {
+func dataSourceSysdigSecureCustomPolicy() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		ReadContext: dataSourceSysdigManagedRulesetRead,
+		ReadContext: dataSourceSysdigSecureCustomPolicyRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(timeout),
@@ -23,10 +23,10 @@ func dataSourceSysdigSecureManagedRuleset() *schema.Resource {
 	}
 }
 
-func dataSourceSysdigManagedRulesetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return commonDataSourceSecurePolicyRead(ctx, d, meta, "managed ruleset", isManagedRuleset)
+func dataSourceSysdigSecureCustomPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return commonDataSourceSecurePolicyRead(ctx, d, meta, "custom policy", isCustomPolicy)
 }
 
-func isManagedRuleset(policy v2.Policy) bool {
-	return !policy.IsDefault && policy.TemplateId != 0
+func isCustomPolicy(policy v2.Policy) bool {
+	return !policy.IsDefault && policy.TemplateId == 0
 }

--- a/sysdig/data_source_sysdig_secure_custom_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_custom_policy_test.go
@@ -45,6 +45,7 @@ resource "sysdig_secure_custom_policy" "sample" {
 	
 data "sysdig_secure_custom_policy" "example" {
 	name = "%s"
+	depends_on=[ sysdig_secure_custom_policy.sample ]
 }
 `
 }

--- a/sysdig/data_source_sysdig_secure_custom_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_custom_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/sysdig/data_source_sysdig_secure_custom_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_custom_policy_test.go
@@ -29,7 +29,7 @@ func TestAccCustomPolicyDataSource(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: customPolicyDataSource(rText()),
+				Config: customPolicyDataSource(rText),
 			},
 		},
 	})

--- a/sysdig/data_source_sysdig_secure_custom_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_custom_policy_test.go
@@ -1,0 +1,49 @@
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+
+package sysdig_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccCustomPolicyDataSource(t *testing.T) {
+	rText := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: customPolicyDataSource(rText()),
+			},
+		},
+	})
+}
+
+func customPolicyDataSource(name string) string {
+	return `
+resource "sysdig_secure_custom_policy" "sample" {
+	name = "%s"
+	description = "Test Description"
+	enabled = true
+}
+	
+data "sysdig_secure_custom_policy" "example" {
+	name = "%s"
+}
+`
+}

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -127,6 +127,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"sysdig_secure_trusted_cloud_identity": dataSourceSysdigSecureTrustedCloudIdentity(),
 			"sysdig_secure_notification_channel":   dataSourceSysdigSecureNotificationChannel(),
+			"sysdig_secure_custom_policy":          dataSourceSysdigSecureCustomPolicy(),
 			"sysdig_secure_managed_policy":         dataSourceSysdigSecureManagedPolicy(),
 			"sysdig_secure_managed_ruleset":        dataSourceSysdigSecureManagedRuleset(),
 			"sysdig_secure_rule_container":         dataSourceSysdigSecureRuleContainer(),

--- a/website/docs/d/secure_custom_policy.md
+++ b/website/docs/d/secure_custom_policy.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_custom_policy"
+description: |-
+  Retrieves a Sysdig Secure Custom Policy.
+---
+
+# Data Source: sysdig_secure_custom_policy
+
+Retrieves the information of an existing Sysdig Secure Custom Policy.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+data "sysdig_secure_custom_policy" "example" {
+  name                 = "Write apt database"
+  type                 = "falco"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Secure custom policy.
+
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The id for the custom policy.
+
+* `description` - The description for the custom policy.
+
+* `severity` -  The severity of Secure policy. The accepted values
+    are: 0, 1, 2, 3 (High), 4, 5 (Medium), 6 (Low) and 7 (Info).
+
+* `enabled` - Whether the policy is enabled or not.
+
+* `runbook` - Customer provided url that provides a runbook for a given policy.
+
+* `scope` - The application scope for the policy.
+
+* `rules` - An array of rules with the properties `name` and `enabled` to identify the rule name and whether it is enabled.
+
+* `notification_channels` - IDs of the notification channels to send alerts to
+    when the policy is fired.
+
+### Actions block
+
+The actions block is optional and supports:
+
+* `container` - (Optional) The action applied to container when this Policy is
+    triggered. Can be *stop*, *pause* or *kill*. If this is not specified,
+    no action will be applied at the container level.
+
+* `capture` - (Optional) Captures with Sysdig the stream of system calls:
+    * `seconds_before_event` - (Required) Captures the system calls during the
+    amount of seconds before the policy was triggered.
+    * `seconds_after_event` - (Required) Captures the system calls for the amount
+    of seconds after the policy was triggered.
+    * `name` - (Optional) The name of the capture file


### PR DESCRIPTION
This PR adds a new data source for sysdig_secure_custom_policy.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->