### PR TITLE
feat(test): add common test tag

### DIFF
--- a/sysdig/data_source_sysdig_secure_notification_channel_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_team_shared_test.go
+++ b/sysdig/resource_sysdig_monitor_team_shared_test.go
@@ -1,5 +1,3 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
-
 package sysdig_test
 
 import "fmt"

--- a/sysdig/resource_sysdig_monitor_team_test.go
+++ b/sysdig/resource_sysdig_monitor_team_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_cloud_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_account_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_policies
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_team_test.go
+++ b/sysdig/resource_sysdig_secure_team_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
 
 package sysdig_test
 


### PR DESCRIPTION
Added `tf_acc_sysdig_common` tag which will be used to run resources which are common for both monitor and secure.
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->