### PR TITLE
Remove unused tags

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -57,17 +57,3 @@ jobs:
     name: Test
     uses: ./.github/workflows/test.yml
     secrets: inherit
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Lint
-        continue-on-error: true
-        uses: golangci/golangci-lint-action@v1
-        with:
-          version: v1.27

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -69,4 +69,6 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          args: --timeout 30m
+          args:
+          - --timeout 30m
+          - --build-tags tf_acc_sysdig,tf_acc_ibm

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -69,6 +69,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          args:
-          - --timeout 30m
-          - --build-tags tf_acc_sysdig,tf_acc_ibm
+          args: --timeout 30m --build-tags tf_acc_sysdig,tf_acc_ibm

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -57,16 +57,3 @@ jobs:
     name: Test
     uses: ./.github/workflows/test.yml
     secrets: inherit
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          args: --timeout 30m --build-tags tf_acc_sysdig,tf_acc_ibm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,19 @@ on:
   workflow_call:
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          args: --timeout 30m --build-tags unit,tf_acc_sysdig_monitor,tf_acc_sysdig_secure,tf_acc_ibm_monitor
+
   test:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 SWEEP?=us-east-1,us-west-2
 TEST?=./...
-TEST_SUITE?=tf_acc_sysdig
+TEST_SUITE?=tf_acc_sysdig_monitor,tf_acc_sysdig_secure
 PKG_NAME=sysdig
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 VERSION=$(shell [ ! -z `git tag -l --contains HEAD` ] && git tag -l --contains HEAD || git rev-parse --short HEAD)

--- a/buildinfo/ibm_monitor.go
+++ b/buildinfo/ibm_monitor.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_ibm_monitor
 
 package buildinfo
 

--- a/buildinfo/sysdig.go
+++ b/buildinfo/sysdig.go
@@ -1,8 +1,0 @@
-//go:build tf_acc_sysdig
-
-package buildinfo
-
-func init() {
-	SysdigSecure = true
-	SysdigMonitor = true
-}

--- a/sysdig/common_test.go
+++ b/sysdig/common_test.go
@@ -1,5 +1,3 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm || tf_acc_ibm_monitor || tf_acc_policies || unit
-
 package sysdig_test
 
 import (

--- a/sysdig/data_source_sysdig_current_user_test.go
+++ b/sysdig/data_source_sysdig_current_user_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_fargate_workload_agent_test.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_current_connection_test.go
+++ b/sysdig/data_source_sysdig_secure_current_connection_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_custom_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_custom_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_managed_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_managed_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_managed_ruleset_test.go
+++ b/sysdig/data_source_sysdig_secure_managed_ruleset_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rule_container_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_container_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rule_file_system.go
+++ b/sysdig/data_source_sysdig_secure_rule_file_system.go
@@ -1,0 +1,106 @@
+package sysdig
+
+import (
+	"context"
+	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSysdigSecureRuleFileSystem() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		ReadContext: dataSourceSysdigRuleFileSystemRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: createRuleDataSourceSchema(map[string]*schema.Schema{
+			"read_only": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"matching": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"paths": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"read_write": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"matching": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"paths": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+		}),
+	}
+}
+
+func dataSourceSysdigRuleFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecureRuleClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ruleName := d.Get("name").(string)
+	ruleType := v2.RuleTypeFileSystem
+
+	rules, err := client.GetRuleGroup(ctx, ruleName, ruleType)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(rules) == 0 {
+		return diag.Errorf("unable to find rule")
+	}
+
+	if len(rules) > 1 {
+		return diag.Errorf("more than one rule with that name was found")
+	}
+
+	rule := rules[0]
+
+	ruleDataSourceToResourceData(rule, d)
+	if len(rule.Details.ReadPaths.Items) > 0 {
+		_ = d.Set("read_only", []map[string]interface{}{{
+			"matching": rule.Details.ReadPaths.MatchItems,
+			"paths":    rule.Details.ReadPaths.Items,
+		}})
+
+	}
+	if len(rule.Details.ReadWritePaths.Items) > 0 {
+		_ = d.Set("read_write", []map[string]interface{}{{
+			"matching": rule.Details.ReadWritePaths.MatchItems,
+			"paths":    rule.Details.ReadWritePaths.Items,
+		}})
+
+	}
+
+	return nil
+}

