### PR TITLE
feat(policies): add `minimum_engine_version` argument to macro and falco rule resources

### DIFF
--- a/sysdig/data_source_sysdig_secure_rule_falco.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco.go
@@ -42,6 +42,11 @@ func dataSourceSysdigSecureRuleFalco() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"minimum_engine_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+				Optional: true,
+			},
 			"append": {
 
 				Type:     schema.TypeBool,
@@ -108,6 +113,9 @@ func dataSourceSysdigRuleFalcoRead(ctx context.Context, d *schema.ResourceData, 
 	_ = d.Set("output", rule.Details.Output)
 	_ = d.Set("priority", rule.Details.Priority)
 	_ = d.Set("source", rule.Details.Source)
+	if rule.Details.MinimumEngineVersion != nil {
+		_ = d.Set("minimum_engine_version", *rule.Details.MinimumEngineVersion)
+	}
 	if rule.Details.Append != nil {
 		_ = d.Set("append", *rule.Details.Append)
 	}

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -228,11 +228,12 @@ type Items struct {
 }
 
 type Macro struct {
-	ID        int            `json:"id,omitempty"`
-	Version   int            `json:"version,omitempty"`
-	Name      string         `json:"name"`
-	Condition MacroCondition `json:"condition"`
-	Append    bool           `json:"append"`
+	ID                   int            `json:"id,omitempty"`
+	Version              int            `json:"version,omitempty"`
+	Name                 string         `json:"name"`
+	Condition            MacroCondition `json:"condition"`
+	Append               bool           `json:"append"`
+	MinimumEngineVersion *int           `json:"minimumEngineVersion,omitempty"`
 }
 
 type MacroCondition struct {
@@ -294,12 +295,13 @@ type Details struct {
 	Syscalls *Syscalls `json:"syscalls,omitempty"`
 
 	// Falco
-	Append     *bool        `json:"append,omitempty"`
-	Source     string       `json:"source,omitempty"`
-	Output     string       `json:"output,omitempty"`
-	Condition  *Condition   `json:"condition,omitempty"`
-	Priority   string       `json:"priority,omitempty"`
-	Exceptions []*Exception `json:"exceptions,omitempty"`
+	Append               *bool        `json:"append,omitempty"`
+	Source               string       `json:"source,omitempty"`
+	Output               string       `json:"output,omitempty"`
+	Condition            *Condition   `json:"condition,omitempty"`
+	Priority             string       `json:"priority,omitempty"`
+	Exceptions           []*Exception `json:"exceptions,omitempty"`
+	MinimumEngineVersion *int         `json:"minimumEngineVersion,omitempty"`
 
 	RuleType string `json:"ruleType"`
 }

--- a/sysdig/resource_sysdig_secure_macro.go
+++ b/sysdig/resource_sysdig_secure_macro.go
@@ -2,9 +2,10 @@ package sysdig
 
 import (
 	"context"
-	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"strconv"
 	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -43,6 +44,10 @@ func resourceSysdigSecureMacro() *schema.Resource {
 			"condition": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"minimum_engine_version": {
+				Type:     schema.TypeInt,
+				Optional: true,
 			},
 			"version": {
 				Type:     schema.TypeInt,
@@ -110,6 +115,9 @@ func resourceSysdigMacroRead(ctx context.Context, d *schema.ResourceData, meta i
 	_ = d.Set("version", macro.Version)
 	_ = d.Set("condition", macro.Condition.Condition)
 	_ = d.Set("append", macro.Append)
+	if macro.MinimumEngineVersion != nil {
+		_ = d.Set("minimum_engine_version", *macro.MinimumEngineVersion)
+	}
 
 	return nil
 }
@@ -130,9 +138,15 @@ func resourceSysdigMacroDelete(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func macroFromResourceData(d *schema.ResourceData) v2.Macro {
-	return v2.Macro{
+	macro := v2.Macro{
 		Name:      d.Get("name").(string),
 		Append:    d.Get("append").(bool),
 		Condition: v2.MacroCondition{Condition: d.Get("condition").(string)},
 	}
+	minimumEngineVersionInterface, ok := d.GetOk("minimum_engine_version")
+	if ok {
+		minimumEngineVersion := minimumEngineVersionInterface.(int)
+		macro.MinimumEngineVersion = &minimumEngineVersion
+	}
+	return macro
 }

--- a/sysdig/resource_sysdig_secure_macro_test.go
+++ b/sysdig/resource_sysdig_secure_macro_test.go
@@ -48,6 +48,9 @@ func TestAccMacro(t *testing.T) {
 			{
 				Config: macroWithMacroAndList(rText(), rText(), rText()),
 			},
+			{
+				Config: macroWithMinimumEngineVersion(rText()),
+			},
 		},
 	})
 }
@@ -108,4 +111,14 @@ resource "sysdig_secure_macro" "sample6" {
   condition = "never_true and ${sysdig_secure_macro.sample5.name}"
 }
 `, listWithName(name3), name1, name2)
+}
+
+func macroWithMinimumEngineVersion(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_macro" "sample" {
+	minimum_engine_version = 13
+	name = "terraform_test_%s"
+	condition = "always_true"
+  }
+`, name)
 }

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -60,6 +60,10 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 				Default:          "",
 				ValidateDiagFunc: validateDiagFunc(validateFalcoRuleSource),
 			},
+			"minimum_engine_version": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"append": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -147,6 +151,9 @@ func resourceSysdigRuleFalcoRead(ctx context.Context, d *schema.ResourceData, me
 	_ = d.Set("output", rule.Details.Output)
 	_ = d.Set("priority", strings.ToLower(rule.Details.Priority))
 	_ = d.Set("source", rule.Details.Source)
+	if rule.Details.MinimumEngineVersion != nil {
+		_ = d.Set("minimum_engine_version", *rule.Details.MinimumEngineVersion)
+	}
 	if rule.Details.Append != nil {
 		_ = d.Set("append", *rule.Details.Append)
 	}
@@ -270,6 +277,12 @@ func resourceSysdigRuleFalcoFromResourceData(d *schema.ResourceData) (v2.Rule, e
 		rule.Details.Priority = priority.(string)
 	} else if !appendModeIsSet || !(appendMode.(bool)) {
 		return v2.Rule{}, errors.New("priority must be set when append = false")
+	}
+
+	minimumEngineVersionInterface, ok := d.GetOk("minimum_engine_version")
+	if ok {
+		minimumEngineVersion := minimumEngineVersionInterface.(int)
+		rule.Details.MinimumEngineVersion = &minimumEngineVersion
 	}
 
 	rule.Details.Condition = &v2.Condition{

--- a/website/docs/d/secure_rule_falco.md
+++ b/website/docs/d/secure_rule_falco.md
@@ -40,6 +40,7 @@ In addition to the argument above, the following attributes are exported:
 * `priority` - The priority of the Falco rule. It can be: "emergency", "alert", "critical", "error", "warning", "notice", "info" or "debug". By default is "warning".
 * `exceptions` - The exceptions key is a list of identifier plus list of tuples of filtercheck fields. See below for details.
 * `append` - This indicates that the rule being created appends the condition to an existing Sysdig-provided rule
+* `minimum_engine_version` - This is used to indicate that the rule requires a minimum engine version.
 * `version` - Current version of the resource in Sysdig Secure.
 
 ### Exceptions

--- a/website/docs/r/secure_macro.md
+++ b/website/docs/r/secure_macro.md
@@ -37,6 +37,11 @@ resource "sysdig_secure_macro" "https_port" {
     The macros can only be extended once, for example if there is an existing macro called "foo", one can have another 
     append macro called "foo" but not a second one. By default this is false.
 
+* `minimum_engine_version` - (Optional) This is used to indicate that the macro requires a minimum engine version. This
+    can allow you to add macros that would not normally pass validation with older agents in your environment. The macro
+    will only be processed by agents that support the minimum_engine_version specified.
+
+
 ## Attributes Reference
 
 No additional attributes are exported.

--- a/website/docs/r/secure_rule_falco.md
+++ b/website/docs/r/secure_rule_falco.md
@@ -66,7 +66,11 @@ The following arguments are supported:
 * `priority` - (Optional) The priority of the Falco rule. It can be: "emergency", "alert", "critical", "error", "warning", "notice", "info" or "debug". By default is "warning".
 * `source` - (Optional) The source of the event. It can be either "syscall", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", or "azure_platformlogs". Required if append is false.
 * `exceptions` - (Optional) The exceptions key is a list of identifier plus list of tuples of filtercheck fields. See below for details.
-* `append` - (Optional) This indicates that the rule being created appends the condition to an existing Sysdig-provided rule. By default this is false. Appending to user-created rules is not supported by the API.
+* `append` - (Optional) This indicates that the rule being created appends the condition to an existing Sysdig-provided
+  rule. By default this is false. Appending to user-created rules is not supported by the API.
+* `minimum_engine_version` - (Optional) This is used to indicate that the rule requires a minimum engine version. This
+    can allow you to add rules that would not normally pass validation with older agents in your environment. The rule
+    will only be processed by agents that support the minimum_engine_version specified.
 
 ### Exceptions
 


### PR DESCRIPTION
This PR:

* adds the `minimum_engine_version` argument to the falco_rule and macro resource
* adds the `minimum_engine_version` attribute to the falco_rule data source.


<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->