### PR TITLE
feat(policies): data source falco rules

### DIFF
--- a/sysdig/data_source_sysdig_secure_rule_falco.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco.go
@@ -45,30 +45,29 @@ func dataSourceSysdigSecureRuleFalco() *schema.Resource {
 			"append": {
 
 				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 			"exceptions": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:     schema.TypeString,
-							Required: true,
+							Computed: true,
 						},
 						"comps": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"values": {
 							Type:     schema.TypeString,
-							Required: true,
+							Computed: true,
 						},
 						"fields": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},

--- a/sysdig/data_source_sysdig_secure_rule_falco.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco.go
@@ -1,0 +1,119 @@
+package sysdig
+
+import (
+	"context"
+	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSysdigSecureRuleFalco() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		ReadContext: dataSourceSysdigRuleFalcoRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: createRuleDataSourceSchema(map[string]*schema.Schema{
+			"index": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"condition": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"output": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"priority": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"append": {
+
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"exceptions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"comps": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"values": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"fields": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		}),
+	}
+}
+
+func dataSourceSysdigRuleFalcoRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecureRuleClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ruleName := d.Get("name").(string)
+	ruleType := v2.RuleTypeFalco
+	ruleIndex := d.Get("index").(int)
+	rules, err := client.GetRuleGroup(ctx, ruleName, ruleType)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(rules) == 0 {
+		return diag.Errorf("unable to find rule")
+	}
+
+	if ruleIndex >= len(rules) {
+		return diag.Errorf("unable to find rule at the index provided")
+	}
+	rule := rules[ruleIndex]
+
+	ruleDataSourceToResourceData(rule, d)
+
+	if rule.Details.Condition != nil {
+		_ = d.Set("condition", rule.Details.Condition.Condition)
+	}
+	_ = d.Set("output", rule.Details.Output)
+	_ = d.Set("priority", rule.Details.Priority)
+	_ = d.Set("source", rule.Details.Source)
+	if rule.Details.Append != nil {
+		_ = d.Set("append", *rule.Details.Append)
+	}
+	if err := updateResourceDataExceptions(d, rule.Details.Exceptions); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/sysdig/data_source_sysdig_secure_rule_falco.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -20,6 +19,12 @@ func dataSourceSysdigSecureRuleFalco() *schema.Resource {
 		},
 
 		Schema: createRuleDataSourceSchema(map[string]*schema.Schema{
+			"source": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "",
+				ValidateDiagFunc: validateDiagFunc(validateFalcoRuleSource),
+			},
 			"index": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -34,10 +39,6 @@ func dataSourceSysdigSecureRuleFalco() *schema.Resource {
 				Computed: true,
 			},
 			"priority": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"source": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -84,7 +85,7 @@ func dataSourceSysdigRuleFalcoRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	ruleName := d.Get("name").(string)
-	ruleType := v2.RuleTypeFalco
+	ruleType := d.Get("source").(string)
 	ruleIndex := d.Get("index").(int)
 	rules, err := client.GetRuleGroup(ctx, ruleName, ruleType)
 	if err != nil {

--- a/sysdig/data_source_sysdig_secure_rule_falco_count.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco_count.go
@@ -1,0 +1,59 @@
+package sysdig
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSysdigSecureRuleFalcoCount() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		ReadContext: dataSourceSysdigRuleFalcoCountRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"source": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "",
+				ValidateDiagFunc: validateDiagFunc(validateFalcoRuleSource),
+			},
+			"rule_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSysdigRuleFalcoCountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecureRuleClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ruleName := d.Get("name").(string)
+	ruleType := d.Get("source").(string)
+	rules, err := client.GetRuleGroup(ctx, ruleName, ruleType)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(fmt.Sprintf("count_%s", ruleName))
+	_ = d.Set("name", ruleName)
+	_ = d.Set("rule_count", len(rules))
+
+	return nil
+}

--- a/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
@@ -1,0 +1,75 @@
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccRuleFalcoCountDataSource(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: ruleFalcoCountDataSource(rText()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", 1),
+				),
+			},
+			{
+				Config: ruleFalcoCountDataSourceWithAppends(rText()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", 2),
+				),
+			},
+		},
+	})
+}
+
+func ruleFalcoCountDataSource(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sysdig_secure_rule_falco_count" "data_terminal_shell" {
+	name = "TERRAFORM TEST %s - Terminal Shell"
+	depends_on = [ sysdig_secure_rule_falco.terminal_shell ]
+}
+`, ruleFalcoTerminalShell(name), name)
+}
+
+func ruleFalcoCountDataSourceWithAppends(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sysdig_secure_rule_falco" "terminal_shell_append" {
+	name = "TERRAFORM TEST %s - Terminal Shell"
+  
+	condition = "and never_true"
+	source = "syscall" // syscall or k8s_audit
+}
+
+data "sysdig_secure_rule_falco_count" "data_terminal_shell" {
+	name = "TERRAFORM TEST %s - Terminal Shell"
+	depends_on = [ sysdig_secure_rule_falco.terminal_shell, sysdig_secure_rule_falco.terminal_shell_append ]
+}
+`, ruleFalcoTerminalShell(name), name, name)
+}

