### PR TITLE
[SSPROD-27032] Negate block_inboud and block_outbound tags for network rules

### DIFF
--- a/sysdig/data_source_sysdig_secure_rule_network.go
+++ b/sysdig/data_source_sysdig_secure_rule_network.go
@@ -76,8 +76,8 @@ func dataSourceSysdigRuleNetworkRead(ctx context.Context, d *schema.ResourceData
 }
 
 func networkRuleDataSourceToResourceData(rule v2.Rule, d *schema.ResourceData) diag.Diagnostics {
-	_ = d.Set("block_inbound", rule.Details.AllInbound)
-	_ = d.Set("block_outbound", rule.Details.AllOutbound)
+	_ = d.Set("block_inbound", !rule.Details.AllInbound)
+	_ = d.Set("block_outbound", !rule.Details.AllOutbound)
 
 	if rule.Details.TCPListenPorts == nil {
 		return diag.Errorf("no tcpListenPorts for a network rule")

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -125,8 +125,8 @@ func resourceSysdigRuleNetworkRead(ctx context.Context, d *schema.ResourceData, 
 	}
 	updateResourceDataForRule(d, rule)
 
-	_ = d.Set("block_inbound", rule.Details.AllInbound)
-	_ = d.Set("block_outbound", rule.Details.AllOutbound)
+	_ = d.Set("block_inbound", !rule.Details.AllInbound)
+	_ = d.Set("block_outbound", !rule.Details.AllOutbound)
 
 	if rule.Details.TCPListenPorts == nil {
 		return diag.Errorf("no tcpListenPorts for a filesystem rule")
@@ -216,8 +216,8 @@ func resourceSysdigRuleNetworkFromResourceData(d *schema.ResourceData) (rule v2.
 	rule.Details.TCPListenPorts = &v2.TCPListenPorts{}
 	rule.Details.UDPListenPorts = &v2.UDPListenPorts{}
 
-	rule.Details.AllInbound = d.Get("block_inbound").(bool)
-	rule.Details.AllOutbound = d.Get("block_outbound").(bool)
+	rule.Details.AllInbound = !d.Get("block_inbound").(bool)
+	rule.Details.AllOutbound = !d.Get("block_outbound").(bool)
 
 	rule.Details.TCPListenPorts.Items = []string{}
 	if tcpRules := d.Get("tcp").([]interface{}); len(tcpRules) > 0 {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->