### PR TITLE
feat(policies): Data source for sysdig_secure_rule_network

### DIFF
--- a/sysdig/data_source_sysdig_secure_rule_container.go
+++ b/sysdig/data_source_sysdig_secure_rule_container.go
@@ -36,31 +36,10 @@ func dataSourceSysdigSecureRuleContainer() *schema.Resource {
 }
 
 func dataSourceSysdigRuleContainerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	return commonDataSourceSysdigRuleRead(ctx, d, meta, v2.RuleTypeContainer, containerRuleDataSourceToResourceData)
+}
 
-	ruleName := d.Get("name").(string)
-	ruleType := v2.RuleTypeContainer
-
-	rules, err := client.GetRuleGroup(ctx, ruleName, ruleType)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	if len(rules) == 0 {
-		return diag.Errorf("unable to find rule")
-	}
-
-	if len(rules) > 1 {
-		return diag.Errorf("more than one rule with that name was found")
-	}
-
-	rule := rules[0]
-
-	ruleDataSourceToResourceData(rule, d)
-
+func containerRuleDataSourceToResourceData(rule v2.Rule, d *schema.ResourceData) diag.Diagnostics {
 	_ = d.Set("matching", rule.Details.Containers.MatchItems)
 	_ = d.Set("containers", rule.Details.Containers.Items)
 

--- a/sysdig/data_source_sysdig_secure_rule_network.go
+++ b/sysdig/data_source_sysdig_secure_rule_network.go
@@ -1,0 +1,120 @@
+package sysdig
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSysdigSecureRuleNetwork() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		ReadContext: dataSourceSysdigRuleNetworkRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: createRuleDataSourceSchema(map[string]*schema.Schema{
+			"block_inbound": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"block_outbound": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"tcp": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"matching": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"ports": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+					},
+				},
+			},
+			"udp": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"matching": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"ports": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+					},
+				},
+			},
+		}),
+	}
+}
+
+func dataSourceSysdigRuleNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return commonDataSourceSysdigRuleRead(ctx, d, meta, v2.RuleTypeNetwork, networkRuleDataSourceToResourceData)
+}
+
+func networkRuleDataSourceToResourceData(rule v2.Rule, d *schema.ResourceData) diag.Diagnostics {
+	_ = d.Set("block_inbound", rule.Details.AllInbound)
+	_ = d.Set("block_outbound", rule.Details.AllOutbound)
+
+	if rule.Details.TCPListenPorts == nil {
+		return diag.Errorf("no tcpListenPorts for a network rule")
+	}
+
+	if rule.Details.UDPListenPorts == nil {
+		return diag.Errorf("no udpListenPorts for a network rule")
+	}
+
+	if len(rule.Details.TCPListenPorts.Items) > 0 {
+		tcpPorts := []int{}
+		for _, port := range rule.Details.TCPListenPorts.Items {
+			intPort, err := strconv.Atoi(port)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			tcpPorts = append(tcpPorts, intPort)
+		}
+		_ = d.Set("tcp", []map[string]interface{}{{
+			"matching": rule.Details.TCPListenPorts.MatchItems,
+			"ports":    tcpPorts,
+		}})
+	}
+	if len(rule.Details.UDPListenPorts.Items) > 0 {
+		udpPorts := []int{}
+		for _, port := range rule.Details.UDPListenPorts.Items {
+			intPort, err := strconv.Atoi(port)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			udpPorts = append(udpPorts, intPort)
+		}
+		_ = d.Set("udp", []map[string]interface{}{{
+			"matching": rule.Details.UDPListenPorts.MatchItems,
+			"ports":    udpPorts,
+		}})
+	}
+
+	return nil
+}

--- a/sysdig/data_source_sysdig_secure_rule_network_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_network_test.go
@@ -1,0 +1,48 @@
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccRuleNetworkDataSource(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: ruleNetworkDataSource(rText()),
+			},
+		},
+	})
+}
+
+func ruleNetworkDataSource(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sysdig_secure_rule_network" "data_sample" {
+	name = "TERRAFORM TEST %s"
+	depends_on = [ sysdig_secure_rule_network.foo ]
+}
+`, ruleNetworkWithName(name), name)
+}

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -260,6 +260,7 @@ type Rule struct {
 
 const (
 	RuleTypeContainer = "CONTAINER"
+	RuleTypeNetwork   = "NETWORK"
 )
 
 type Details struct {

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -131,6 +131,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_managed_policy":         dataSourceSysdigSecureManagedPolicy(),
 			"sysdig_secure_managed_ruleset":        dataSourceSysdigSecureManagedRuleset(),
 			"sysdig_secure_rule_container":         dataSourceSysdigSecureRuleContainer(),
+			"sysdig_secure_rule_network":           dataSourceSysdigSecureRuleNetwork(),
 
 			"sysdig_current_user":      dataSourceSysdigCurrentUser(),
 			"sysdig_user":              dataSourceSysdigUser(),

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -2,9 +2,10 @@ package sysdig
 
 import (
 	"context"
-	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"strconv"
 	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -210,7 +211,7 @@ func resourceSysdigRuleNetworkDelete(ctx context.Context, d *schema.ResourceData
 
 func resourceSysdigRuleNetworkFromResourceData(d *schema.ResourceData) (rule v2.Rule, err error) {
 	rule = ruleFromResourceData(d)
-	rule.Details.RuleType = "NETWORK"
+	rule.Details.RuleType = v2.RuleTypeNetwork
 
 	rule.Details.TCPListenPorts = &v2.TCPListenPorts{}
 	rule.Details.UDPListenPorts = &v2.UDPListenPorts{}

--- a/website/docs/d/secure_rule_network.md
+++ b/website/docs/d/secure_rule_network.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_rule_network"
+description: |-
+  Retrieves a Sysdig Secure Network Rule.
+---
+
+# Data Source: sysdig_secure_rule_network
+
+Retrieves the information of an existing Sysdig Secure Network Rule.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+data "sysdig_secure_rule_network" "example" {
+    name = "Disallowed SSH Connection"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Secure rule to retrieve.
+
+## Attributes Reference
+
+In addition to the argument above, the following attributes are exported:
+
+* `description` - The description of Secure rule.
+* `tags` - A list of tags for this rule.
+* `block_inbound` - Detect if there is an inbound connection.
+* `block_outbound` - Detect if there is an outbound connection.
+* `tcp` - A block with the properties `matching` and `ports` for TCP connections.
+* `udp` - A block with the properties `matching` and `ports` for UDP connections.
+* `version` - Current version of the resource in Sysdig Secure.
+
+## Connection Blocks
+
+The `tcp` and `udp` blocks will have the the following attributes:
+
+* `matching` - Defines if the port matches or not with the provided list.
+* `ports` - List of ports to match.


### PR DESCRIPTION
This PR adds a new data source for sysdig_secure_rule_network.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->