--- a/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
@@ -32,13 +32,13 @@ func TestAccRuleFalcoCountDataSource(t *testing.T) {
 			{
 				Config: ruleFalcoCountDataSource(rText()),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", "1"),
+					resource.TestCheckResourceAttr("data.sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", "1"),
 				),
 			},
 			{
 				Config: ruleFalcoCountDataSourceWithAppends(rText()),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", "2"),
+					resource.TestCheckResourceAttr("data.sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", "2"),
 				),
 			},
 		},
@@ -65,6 +65,8 @@ resource "sysdig_secure_rule_falco" "terminal_shell_append" {
   
 	condition = "and never_true"
 	source = "syscall" // syscall or k8s_audit
+	append = true
+	depends_on = [ sysdig_secure_rule_falco.terminal_shell ]
 }
 
 data "sysdig_secure_rule_falco_count" "data_terminal_shell" {

--- a/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
@@ -32,13 +32,13 @@ func TestAccRuleFalcoCountDataSource(t *testing.T) {
 			{
 				Config: ruleFalcoCountDataSource(rText()),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", 1),
+					resource.TestCheckResourceAttr("sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", "1"),
 				),
 			},
 			{
 				Config: ruleFalcoCountDataSourceWithAppends(rText()),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", 2),
+					resource.TestCheckResourceAttr("sysdig_secure_rule_falco_count.data_terminal_shell", "rule_count", "2"),
 				),
 			},
 		},

