### PR TITLE
feat(serverless-agent): add option to disable pdig optimizations

### DIFF
--- a/sysdig/testfiles/fargate_pdig_only.json
+++ b/sysdig/testfiles/fargate_pdig_only.json
@@ -1,0 +1,70 @@
+[
+    {
+        "name": "useBinaryPatching1",
+        "Image": "test_image:latest",
+        "EntryPoint": [
+            "/bin/test"
+        ],
+        "Environment": [
+            {
+                "Name": "TMP",
+                "Value": "temporary"
+            },
+            {
+                "Name": "SYSDIG_CUSTOM",
+                "Value": "custom"
+            }
+        ]
+    },
+    {
+        "Name": "useBinaryPatching2",
+        "Image": "test_image:latest",
+        "EntryPoint": [
+            "/bin/test"
+        ],
+        "Environment": [
+            {
+                "Name": "TMP",
+                "Value": "temporary"
+            },
+            {
+                "Name": "SYSDIG_CUSTOM",
+                "Value": "custom"
+            }
+        ]
+    },
+    {
+        "name": "usePdigOnly1",
+        "Image": "test_image:latest",
+        "EntryPoint": [
+            "/bin/test"
+        ],
+        "Environment": [
+            {
+                "Name": "TMP",
+                "Value": "temporary"
+            },
+            {
+                "Name": "SYSDIG_CUSTOM",
+                "Value": "custom"
+            }
+        ]
+    },
+    {
+        "Name": "usePdigOnly2",
+        "Image": "test_image:latest",
+        "EntryPoint": [
+            "/bin/test"
+        ],
+        "Environment": [
+            {
+                "Name": "TMP",
+                "Value": "temporary"
+            },
+            {
+                "Name": "SYSDIG_CUSTOM",
+                "Value": "custom"
+            }
+        ]
+    }
+]

