### PR TITLE
feat (team service account)  Manage Team Based Service Account as Terraform resource

### DIFF
--- a/sysdig/common.go
+++ b/sysdig/common.go
@@ -2,6 +2,7 @@ package sysdig
 
 const (
 	SchemaIDKey             = "id"
+	SchemaTeamIDKey         = "team_id"
 	SchemaPoliciesKey       = "policies"
 	SchemaPolicyIDsKey      = "policy_ids"
 	SchemaNameKey           = "name"
@@ -14,7 +15,9 @@ const (
 	SchemaAuthorKey         = "author"
 	SchemaLastModifiedBy    = "last_modified_by"
 	SchemaLastUpdated       = "last_updated"
+	SchemaExpirationDateKey = "expiration_date"
 	SchemaPublishedDateKey  = "published_date"
+	SchemaCreatedDateKey    = "date_created"
 	SchemaMinKubeVersionKey = "min_kube_version"
 	SchemaMaxKubeVersionKey = "max_kube_version"
 	SchemaIsCustomKey       = "is_custom"
@@ -26,5 +29,8 @@ const (
 	SchemaScopeKey          = "scope"
 	SchemaScopesKey         = "scopes"
 	SchemaTargetTypeKey     = "target_type"
+	SchemaRoleKey           = "role"
+	SchemaSystemRoleKey     = "system_role"
 	SchemaRulesKey          = "rules"
+	SchemaApiKeyKey         = "api_key"
 )

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -38,6 +38,17 @@ type UserRoles struct {
 	Admin  bool   `json:"admin,omitempty"`
 }
 
+type TeamServiceAccount struct {
+	ID             int    `json:"id,omitempty"`
+	Name           string `json:"name"`
+	SystemRole     string `json:"systemRole"`
+	TeamId         int    `json:"teamId"`
+	TeamRole       string `json:"teamRole"`
+	DateCreated    int64  `json:"dateCreated,omitempty"`
+	ExpirationDate int64  `json:"expirationDate"`
+	ApiKey         string `json:"apiKey,omitempty"`
+}
+
 type EntryPoint struct {
 	Module    string `json:"module"`
 	Selection string `json:"selection,omitempty"`

--- a/sysdig/internal/client/v2/sysdig.go
+++ b/sysdig/internal/client/v2/sysdig.go
@@ -20,6 +20,7 @@ type SysdigCommon interface {
 	Common
 	GroupMappingInterface
 	GroupMappingConfigInterface
+	TeamServiceAccountInterface
 }
 
 type SysdigMonitor interface {

--- a/sysdig/internal/client/v2/team_service_account.go
+++ b/sysdig/internal/client/v2/team_service_account.go
@@ -17,13 +17,13 @@ const (
 
 type TeamServiceAccountInterface interface {
 	Base
-	GetTeamServiceAccountById(ctx context.Context, id int) (*TeamServiceAccount, error)
+	GetTeamServiceAccountByID(ctx context.Context, id int) (*TeamServiceAccount, error)
 	CreateTeamServiceAccount(ctx context.Context, account *TeamServiceAccount) (*TeamServiceAccount, error)
 	UpdateTeamServiceAccount(ctx context.Context, account *TeamServiceAccount, id int) (*TeamServiceAccount, error)
 	DeleteTeamServiceAccount(ctx context.Context, id int) error
 }
 
-func (client *Client) GetTeamServiceAccountById(ctx context.Context, id int) (*TeamServiceAccount, error) {
+func (client *Client) GetTeamServiceAccountByID(ctx context.Context, id int) (*TeamServiceAccount, error) {
 	response, err := client.requester.Request(ctx, http.MethodGet, client.GetTeamServiceAccountURL(id), nil)
 	if err != nil {
 		return nil, err

--- a/sysdig/internal/client/v2/team_service_account.go
+++ b/sysdig/internal/client/v2/team_service_account.go
@@ -1,0 +1,123 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+var TeamServiceAccountNotFound = errors.New("group mapping not found")
+
+const (
+	ServiceAccountsPath      = "%s/api/serviceaccounts/team"
+	ServiceAccountPath       = "%s/api/serviceaccounts/team/%d"
+	ServiceAccountDeletePath = "%s/api/serviceaccounts/team/%d/delete"
+)
+
+type TeamServiceAccountInterface interface {
+	Base
+	GetTeamServiceAccountById(ctx context.Context, id int) (*TeamServiceAccount, error)
+	CreateTeamServiceAccount(ctx context.Context, account *TeamServiceAccount) (*TeamServiceAccount, error)
+	UpdateTeamServiceAccount(ctx context.Context, account *TeamServiceAccount, id int) (*TeamServiceAccount, error)
+	DeleteTeamServiceAccount(ctx context.Context, id int) error
+}
+
+func (client *Client) GetTeamServiceAccountById(ctx context.Context, id int) (*TeamServiceAccount, error) {
+	response, err := client.requester.Request(ctx, http.MethodGet, client.GetTeamServiceAccountURL(id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		if response.StatusCode == http.StatusNotFound {
+			return nil, TeamServiceAccountNotFound
+		}
+		return nil, client.ErrorFromResponse(response)
+	}
+
+	teamServiceaccount, err := Unmarshal[TeamServiceAccount](response.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &teamServiceaccount, nil
+}
+
+func (client *Client) CreateTeamServiceAccount(ctx context.Context, account *TeamServiceAccount) (*TeamServiceAccount, error) {
+	payload, err := Marshal(account)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.requester.Request(ctx, http.MethodPost, client.CreateTeamServiceAccountURL(), payload)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, client.ErrorFromResponse(response)
+	}
+
+	created, err := Unmarshal[TeamServiceAccount](response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &created, nil
+}
+
+func (client *Client) UpdateTeamServiceAccount(ctx context.Context, account *TeamServiceAccount, id int) (*TeamServiceAccount, error) {
+	payload, err := Marshal(account)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.requester.Request(ctx, http.MethodPut, client.UpdateTeamServiceAccountURL(id), payload)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, client.ErrorFromResponse(response)
+	}
+
+	updated, err := Unmarshal[TeamServiceAccount](response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updated, nil
+}
+
+func (client *Client) DeleteTeamServiceAccount(ctx context.Context, id int) error {
+	response, err := client.requester.Request(ctx, http.MethodDelete, client.DeleteTeamServiceAccountURL(id), nil)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNoContent && response.StatusCode != http.StatusOK && response.StatusCode != http.StatusNotFound {
+		return client.ErrorFromResponse(response)
+	}
+
+	return nil
+}
+
+func (client *Client) GetTeamServiceAccountURL(id int) string {
+	return fmt.Sprintf(ServiceAccountPath, client.config.url, id)
+}
+
+func (client *Client) CreateTeamServiceAccountURL() string {
+	return fmt.Sprintf(ServiceAccountsPath, client.config.url)
+}
+
+func (client *Client) UpdateTeamServiceAccountURL(id int) string {
+	return fmt.Sprintf(ServiceAccountPath, client.config.url, id)
+}
+
+func (client *Client) DeleteTeamServiceAccountURL(id int) string {
+	return fmt.Sprintf(ServiceAccountDeletePath, client.config.url, id)
+}

--- a/sysdig/internal/client/v2/team_service_account.go
+++ b/sysdig/internal/client/v2/team_service_account.go
@@ -37,11 +37,11 @@ func (client *Client) GetTeamServiceAccountById(ctx context.Context, id int) (*T
 		return nil, client.ErrorFromResponse(response)
 	}
 
-	teamServiceaccount, err := Unmarshal[TeamServiceAccount](response.Body)
+	teamServiceAccount, err := Unmarshal[TeamServiceAccount](response.Body)
 	if err != nil {
 		return nil, err
 	}
-	return &teamServiceaccount, nil
+	return &teamServiceAccount, nil
 }
 
 func (client *Client) CreateTeamServiceAccount(ctx context.Context, account *TeamServiceAccount) (*TeamServiceAccount, error) {

--- a/sysdig/internal/client/v2/team_service_account.go
+++ b/sysdig/internal/client/v2/team_service_account.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-var TeamServiceAccountNotFound = errors.New("group mapping not found")
+var TeamServiceAccountNotFound = errors.New("team service account not found")
 
 const (
 	ServiceAccountsPath      = "%s/api/serviceaccounts/team"

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -102,6 +102,7 @@ func Provider() *schema.Provider {
 			"sysdig_user":                 resourceSysdigUser(),
 			"sysdig_group_mapping":        resourceSysdigGroupMapping(),
 			"sysdig_group_mapping_config": resourceSysdigGroupMappingConfig(),
+			"sysdig_team_service_account": resourceSysdigTeamServiceAccount(),
 
 			"sysdig_secure_custom_policy":                  resourceSysdigSecureCustomPolicy(),
 			"sysdig_secure_managed_policy":                 resourceSysdigSecureManagedPolicy(),

--- a/sysdig/resource_sysdig_team_service_account.go
+++ b/sysdig/resource_sysdig_team_service_account.go
@@ -26,33 +26,33 @@ func resourceSysdigTeamServiceAccount() *schema.Resource {
 			Delete: schema.DefaultTimeout(timeout),
 		},
 		Schema: map[string]*schema.Schema{
-			"name": {
+			SchemaNameKey: {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"role": {
+			SchemaRoleKey: {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "ROLE_TEAM_READ",
 			},
-			"expiration_date": {
+			SchemaExpirationDateKey: {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
-			"team_id": {
+			SchemaTeamIDKey: {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
-			"system_role": {
+			SchemaSystemRoleKey: {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "ROLE_SERVICE_ACCOUNT",
 			},
-			"date_created": {
+			SchemaCreatedDateKey: {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"api_key": {
+			SchemaApiKeyKey: {
 				Type:      schema.TypeString,
 				Computed:  true,
 				Sensitive: true,

--- a/sysdig/resource_sysdig_team_service_account.go
+++ b/sysdig/resource_sysdig_team_service_account.go
@@ -72,7 +72,7 @@ func resourceSysdigTeamServiceAccountRead(ctx context.Context, d *schema.Resourc
 		diag.FromErr(err)
 	}
 
-	teamServiceAccount, err := client.GetTeamServiceAccountById(ctx, id)
+	teamServiceAccount, err := client.GetTeamServiceAccountByID(ctx, id)
 	if err != nil {
 		if err == v2.TeamServiceAccountNotFound {
 			d.SetId("")

--- a/sysdig/resource_sysdig_team_service_account.go
+++ b/sysdig/resource_sysdig_team_service_account.go
@@ -1,0 +1,197 @@
+package sysdig
+
+import (
+	"context"
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"strconv"
+	"time"
+)
+
+func resourceSysdigTeamServiceAccount() *schema.Resource {
+	timeout := 5 * time.Minute
+	return &schema.Resource{
+		ReadContext:   resourceSysdigTeamServiceAccountRead,
+		CreateContext: resourceSysdigTeamServiceAccountCreate,
+		UpdateContext: resourceSysdigTeamServiceAccountUpdate,
+		DeleteContext: resourceSysdigTeamServiceAccountDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"role": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "ROLE_TEAM_READ",
+			},
+			"expiration_date": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"team_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"system_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "ROLE_SERVICE_ACCOUNT",
+			},
+			"date_created": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"api_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSysdigTeamServiceAccountRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client, err := m.(SysdigClients).sysdigCommonClientV2()
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	teamServiceAccount, err := client.GetTeamServiceAccountById(ctx, id)
+	if err != nil {
+		if err == v2.TeamServiceAccountNotFound {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	err = teamServiceAccountToResourceData(teamServiceAccount, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceSysdigTeamServiceAccountCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var err error
+
+	client, err := m.(SysdigClients).sysdigCommonClientV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	teamServiceAccount := teamServiceAccountFromResourceData(d)
+	teamServiceAccount, err = client.CreateTeamServiceAccount(ctx, teamServiceAccount)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(strconv.Itoa(teamServiceAccount.ID))
+
+	resourceSysdigTeamServiceAccountRead(ctx, d, m)
+
+	return nil
+}
+
+func resourceSysdigTeamServiceAccountUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var err error
+
+	client, err := m.(SysdigClients).sysdigCommonClientV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	teamServiceAccount := teamServiceAccountFromResourceData(d)
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	teamServiceAccount.ID = id
+	_, err = client.UpdateTeamServiceAccount(ctx, teamServiceAccount, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceSysdigTeamServiceAccountRead(ctx, d, m)
+
+	return nil
+}
+
+func resourceSysdigTeamServiceAccountDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client, err := m.(SysdigClients).sysdigCommonClientV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = client.DeleteTeamServiceAccount(ctx, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func teamServiceAccountFromResourceData(d *schema.ResourceData) *v2.TeamServiceAccount {
+	return &v2.TeamServiceAccount{
+		Name:           d.Get("name").(string),
+		TeamRole:       d.Get("role").(string),
+		ExpirationDate: int64(d.Get("expiration_date").(int) * 1000),
+		TeamId:         d.Get("team_id").(int),
+		SystemRole:     d.Get("system_role").(string),
+		ApiKey:         d.Get("api_key").(string),
+	}
+}
+
+func teamServiceAccountToResourceData(teamServiceAccount *v2.TeamServiceAccount, d *schema.ResourceData) error {
+	err := d.Set("name", teamServiceAccount.Name)
+	if err != nil {
+		return err
+	}
+	err = d.Set("role", teamServiceAccount.TeamRole)
+	if err != nil {
+		return err
+	}
+	err = d.Set("expiration_date", teamServiceAccount.ExpirationDate/1000)
+	if err != nil {
+		return err
+	}
+	err = d.Set("team_id", teamServiceAccount.TeamId)
+	if err != nil {
+		return err
+	}
+	err = d.Set("system_role", teamServiceAccount.SystemRole)
+	if err != nil {
+		return err
+	}
+	err = d.Set("date_created", teamServiceAccount.DateCreated)
+	if err != nil {
+		return err
+	}
+	err = d.Set("api_key", teamServiceAccount.ApiKey)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sysdig/resource_sysdig_team_service_account.go
+++ b/sysdig/resource_sysdig_team_service_account.go
@@ -155,41 +155,41 @@ func resourceSysdigTeamServiceAccountDelete(ctx context.Context, d *schema.Resou
 
 func teamServiceAccountFromResourceData(d *schema.ResourceData) *v2.TeamServiceAccount {
 	return &v2.TeamServiceAccount{
-		Name:           d.Get("name").(string),
-		TeamRole:       d.Get("role").(string),
-		ExpirationDate: int64(d.Get("expiration_date").(int) * 1000),
-		TeamId:         d.Get("team_id").(int),
-		SystemRole:     d.Get("system_role").(string),
-		ApiKey:         d.Get("api_key").(string),
+		Name:           d.Get(SchemaNameKey).(string),
+		TeamRole:       d.Get(SchemaRoleKey).(string),
+		ExpirationDate: int64(d.Get(SchemaExpirationDateKey).(int) * 1000),
+		TeamId:         d.Get(SchemaTeamIDKey).(int),
+		SystemRole:     d.Get(SchemaSystemRoleKey).(string),
+		ApiKey:         d.Get(SchemaApiKeyKey).(string),
 	}
 }
 
 func teamServiceAccountToResourceData(teamServiceAccount *v2.TeamServiceAccount, d *schema.ResourceData) error {
-	err := d.Set("name", teamServiceAccount.Name)
+	err := d.Set(SchemaNameKey, teamServiceAccount.Name)
 	if err != nil {
 		return err
 	}
-	err = d.Set("role", teamServiceAccount.TeamRole)
+	err = d.Set(SchemaRoleKey, teamServiceAccount.TeamRole)
 	if err != nil {
 		return err
 	}
-	err = d.Set("expiration_date", teamServiceAccount.ExpirationDate/1000)
+	err = d.Set(SchemaExpirationDateKey, teamServiceAccount.ExpirationDate/1000)
 	if err != nil {
 		return err
 	}
-	err = d.Set("team_id", teamServiceAccount.TeamId)
+	err = d.Set(SchemaTeamIDKey, teamServiceAccount.TeamId)
 	if err != nil {
 		return err
 	}
-	err = d.Set("system_role", teamServiceAccount.SystemRole)
+	err = d.Set(SchemaSystemRoleKey, teamServiceAccount.SystemRole)
 	if err != nil {
 		return err
 	}
-	err = d.Set("date_created", teamServiceAccount.DateCreated)
+	err = d.Set(SchemaCreatedDateKey, teamServiceAccount.DateCreated)
 	if err != nil {
 		return err
 	}
-	err = d.Set("api_key", teamServiceAccount.ApiKey)
+	err = d.Set(SchemaApiKeyKey, teamServiceAccount.ApiKey)
 	if err != nil {
 		return err
 	}

--- a/sysdig/resource_sysdig_team_service_account.go
+++ b/sysdig/resource_sysdig_team_service_account.go
@@ -53,8 +53,9 @@ func resourceSysdigTeamServiceAccount() *schema.Resource {
 				Computed: true,
 			},
 			"api_key": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/sysdig/resource_sysdig_team_service_account_test.go
+++ b/sysdig/resource_sysdig_team_service_account_test.go
@@ -1,0 +1,65 @@
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+
+package sysdig_test
+
+import (
+	"fmt"
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"testing"
+)
+
+func TestAccTeamServiceAccount(t *testing.T) {
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: preCheckAnyEnv(t, SysdigMonitorApiTokenEnv, SysdigSecureApiTokenEnv),
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {Source: "hashicorp/time"},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: teamServiceAccount(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sysdig_team_service_account.service-account",
+						"name",
+						name,
+					),
+					resource.TestCheckResourceAttr("sysdig_team_service_account.service-account",
+						"role",
+						"ROLE_TEAM_READ",
+					),
+				),
+			},
+		},
+	})
+}
+
+func teamServiceAccount(name string) string {
+	return fmt.Sprintf(`
+resource "time_static" "example" {
+  rfc3339 = "2099-01-01T00:00:00Z"
+}
+
+resource "sysdig_monitor_team" "sample" {
+  name      = "sample-%s"
+
+  entrypoint {
+	type = "Explore"
+  }
+}
+
+resource "sysdig_team_service_account" "service-account" {
+  name = "%s"
+  expiration_date = time_static.example.unix
+  team_id = sysdig_monitor_teamt.sample.id
+}
+`, name, name)
+}

--- a/sysdig/resource_sysdig_team_service_account_test.go
+++ b/sysdig/resource_sysdig_team_service_account_test.go
@@ -59,7 +59,7 @@ resource "sysdig_monitor_team" "sample" {
 resource "sysdig_team_service_account" "service-account" {
   name = "%s"
   expiration_date = time_static.example.unix
-  team_id = sysdig_monitor_teamt.sample.id
+  team_id = sysdig_monitor_team.sample.id
 }
 `, name, name)
 }

--- a/website/docs/r/team_service_account.md
+++ b/website/docs/r/team_service_account.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Sysdig Platform"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_team_service_account"
+description: |-
+  Creates a team service account in Sysdig.
+---
+
+# Resource: sysdig_team_service_account
+
+Creates a team service account in Sysdig.
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+resource "time_static" "example" {
+  rfc3339 = "2025-01-01T00:00:00Z"
+}
+
+resource "sysdig_monitor_team" "devops" {
+  name = "Monitoring DevOps team"
+
+  entrypoint {
+    type = "Explore"
+  }
+}
+
+resource "sysdig_team_service_account" "service-account" {
+  name = "read only"
+  role = "ROLE_TEAM_READ"
+  expiration_date = time_static.example.unix
+  team_id = sysdig_monitor_teamt.sample.id
+}
+
+```
+
+## Argument Reference
+
+* `name` - (Required) The team service account name.
+
+* `role` - (Required) The role that is assigned to the service account. It can be a standard role or a custom team role ID.
+
+* `expiration_date` (Required) The service account expiration date.
+
+* `team_id` - (Required) The team where the service account belongs to.
+
+* `system_role`- The service account system role. The only value supported is `ROLE_SERVICE_ACCOUNT`
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `date_created` - The team service account creation date
+
+* `api_key` - The api key to be using in API calls
+
+## Import
+
+Sysdig team service account can be imported using the ID, e.g.
+
+```
+$ terraform import sysdig_team_service_account.my_team_service_account 10
+```
+


### PR DESCRIPTION
This PR adds support for managing team service account via `sysdig_team_service_account` resource for both monitor and secure teams.
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->