--- a/sysdig/data_source_sysdig_secure_rule_falco_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco_test.go
@@ -1,0 +1,81 @@
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccRuleFalcoDataSource(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: ruleFalcoDataSource(rText()),
+			},
+			{
+				Config: ruleFalcoCountDataSourceWithAppends(rText()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("sysdig_secure_rule_falco.data_terminal_shell.0", "id"),
+					resource.TestCheckResourceAttrSet("sysdig_secure_rule_falco.data_terminal_shell.1", "id"),
+				),
+			},
+		},
+	})
+}
+
+func ruleFalcoDataSource(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sysdig_secure_rule_falco" "data_terminal_shell" {
+	name = "TERRAFORM TEST %s - Terminal Shell"
+	depends_on = [ sysdig_secure_rule_falco.terminal_shell ]
+}
+`, ruleFalcoTerminalShell(name), name)
+}
+
+func ruleFalcoDataSourceWithAppends(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "sysdig_secure_rule_falco" "terminal_shell_append" {
+	name = "TERRAFORM TEST %s - Terminal Shell"
+  
+	condition = "and never_true"
+	source = "syscall" // syscall or k8s_audit
+}
+
+data "sysdig_secure_rule_falco_count" "terminal_shell_count" {
+	name = "TERRAFORM TEST %s - Terminal Shell"
+	depends_on = [ sysdig_secure_rule_falco.terminal_shell, sysdig_secure_rule_falco.terminal_shell_append ]
+}
+
+data "sysdig_secure_rule_falco" "data_terminal_shell" {
+	count = "data.sysdig_rule_falco_count.terminal_shell_count.rule_count
+	name = "TERRAFORM TEST %s - Terminal Shell"
+	index = ${count.index}
+
+	depends_on = [ sysdig_secure_rule_falco_count.terminal_shell_count ]
+}
+`, ruleFalcoTerminalShell(name), name, name, name)
+}

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -260,6 +260,7 @@ type Rule struct {
 
 const (
 	RuleTypeContainer = "CONTAINER"
+	RuleTypeFalco     = "FALCO"
 )
 
 type Details struct {

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -130,6 +130,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_managed_policy":         dataSourceSysdigSecureManagedPolicy(),
 			"sysdig_secure_managed_ruleset":        dataSourceSysdigSecureManagedRuleset(),
 			"sysdig_secure_rule_container":         dataSourceSysdigSecureRuleContainer(),
+			"sysdig_secure_rule_falco":             dataSourceSysdigSecureRuleFalco(),
 
 			"sysdig_current_user":      dataSourceSysdigCurrentUser(),
 			"sysdig_user":              dataSourceSysdigUser(),

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -131,6 +131,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_managed_ruleset":        dataSourceSysdigSecureManagedRuleset(),
 			"sysdig_secure_rule_container":         dataSourceSysdigSecureRuleContainer(),
 			"sysdig_secure_rule_falco":             dataSourceSysdigSecureRuleFalco(),
+			"sysdig_secure_rule_falco_count":       dataSourceSysdigSecureRuleFalcoCount(),
 
 			"sysdig_current_user":      dataSourceSysdigCurrentUser(),
 			"sysdig_user":              dataSourceSysdigUser(),

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"strconv"
 	"strings"
 	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -243,7 +244,7 @@ func resourceSysdigRuleFalcoDelete(ctx context.Context, d *schema.ResourceData, 
 
 func resourceSysdigRuleFalcoFromResourceData(d *schema.ResourceData) (v2.Rule, error) {
 	rule := ruleFromResourceData(d)
-	rule.Details.RuleType = "FALCO"
+	rule.Details.RuleType = v2.RuleTypeFalco
 
 	appendMode, appendModeIsSet := d.GetOk("append")
 	if appendModeIsSet {

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -17,6 +17,8 @@ import (
 	"github.com/spf13/cast"
 )
 
+var validateFalcoRuleSource = validation.StringInSlice([]string{"syscall", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", "azure_platformlogs"}, false)
+
 func resourceSysdigSecureRuleFalco() *schema.Resource {
 	timeout := 5 * time.Minute
 
@@ -56,7 +58,7 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Default:          "",
-				ValidateDiagFunc: validateDiagFunc(validation.StringInSlice([]string{"syscall", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", "azure_platformlogs"}, false)),
+				ValidateDiagFunc: validateDiagFunc(validateFalcoRuleSource),
 			},
 			"append": {
 				Type:     schema.TypeBool,

--- a/website/docs/d/secure_rule_falco.md
+++ b/website/docs/d/secure_rule_falco.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_rule_falco"
+description: |-
+  Retrieves a Sysdig Secure Falco Rule.
+---
+
+# Data Source: sysdig_secure_rule_falco
+
+Retrieves the information of an existing Sysdig Secure Falco Rule.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+data "sysdig_secure_rule_falco" "example" {
+    name = "Terminal shell in container"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Secure rule to retrieve.
+* `source` - (Optional) The source of the Secure rule to retrieve. This is required if a rule with this name exists in
+  multiple sources.
+* `index` - (Optional) The index of the Secure rule to retrieve in the event of multiple rules. The default value is 0.
+  see section on rules with appended rules.
+
+## Attributes Reference
+
+In addition to the argument above, the following attributes are exported:
+
+* `description` - The description of Secure rule.
+* `tags` - A list of tags for this rule.
+* `condition` - A [Falco condition](https://falco.org/docs/rules/) is simply a Boolean predicate on Sysdig events
+  expressed using the Sysdig [filter syntax](http://www.sysdig.org/wiki/sysdig-user-guide/#filtering) and macro terms.
+* `output` - Add additional information to each Falco notification's output.
+* `priority` - The priority of the Falco rule. It can be: "emergency", "alert", "critical", "error", "warning", "notice", "info" or "debug". By default is "warning".
+* `exceptions` - The exceptions key is a list of identifier plus list of tuples of filtercheck fields. See below for details.
+* `append` - This indicates that the rule being created appends the condition to an existing Sysdig-provided rule
+* `version` - Current version of the resource in Sysdig Secure.
+
+### Exceptions
+
+Starting in 0.28.0, Falco supports an optional exceptions property to rules. The exceptions key is a list of identifier plus list of tuples of filtercheck fields.
+For more information about the syntax of the exceptions, check the [official Falco documentation](https://falco.org/docs/rules/exceptions/).
+
+Supported fields for exceptions:
+
+* `name` - The name of the exception.
+* `fields` - Contains one or more fields that will extract a value from the syscall/k8s_audit events.
+* `comps` - Contains comparison operators that align 1-1 with the items in the fields property.
+* `values` - Contains tuples of values. Each item in the tuple should align 1-1 with the corresponding field
+  and comparison operator. 
+
+## Rules with Appended Rules
+
+In the event that a rule has appended rules, the data source can return the default rule and its appended rules using
+the `index` argument. This can be combined with the `sysdig_secure_rule_falco_count` data source to easily retrieve all
+of the rules in the rule group.
+
+An example of how this could be used follows:
+
+```terraform
+data "sysdig_secure_rule_falco_count" "disallowed_container" {
+  name = "Launch Disallowed Container"
+  source = "syscall"
+}
+
+data "sysdig_secure_rule_falco" "disallowed_container" {
+  count = data.sysdig_secure_rule_falco_count.disallowed_container.rule_count
+  name = "Launch Disallowed Container"
+  source = "syscall"
+  index = "${count.index}"
+  depends_on = [ data.sysdig_secure_rule_falco_count.disallowed_container ]
+}
+
+output "disallowed_container_rule_group" {
+  value = ["${data.sysdig_secure_rule_falco.disallowed_container.*}"]
+}
+```

--- a/website/docs/d/secure_rule_falco_count.md
+++ b/website/docs/d/secure_rule_falco_count.md
@@ -1,0 +1,33 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_rule_falco_count"
+description: |-
+  Retrieves the count of rules (including appends) for a named falco rule.
+---
+
+# Data Source: sysdig_secure_rule_falco_count
+
+Retrieves the count of rules (including appends) for a named falco rule.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+data "sysdig_secure_rule_falco_count" "example" {
+    name = "Terminal shell in container"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Secure rule to retrieve.
+* `source` - (Optional) The source of the Secure rule to retrieve. This is required if a rule with this name exists in
+  multiple sources.
+
+## Attributes Reference
+
+In addition to the argument above, the following attributes are exported:
+
+* `rule_count` - The number of rules (including appends).


### PR DESCRIPTION
This PR adds new data sources for sysdig_secure_rule_falco and sysdig_secure_rule_falco_count.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->