### PR TITLE
feat(teams) Add custom role data source

### DIFF
--- a/sysdig/data_source_sysdig_custom_role.go
+++ b/sysdig/data_source_sysdig_custom_role.go
@@ -1,0 +1,63 @@
+package sysdig
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func dataSourceSysdigCustomRole() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		ReadContext: dataSourceSysdigCustomRoleRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"monitor_permissions": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secure_permissions": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSysdigCustomRoleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client, err := m.(SysdigClients).sysdigCommonClientV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name := d.Get("name").(string)
+
+	customRole, err := client.GetCustomRoleByName(ctx, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(strconv.Itoa(customRole.ID))
+	_ = d.Set("name", customRole.Name)
+	_ = d.Set("description", customRole.Description)
+	_ = d.Set("monitor_permissions", strings.Join(customRole.MonitorPermissions, ","))
+	_ = d.Set("secure_permissions", strings.Join(customRole.SecurePermissions, ","))
+
+	return nil
+}

--- a/sysdig/data_source_sysdig_custom_role.go
+++ b/sysdig/data_source_sysdig_custom_role.go
@@ -5,7 +5,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -29,12 +28,18 @@ func dataSourceSysdigCustomRole() *schema.Resource {
 				Computed: true,
 			},
 			"monitor_permissions": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeSet,
 				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			"secure_permissions": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeSet,
 				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 		},
 	}
@@ -56,8 +61,8 @@ func dataSourceSysdigCustomRoleRead(ctx context.Context, d *schema.ResourceData,
 	d.SetId(strconv.Itoa(customRole.ID))
 	_ = d.Set("name", customRole.Name)
 	_ = d.Set("description", customRole.Description)
-	_ = d.Set("monitor_permissions", strings.Join(customRole.MonitorPermissions, ","))
-	_ = d.Set("secure_permissions", strings.Join(customRole.SecurePermissions, ","))
+	_ = d.Set("monitor_permissions", customRole.MonitorPermissions)
+	_ = d.Set("secure_permissions", customRole.SecurePermissions)
 
 	return nil
 }

--- a/sysdig/data_source_sysdig_custom_role_test.go
+++ b/sysdig/data_source_sysdig_custom_role_test.go
@@ -1,0 +1,54 @@
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+
+package sysdig_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccCustomRoleDateSource(t *testing.T) {
+	rText := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: preCheckAnyEnv(t, SysdigMonitorApiTokenEnv, SysdigSecureApiTokenEnv),
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: getCustomRole(rText),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckTypeSetElemAttr("data.sysdig_custom_role.custom", "monitor_permissions.*", "token.view"),
+					resource.TestCheckTypeSetElemAttr("data.sysdig_custom_role.custom", "monitor_permissions.*", "api-token.read"),
+					resource.TestCheckResourceAttr("data.sysdig_custom_role.custom", "secure_permissions.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func getCustomRole(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_custom_role" "test" {
+  name = "%s"
+  description = "test"
+
+  permissions {
+    monitor_permissions = ["token.view", "api-token.read"]
+  }
+}
+data "sysdig_custom_role" "custom" {
+  depends_on = [sysdig_custom_role.test]
+  name = sysdig_custom_role.test.name
+}
+`, name)
+}

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -174,6 +174,7 @@ func Provider() *schema.Provider {
 			"sysdig_current_user":      dataSourceSysdigCurrentUser(),
 			"sysdig_user":              dataSourceSysdigUser(),
 			"sysdig_secure_connection": dataSourceSysdigSecureConnection(),
+			"sysdig_custom_role":       dataSourceSysdigCustomRole(),
 
 			"sysdig_fargate_workload_agent":                 dataSourceSysdigFargateWorkloadAgent(),
 			"sysdig_monitor_notification_channel_pagerduty": dataSourceSysdigMonitorNotificationChannelPagerduty(),

--- a/website/docs/d/custom_role.md
+++ b/website/docs/d/custom_role.md
@@ -1,0 +1,35 @@
+---
+subcategory: "Sysdig Platform"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_custom_role"
+description: |-
+  Retrieves information about a custom role from the name
+---
+
+# Data Source: sysdig_custom_role
+
+Retrieves information about a custom role from the name
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+data "sysdig_custom_role" "custom_role" {
+  name = "CustomRoleName"
+}
+```
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The custom role's ID.
+
+* `name` - The custom role's name.
+
+* `description` - The custom role's description.
+
+* `monitor_permissions` - The custom role's monitor permissions.
+
+* `secure_permissions` - The custom role's secure permissions.


### PR DESCRIPTION
This is first PR in order to add tthe ability to assign custom roles to users in teams

Changes made in the PR:
- Add custom role data source
- Add documentation

Tests are missing and will be added in a later stage, when we introduce the custom role resource.
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->