### PR TITLE
feat(alerts): add keep_firing_for_minutes field

### DIFF
--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -501,7 +501,8 @@ type AlertV2Common struct {
 }
 
 type AlertV2ConfigPrometheus struct {
-	Query string `json:"query"`
+	Query            string `json:"query"`
+	KeepFiringForSec *int   `json:"keepFiringForSec,omitempty"`
 }
 
 type AlertV2Prometheus struct {

--- a/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
@@ -36,6 +36,9 @@ func TestAccAlertV2Prometheus(t *testing.T) {
 				Config: alertV2PrometheusWithGroup(rText()),
 			},
 			{
+				Config: alertV2PrometheusWithKeepFiringFor(rText()),
+			},
+			{
 				ResourceName:      "sysdig_monitor_alert_v2_prometheus.sample",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -67,6 +70,20 @@ resource "sysdig_monitor_alert_v2_prometheus" "sample" {
 	query = "(elasticsearch_jvm_memory_used_bytes{area=\"heap\"} / elasticsearch_jvm_memory_max_bytes{area=\"heap\"}) * 100 > 80"
 	trigger_after_minutes = 10
 	enabled = false
+}
+`, name, name)
+}
+
+func alertV2PrometheusWithKeepFiringFor(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_prometheus" "sample" {
+	name = "TERRAFORM TEST - PROMQL %s"
+	description = "TERRAFORM TEST - PROMQL %s"
+	severity = "high"
+	query = "(elasticsearch_jvm_memory_used_bytes{area=\"heap\"} / elasticsearch_jvm_memory_max_bytes{area=\"heap\"}) * 100 > 80"
+	trigger_after_minutes = 10
+	enabled = false
+	keep_firing_for_minutes = 10
 }
 `, name, name)
 }

--- a/website/docs/r/monitor_alert_v2_prometheus.md
+++ b/website/docs/r/monitor_alert_v2_prometheus.md
@@ -73,6 +73,7 @@ By defining this field, the user can add link to notificatons.
 ### Prometheus alert arguments
 
 * `query` - (Required) PromQL-based metric expression to alert on. Example: `histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m]) > 0.15` or `predict_linear(sysdig_fs_free_bytes{fstype!~"tmpfs"}[1h], 24*3600) < 10000000000`.
+* `keep_firing_for_minutes` - (Optional) Alert resolution delay before actually resolving an alert.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add new `keep_firing_for_minutes` field to `sysdig_monitor_alert_v2_prometheus` resource, implementing the feature "Alert Resolution Delay" described in https://docs.sysdig.com/en/docs/sysdig-monitor/alerts/alert-types/promql-alerts/#define-a-promql-alert