--- a/sysdig/testfiles/fargate_pdig_only_expected.json
+++ b/sysdig/testfiles/fargate_pdig_only_expected.json
@@ -1,0 +1,248 @@
+[
+    {
+        "Name": "useBinaryPatching1",
+        "Image": "test_image:latest",
+        "EntryPoint": [
+            "/opt/draios/bin/instrument"
+        ],
+        "Command": [
+            "/bin/test"
+        ],
+        "Environment": [
+            {
+                "Name": "SYSDIG_ORCHESTRATOR_PORT",
+                "Value": "orchestrator_port"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR",
+                "Value": "collector_host"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR_PORT",
+                "Value": "collector_port"
+            },
+            {
+                "Name": "SYSDIG_ACCESS_KEY",
+                "Value": "sysdig_access_key"
+            },
+            {
+                "Name": "SYSDIG_LOGGING",
+                "Value": "sysdig_logging"
+            },
+            {
+                "Name": "SYSDIG_ORCHESTRATOR",
+                "Value": "orchestrator_host"
+            },
+            {
+                "Name": "TMP",
+                "Value": "temporary"
+            },
+            {
+                "Name": "SYSDIG_CUSTOM",
+                "Value": "custom"
+            }
+        ],
+        "LinuxParameters": {
+            "Capabilities": {
+                "Add": [
+                    "SYS_PTRACE"
+                ]
+            }
+        },
+        "VolumesFrom": [
+            {
+                "ReadOnly": true,
+                "SourceContainer": "SysdigInstrumentation"
+            }
+        ]
+    },
+    {
+        "Name": "useBinaryPatching2",
+        "Image": "test_image:latest",
+        "EntryPoint": [
+            "/opt/draios/bin/instrument"
+        ],
+        "Command": [
+            "/bin/test"
+        ],
+        "Environment": [
+            {
+                "Name": "SYSDIG_ORCHESTRATOR_PORT",
+                "Value": "orchestrator_port"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR",
+                "Value": "collector_host"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR_PORT",
+                "Value": "collector_port"
+            },
+            {
+                "Name": "SYSDIG_ACCESS_KEY",
+                "Value": "sysdig_access_key"
+            },
+            {
+                "Name": "SYSDIG_LOGGING",
+                "Value": "sysdig_logging"
+            },
+            {
+                "Name": "SYSDIG_ORCHESTRATOR",
+                "Value": "orchestrator_host"
+            },
+            {
+                "Name": "TMP",
+                "Value": "temporary"
+            },
+            {
+                "Name": "SYSDIG_CUSTOM",
+                "Value": "custom"
+            }
+        ],
+        "LinuxParameters": {
+            "Capabilities": {
+                "Add": [
+                    "SYS_PTRACE"
+                ]
+            }
+        },
+        "VolumesFrom": [
+            {
+                "ReadOnly": true,
+                "SourceContainer": "SysdigInstrumentation"
+            }
+        ]
+    },
+    {
+        "Name": "usePdigOnly1",
+        "Image": "test_image:latest",
+        "EntryPoint": [
+            "/opt/draios/bin/instrument"
+        ],
+        "Command": [
+            "/bin/test"
+        ],
+        "Environment": [
+            {
+                "Name": "SYSDIG_ORCHESTRATOR_PORT",
+                "Value": "orchestrator_port"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR",
+                "Value": "collector_host"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR_PORT",
+                "Value": "collector_port"
+            },
+            {
+                "Name": "SYSDIG_ACCESS_KEY",
+                "Value": "sysdig_access_key"
+            },
+            {
+                "Name": "SYSDIG_LOGGING",
+                "Value": "sysdig_logging"
+            },
+            {
+                "Name": "SYSDIG_ORCHESTRATOR",
+                "Value": "orchestrator_host"
+            },
+            {
+                 "Name": "__INSTRUMENTATION_WRAPPER",
+                 "Value": "/opt/draios/bin/pdig,-C,-t,-1"
+            },
+            {
+                "Name": "TMP",
+                "Value": "temporary"
+            },
+            {
+                "Name": "SYSDIG_CUSTOM",
+                "Value": "custom"
+            }
+        ],
+        "LinuxParameters": {
+            "Capabilities": {
+                "Add": [
+                    "SYS_PTRACE"
+                ]
+            }
+        },
+        "VolumesFrom": [
+            {
+                "ReadOnly": true,
+                "SourceContainer": "SysdigInstrumentation"
+            }
+        ]
+    },
+    {
+        "Name": "useBinaryPatching1",
+        "Image": "test_image:latest",
+        "EntryPoint": [
+            "/opt/draios/bin/instrument"
+        ],
+        "Command": [
+            "/bin/test"
+        ],
+        "Environment": [
+            {
+                "Name": "SYSDIG_ORCHESTRATOR_PORT",
+                "Value": "orchestrator_port"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR",
+                "Value": "collector_host"
+            },
+            {
+                "Name": "SYSDIG_COLLECTOR_PORT",
+                "Value": "collector_port"
+            },
+            {
+                "Name": "SYSDIG_ACCESS_KEY",
+                "Value": "sysdig_access_key"
+            },
+            {
+                "Name": "SYSDIG_LOGGING",
+                "Value": "sysdig_logging"
+            },
+            {
+                "Name": "SYSDIG_ORCHESTRATOR",
+                "Value": "orchestrator_host"
+            },
+            {
+                 "Name": "__INSTRUMENTATION_WRAPPER",
+                 "Value": "/opt/draios/bin/pdig,-C,-t,-1"
+            },
+            {
+                "Name": "TMP",
+                "Value": "temporary"
+            },
+            {
+                "Name": "SYSDIG_CUSTOM",
+                "Value": "custom"
+            }
+        ],
+        "LinuxParameters": {
+            "Capabilities": {
+                "Add": [
+                    "SYS_PTRACE"
+                ]
+            }
+        },
+        "VolumesFrom": [
+            {
+                "ReadOnly": true,
+                "SourceContainer": "SysdigInstrumentation"
+            }
+        ]
+    },
+    {
+        "EntryPoint": [
+            "/opt/draios/bin/logwriter"
+        ],
+        "Image": "workload_agent_image",
+        "Name": "SysdigInstrumentation",
+        "RepositoryCredentials": {
+            "CredentialsParameter": "image_auth_secret"
+        }
+    }
+]


### PR DESCRIPTION
# Description
This PR adds the boolean option `disable_pdig_optimizations` to the `fargate_workload_agent` data source to disable pdig optimizations.

This could be useful to workaround issues due to binary patching.

By default `disable_pdig_optimizations=false`, that is the workload agent runs with optimizations in place.