--- a/sysdig/data_source_sysdig_secure_rules_file_system_test.go
+++ b/sysdig/data_source_sysdig_secure_rules_file_system_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rules_file_system_test.go
+++ b/sysdig/data_source_sysdig_secure_rules_file_system_test.go
@@ -1,0 +1,48 @@
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccRuleFileSystemDataSource(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: ruleFileSystemDataSource(rText()),
+			},
+		},
+	})
+}
+
+func ruleFileSystemDataSource(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sysdig_secure_rule_file_system" "data_sample" {
+	name = "TERRAFORM TEST %s"
+	depends_on = [ sysdig_secure_rule_filesystem.foo ]
+}
+`, ruleFilesystemWithName(name), name)
+}

--- a/sysdig/data_source_sysdig_secure_trusted_cloud_identity_test.go
+++ b/sysdig/data_source_sysdig_secure_trusted_cloud_identity_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_user_test.go
+++ b/sysdig/data_source_sysdig_user_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/internal/client/v2/ibm_test.go
+++ b/sysdig/internal/client/v2/ibm_test.go
@@ -168,7 +168,6 @@ func TestIBMClient_CurrentTeamID(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to create response, err: %v", err)
 		}
-		return
 	}))
 
 	for _, testCase := range testTable {

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -259,7 +259,8 @@ type Rule struct {
 }
 
 const (
-	RuleTypeContainer = "CONTAINER"
+	RuleTypeContainer  = "CONTAINER"
+	RuleTypeFileSystem = "FILESYSTEM"
 )
 
 type Details struct {

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -131,6 +131,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_managed_policy":         dataSourceSysdigSecureManagedPolicy(),
 			"sysdig_secure_managed_ruleset":        dataSourceSysdigSecureManagedRuleset(),
 			"sysdig_secure_rule_container":         dataSourceSysdigSecureRuleContainer(),
+			"sysdig_secure_rule_file_system":       dataSourceSysdigSecureRuleFileSystem(),
 
 			"sysdig_current_user":      dataSourceSysdigCurrentUser(),
 			"sysdig_user":              dataSourceSysdigUser(),

--- a/sysdig/provider_test.go
+++ b/sysdig/provider_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_group_mapping_test.go
+++ b/sysdig/resource_sysdig_group_mapping_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_downtime_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_downtime_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_event_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_event_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_group_outlier_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_group_outlier_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_metric_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_promql_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_promql_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_event_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_event_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_cloud_account_test.go
+++ b/sysdig/resource_sysdig_monitor_cloud_account_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_dashboard_test.go
+++ b/sysdig/resource_sysdig_monitor_dashboard_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_team_ibm_test.go
+++ b/sysdig/resource_sysdig_monitor_team_ibm_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_team_shared_test.go
+++ b/sysdig/resource_sysdig_monitor_team_shared_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_ibm || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_team_test.go
+++ b/sysdig/resource_sysdig_monitor_team_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_cloud_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_account_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_list_test.go
+++ b/sysdig/resource_sysdig_secure_list_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_macro_test.go
+++ b/sysdig/resource_sysdig_secure_macro_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_managed_policy_test.go
+++ b/sysdig/resource_sysdig_secure_managed_policy_test.go
@@ -91,7 +91,7 @@ resource "sysdig_secure_managed_policy" "sample" {
 }
 
 func managedPolicyWithoutNotificationChannels() string {
-	return fmt.Sprintf(`
+	return `
 resource "sysdig_secure_managed_policy" "sample" {
 	name = "Sysdig Runtime Threat Detection"
 	enabled = true
@@ -107,22 +107,19 @@ resource "sysdig_secure_managed_policy" "sample" {
 		  name = "testcapture"
 		}
 	}	
-}
-	`)
+}`
 }
 
 func managedPolicyWithMinimumConfiguration() string {
-	return fmt.Sprintf(`
+	return `
 resource "sysdig_secure_managed_policy" "sample" {
 	name = "Sysdig Runtime Threat Detection"
 	enabled = true
-}
-	`)
+}`
 }
 
 func managedPolicyWithKillAction() string {
-	return fmt.Sprintf(`
-resource "sysdig_secure_managed_policy" "sample" {
+	return `resource "sysdig_secure_managed_policy" "sample" {
 	name = "Sysdig Runtime Threat Detection"
 	enabled = true
 	scope = "container.id != \"\""
@@ -132,6 +129,5 @@ resource "sysdig_secure_managed_policy" "sample" {
 	actions {
 		container = "kill"
 	}
-}
-	`)
+}`
 }

--- a/sysdig/resource_sysdig_secure_managed_policy_test.go
+++ b/sysdig/resource_sysdig_secure_managed_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_managed_ruleset_test.go
+++ b/sysdig/resource_sysdig_secure_managed_ruleset_test.go
@@ -106,7 +106,7 @@ resource "sysdig_secure_managed_ruleset" "sample" {
 }
 
 func managedRulesetWithoutNotificationChannels() string {
-	return fmt.Sprintf(`
+	return `
 resource "sysdig_secure_managed_ruleset" "sample" {
 	name = "Sysdig Runtime Threat Detection (Copy)"
 	description = "Test Description"
@@ -127,12 +127,11 @@ resource "sysdig_secure_managed_ruleset" "sample" {
 		  name = "testcapture"
 		}
 	}	
-}
-	`)
+}`
 }
 
 func managedRulesetWithMinimumConfiguration() string {
-	return fmt.Sprintf(`
+	return `
 resource "sysdig_secure_managed_ruleset" "sample" {
 	name = "Sysdig Runtime Threat Detection (Copy)"
 	description = "Test Description"
@@ -141,12 +140,11 @@ resource "sysdig_secure_managed_ruleset" "sample" {
 		type = "falco"
 	}
 	enabled = true
-}
-	`)
+}`
 }
 
 func managedRulesetWithKillAction() string {
-	return fmt.Sprintf(`
+	return `
 resource "sysdig_secure_managed_ruleset" "sample" {
 	name = "Sysdig Runtime Threat Detection (Copy)"
 	description = "Test Description"
@@ -162,6 +160,5 @@ resource "sysdig_secure_managed_ruleset" "sample" {
 	actions {
 		container = "kill"
 	}
-}
-	`)
+}`
 }

--- a/sysdig/resource_sysdig_secure_managed_ruleset_test.go
+++ b/sysdig/resource_sysdig_secure_managed_ruleset_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_container_test.go
+++ b/sysdig/resource_sysdig_secure_rule_container_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_filesystem.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem.go
@@ -185,7 +185,7 @@ func resourceSysdigRuleFilesystemDelete(ctx context.Context, d *schema.ResourceD
 
 func resourceSysdigRuleFilesystemFromResourceData(d *schema.ResourceData) (rule v2.Rule, err error) {
 	rule = ruleFromResourceData(d)
-	rule.Details.RuleType = "FILESYSTEM"
+	rule.Details.RuleType = v2.RuleTypeFileSystem
 
 	rule.Details.ReadPaths = &v2.ReadPaths{
 		MatchItems: true,

--- a/sysdig/resource_sysdig_secure_rule_filesystem_test.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_network_test.go
+++ b/sysdig/resource_sysdig_secure_rule_network_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_process_test.go
+++ b/sysdig/resource_sysdig_secure_rule_process_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_syscall_test.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_scanningpolicies_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpolicies_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_scanning_legacy
+//go:build tf_acc_sysdig_secure || tf_acc_scanning_legacy
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
+++ b/sysdig/resource_sysdig_secure_scanningpoliciesassignments_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_scanning_legacy
+//go:build tf_acc_sysdig_secure || tf_acc_scanning_legacy
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_team_test.go
+++ b/sysdig/resource_sysdig_secure_team_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_vulnerability_exception_list_test.go
+++ b/sysdig/resource_sysdig_secure_vulnerability_exception_list_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_scanning_legacy
+//go:build tf_acc_sysdig_secure || tf_acc_scanning_legacy
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_vulnerability_exception_test.go
+++ b/sysdig/resource_sysdig_secure_vulnerability_exception_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_scanning_legacy
+//go:build tf_acc_sysdig_secure || tf_acc_scanning_legacy
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_user_test.go
+++ b/sysdig/resource_sysdig_user_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/website/docs/d/secure_rule_file_system.md
+++ b/website/docs/d/secure_rule_file_system.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_rule_file_system"
+description: |-
+  Retrieves a Sysdig Secure File System Rule.
+---
+
+# Data Source: sysdig_secure_rule_file_system
+
+Retrieves the information of an existing Sysdig Secure File System Rule.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+data "sysdig_secure_rule_file_system" "example" {
+    name = "Write below etc"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Secure rule to retrieve.
+
+## Attributes Reference
+
+In addition to the argument above, the following attributes are exported:
+
+* `description` - The description of Secure rule.
+* `tags` - A list of tags for this rule.
+* `read_only` - Block that defines read only paths to match or not match.
+* `read_write` - Block that defines read and write paths to match or not match.
+* `version` - Current version of the resource in Sysdig Secure.
+
+## read_write and read_only blocks
+
+Description of the attributes within the read_only and read_write blocks.
+
+* `matching` - Boolean value that defines if the path matches or not with the provided list.
+* `paths` - List of paths to match.


### PR DESCRIPTION
- Removed unused tags `tf_acc_sysdig` ,`tf_acc_ibm`
- Lint is part of test workflow, removed code duplication
- `golangci-lint` will lint tests which contains build tags
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->