### PR TITLE
feat(teams): allow ibm metrics on sysdig token

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -42,7 +42,7 @@ testacc: fmtcheck
 
 junit-report: fmtcheck
 	@go install github.com/jstemmer/go-junit-report/v2@latest
-	CGO_ENABLED=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -tags=$(TEST_SUITE) -timeout 120m -race -parallel=1 2>&1 | tee output.txt
+	CGO_ENABLED=1 TF_ACC=1 TF_LOG=DEBUG go test $(TEST) -v $(TESTARGS) -tags=$(TEST_SUITE) -timeout 120m -race -parallel=1 2>&1 | tee output.txt
 	! grep -q "\[build failed\]" output.txt
 	go-junit-report -in output.txt -out junit-report.xml
 

--- a/sysdig/resource_sysdig_monitor_team.go
+++ b/sysdig/resource_sysdig_monitor_team.go
@@ -193,9 +193,7 @@ func resourceSysdigMonitorTeamRead(ctx context.Context, d *schema.ResourceData, 
 	_ = d.Set("user_roles", userMonitorRolesToSet(t.UserRoles))
 	_ = d.Set("entrypoint", entrypointToSet(t.EntryPoint))
 
-	if clients.GetClientType() == IBMMonitor {
-		resourceSysdigTeamReadIBM(d, &t)
-	}
+	resourceSysdigTeamReadIBM(d, &t)
 
 	return nil
 }
@@ -298,9 +296,7 @@ func teamFromResourceData(d *schema.ResourceData, clientType ClientType) v2.Team
 		t.EntryPoint.Selection = val.(string)
 	}
 
-	if clientType == IBMMonitor {
-		teamFromResourceDataIBM(d, &t)
-	}
+	teamFromResourceDataIBM(d, &t)
 
 	return t
 }

--- a/sysdig/resource_sysdig_secure_team.go
+++ b/sysdig/resource_sysdig_secure_team.go
@@ -202,9 +202,7 @@ func resourceSysdigSecureTeamRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	if clients.GetClientType() == IBMSecure {
-		resourceSysdigTeamReadIBM(d, &t)
-	}
+	resourceSysdigTeamReadIBM(d, &t)
 
 	return nil
 }
@@ -292,9 +290,7 @@ func secureTeamFromResourceData(d *schema.ResourceData, clientType ClientType) v
 		t.ZoneIDs[i] = z.(int)
 	}
 
-	if clientType == IBMSecure {
-		teamFromResourceDataIBM(d, &t)
-	}
+	teamFromResourceDataIBM(d, &t)
 
 	return t
 }


### PR DESCRIPTION
This PR includes:
- allow teams on IBM to create platform metrics regardless of auth method used
- add debug logs for command used by Jenkins
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->