### PR TITLE
feat(policies): Data source for sysdig_secure_rule_process

### DIFF
--- a/sysdig/data_source_sysdig_secure_rule_process.go
+++ b/sysdig/data_source_sysdig_secure_rule_process.go
@@ -1,0 +1,50 @@
+package sysdig
+
+import (
+	"context"
+	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSysdigSecureRuleProcess() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		ReadContext: dataSourceSysdigRuleProcessRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: createRuleDataSourceSchema(map[string]*schema.Schema{
+			"matching": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"processes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		}),
+	}
+}
+
+func dataSourceSysdigRuleProcessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return commonDataSourceSysdigRuleRead(ctx, d, meta, v2.RuleTypeProcess, processRuleDataSourceToResourceData)
+}
+
+func processRuleDataSourceToResourceData(rule v2.Rule, d *schema.ResourceData) diag.Diagnostics {
+	if rule.Details.Processes == nil {
+		return diag.Errorf("no process data for a process rule")
+	}
+	_ = d.Set("matching", rule.Details.Processes.MatchItems)
+	_ = d.Set("processes", rule.Details.Processes.Items)
+
+	return nil
+}

--- a/sysdig/data_source_sysdig_secure_rule_process_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_process_test.go
@@ -1,0 +1,48 @@
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+
+package sysdig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccRuleProcessDataSource(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: ruleProcessDataSource(rText()),
+			},
+		},
+	})
+}
+
+func ruleProcessDataSource(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sysdig_secure_rule_network" "data_sample" {
+	name = "TERRAFORM TEST %s"
+	depends_on = [ sysdig_secure_rule_process.foo ]
+}
+`, ruleProcessWithName(name), name)
+}

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -263,6 +263,7 @@ const (
 	RuleTypeFalco      = "FALCO"
 	RuleTypeFilesystem = "FILESYSTEM"
 	RuleTypeNetwork    = "NETWORK"
+	RuleTypeProcess    = "PROCESS"
 )
 
 type Details struct {

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -135,6 +135,7 @@ func Provider() *schema.Provider {
 			"sysdig_secure_rule_falco_count":       dataSourceSysdigSecureRuleFalcoCount(),
 			"sysdig_secure_rule_filesystem":        dataSourceSysdigSecureRuleFilesystem(),
 			"sysdig_secure_rule_network":           dataSourceSysdigSecureRuleNetwork(),
+			"sysdig_secure_rule_process":           dataSourceSysdigSecureRuleProcess(),
 
 			"sysdig_current_user":      dataSourceSysdigCurrentUser(),
 			"sysdig_user":              dataSourceSysdigUser(),

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -2,9 +2,10 @@ package sysdig
 
 import (
 	"context"
-	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"strconv"
 	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -134,7 +135,7 @@ func resourceSysdigRuleProcessDelete(ctx context.Context, d *schema.ResourceData
 
 func resourceSysdigRuleProcessFromResourceData(d *schema.ResourceData) v2.Rule {
 	rule := ruleFromResourceData(d)
-	rule.Details.RuleType = "PROCESS"
+	rule.Details.RuleType = v2.RuleTypeProcess
 
 	rule.Details.Processes = &v2.Processes{}
 	rule.Details.Processes.MatchItems = d.Get("matching").(bool)


### PR DESCRIPTION
This PR adds a new data source for sysdig_secure_rule_process
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->