### PR TITLE
fix(policies): update for consistency between resource and data source

### DIFF
--- a/sysdig/data_source_sysdig_secure_rule_filesystem.go
+++ b/sysdig/data_source_sysdig_secure_rule_filesystem.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceSysdigSecureRuleFileSystem() *schema.Resource {
+func dataSourceSysdigSecureRuleFilesystem() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		ReadContext: dataSourceSysdigRuleFileSystemRead,
+		ReadContext: dataSourceSysdigRuleFilesystemRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(timeout),
@@ -62,14 +62,14 @@ func dataSourceSysdigSecureRuleFileSystem() *schema.Resource {
 	}
 }
 
-func dataSourceSysdigRuleFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSysdigRuleFilesystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, err := getSecureRuleClient(meta.(SysdigClients))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	ruleName := d.Get("name").(string)
-	ruleType := v2.RuleTypeFileSystem
+	ruleType := v2.RuleTypeFilesystem
 
 	rules, err := client.GetRuleGroup(ctx, ruleName, ruleType)
 	if err != nil {

--- a/sysdig/data_source_sysdig_secure_rule_filesystem_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_filesystem_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/draios/terraform-provider-sysdig/sysdig"
 )
 
-func TestAccRuleFileSystemDataSource(t *testing.T) {
+func TestAccRuleFilesystemDataSource(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,17 +30,17 @@ func TestAccRuleFileSystemDataSource(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: ruleFileSystemDataSource(rText()),
+				Config: ruleFilesystemDataSource(rText()),
 			},
 		},
 	})
 }
 
-func ruleFileSystemDataSource(name string) string {
+func ruleFilesystemDataSource(name string) string {
 	return fmt.Sprintf(`
 %s
 
-data "sysdig_secure_rule_file_system" "data_sample" {
+data "sysdig_secure_rule_filesystem" "data_sample" {
 	name = "TERRAFORM TEST %s"
 	depends_on = [ sysdig_secure_rule_filesystem.foo ]
 }

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -260,7 +260,7 @@ type Rule struct {
 
 const (
 	RuleTypeContainer  = "CONTAINER"
-	RuleTypeFileSystem = "FILESYSTEM"
+	RuleTypeFilesystem = "FILESYSTEM"
 )
 
 type Details struct {

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -131,7 +131,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_managed_policy":         dataSourceSysdigSecureManagedPolicy(),
 			"sysdig_secure_managed_ruleset":        dataSourceSysdigSecureManagedRuleset(),
 			"sysdig_secure_rule_container":         dataSourceSysdigSecureRuleContainer(),
-			"sysdig_secure_rule_file_system":       dataSourceSysdigSecureRuleFileSystem(),
+			"sysdig_secure_rule_filesystem":        dataSourceSysdigSecureRuleFilesystem(),
 
 			"sysdig_current_user":      dataSourceSysdigCurrentUser(),
 			"sysdig_user":              dataSourceSysdigUser(),

--- a/sysdig/resource_sysdig_secure_rule_filesystem.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem.go
@@ -2,9 +2,10 @@ package sysdig
 
 import (
 	"context"
-	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"strconv"
 	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -185,7 +186,7 @@ func resourceSysdigRuleFilesystemDelete(ctx context.Context, d *schema.ResourceD
 
 func resourceSysdigRuleFilesystemFromResourceData(d *schema.ResourceData) (rule v2.Rule, err error) {
 	rule = ruleFromResourceData(d)
-	rule.Details.RuleType = v2.RuleTypeFileSystem
+	rule.Details.RuleType = v2.RuleTypeFilesystem
 
 	rule.Details.ReadPaths = &v2.ReadPaths{
 		MatchItems: true,

--- a/website/docs/d/secure_rule_filesystem.md
+++ b/website/docs/d/secure_rule_filesystem.md
@@ -1,14 +1,14 @@
 ---
 subcategory: "Sysdig Secure"
 layout: "sysdig"
-page_title: "Sysdig: sysdig_secure_rule_file_system"
+page_title: "Sysdig: sysdig_secure_rule_filesystem"
 description: |-
-  Retrieves a Sysdig Secure File System Rule.
+  Retrieves a Sysdig Secure Filesystem Rule.
 ---
 
-# Data Source: sysdig_secure_rule_file_system
+# Data Source: sysdig_secure_rule_filesystem
 
-Retrieves the information of an existing Sysdig Secure File System Rule.
+Retrieves the information of an existing Sysdig Secure Filesystem Rule.
 
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 


### PR DESCRIPTION
This PR ensures that the data source and resource are consistent in their naming.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->