### PR TITLE
feat(notification channel): add new arguments to monitor slack notification channels

### DIFF
--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -109,7 +109,7 @@ type NotificationChannelOptions struct {
 	SnsTopicARNs             []string                                   `json:"snsTopicARNs,omitempty"`             // Type: SNS
 	APIKey                   string                                     `json:"apiKey,omitempty"`                   // Type: VictorOps, ibm event function
 	RoutingKey               string                                     `json:"routingKey,omitempty"`               // Type: VictorOps
-	Url                      string                                     `json:"url,omitempty"`                      // Type: OpsGenie, Webhook, Slack, google chat, prometheus alert manager, custom webhook
+	Url                      string                                     `json:"url,omitempty"`                      // Type: OpsGenie, Webhook, Slack, google chat, prometheus alert manager, custom webhook, ms teams
 	Channel                  string                                     `json:"channel,omitempty"`                  // Type: Slack
 	Account                  string                                     `json:"account,omitempty"`                  // Type: PagerDuty
 	ServiceKey               string                                     `json:"serviceKey,omitempty"`               // Type: PagerDuty
@@ -123,7 +123,7 @@ type NotificationChannelOptions struct {
 	InstanceId               string                                     `json:"instanceId,omitempty"`               // Type: ibm event notification
 	IbmFunctionType          string                                     `json:"ibmFunctionType,omitempty"`          // Type: ibm event function
 	CustomData               map[string]interface{}                     `json:"customData,omitempty"`               // Type: ibm function, Webhook
-	TemplateConfiguration    []NotificationChannelTemplateConfiguration `json:"templateConfiguration,omitempty"`
+	TemplateConfiguration    []NotificationChannelTemplateConfiguration `json:"templateConfiguration,omitempty"`    // Type: slack, ms teams
 
 	NotifyOnOk           bool `json:"notifyOnOk"`
 	NotifyOnResolve      bool `json:"notifyOnResolve"`

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack.go
@@ -39,6 +39,41 @@ func resourceSysdigMonitorNotificationChannelSlack() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"show_section_runbook_links": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"show_section_event_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"show_section_user_defined_content": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"show_section_notification_chart": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"show_section_dashboard_links": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"show_section_alert_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"show_section_capturing_information": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		}),
 	}
 }
@@ -157,6 +192,46 @@ func monitorNotificationChannelSlackFromResourceData(d *schema.ResourceData, tea
 	nc.Type = NOTIFICATION_CHANNEL_TYPE_SLACK
 	nc.Options.Url = d.Get("url").(string)
 	nc.Options.Channel = d.Get("channel").(string)
+	nc.Options.TemplateConfiguration = []v2.NotificationChannelTemplateConfiguration{
+		{
+			TemplateKey: "SLACK_MONITOR_ALERT_NOTIFICATION_TEMPLATE_METADATA_v1",
+			TemplateConfigurationSections: []v2.NotificationChannelTemplateConfigurationSection{
+				{
+					SectionName: "MONITOR_ALERT_NOTIFICATION_HEADER",
+					ShouldShow:  true,
+				},
+				{
+					SectionName: "MONITOR_ALERT_NOTIFICATION_RUNBOOK_LINKS",
+					ShouldShow:  d.Get("show_section_runbook_links").(bool),
+				},
+				{
+					SectionName: "MONITOR_ALERT_NOTIFICATION_EVENT_DETAILS",
+					ShouldShow:  d.Get("show_section_event_details").(bool),
+				},
+				{
+					SectionName: "MONITOR_ALERT_NOTIFICATION_USER_DEFINED_CONTENT",
+					ShouldShow:  d.Get("show_section_user_defined_content").(bool),
+				},
+				{
+					SectionName: "MONITOR_ALERT_NOTIFICATION_CHART",
+					ShouldShow:  d.Get("show_section_notification_chart").(bool),
+				},
+				{
+					SectionName: "MONITOR_ALERT_NOTIFICATION_DASHBOARD_LINKS",
+					ShouldShow:  d.Get("show_section_dashboard_links").(bool),
+				},
+				{
+					SectionName: "MONITOR_ALERT_NOTIFICATION_ALERT_DETAILS",
+					ShouldShow:  d.Get("show_section_alert_details").(bool),
+				},
+				{
+					SectionName: "MONITOR_ALERT_NOTIFICATION_CAPTURING_INFORMATION",
+					ShouldShow:  d.Get("show_section_capturing_information").(bool),
+				},
+			},
+		},
+	}
+
 	return
 }
 
@@ -168,6 +243,43 @@ func monitorNotificationChannelSlackToResourceData(nc *v2.NotificationChannel, d
 
 	_ = d.Set("url", nc.Options.Url)
 	_ = d.Set("channel", nc.Options.Channel)
+
+	runbookLinks := true
+	eventDetails := true
+	userDefinedContent := true
+	notificationChart := true
+	dashboardLinks := true
+	alertDetails := true
+	capturingInformation := true
+
+	if len(nc.Options.TemplateConfiguration) == 1 {
+		for _, c := range nc.Options.TemplateConfiguration[0].TemplateConfigurationSections {
+			switch c.SectionName {
+			case "MONITOR_ALERT_NOTIFICATION_RUNBOOK_LINKS":
+				runbookLinks = c.ShouldShow
+			case "MONITOR_ALERT_NOTIFICATION_EVENT_DETAILS":
+				eventDetails = c.ShouldShow
+			case "MONITOR_ALERT_NOTIFICATION_USER_DEFINED_CONTENT":
+				userDefinedContent = c.ShouldShow
+			case "MONITOR_ALERT_NOTIFICATION_CHART":
+				notificationChart = c.ShouldShow
+			case "MONITOR_ALERT_NOTIFICATION_DASHBOARD_LINKS":
+				dashboardLinks = c.ShouldShow
+			case "MONITOR_ALERT_NOTIFICATION_ALERT_DETAILS":
+				alertDetails = c.ShouldShow
+			case "MONITOR_ALERT_NOTIFICATION_CAPTURING_INFORMATION":
+				capturingInformation = c.ShouldShow
+			}
+		}
+	}
+
+	_ = d.Set("show_section_runbook_links", runbookLinks)
+	_ = d.Set("show_section_event_details", eventDetails)
+	_ = d.Set("show_section_user_defined_content", userDefinedContent)
+	_ = d.Set("show_section_notification_chart", notificationChart)
+	_ = d.Set("show_section_dashboard_links", dashboardLinks)
+	_ = d.Set("show_section_alert_details", alertDetails)
+	_ = d.Set("show_section_capturing_information", capturingInformation)
 
 	return
 }

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
@@ -35,6 +35,14 @@ func TestAccMonitorNotificationChannelSlack(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: monitorNotificationChannelSlackSharedWithShowSection(rText()),
+			},
+			{
+				ResourceName:      "sysdig_monitor_notification_channel_slack.sample-slack",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -61,5 +69,24 @@ resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
 	channel = "#sysdig"
 	notify_when_ok = true
 	notify_when_resolved = true
+}`, name)
+}
+
+func monitorNotificationChannelSlackSharedWithShowSection(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
+	name = "Example Channel %s - Slack"
+	enabled = true
+	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	channel = "#sysdig"
+	notify_when_ok = true
+	notify_when_resolved = true
+	show_section_runbook_links = false
+	show_section_event_details = false
+	show_section_user_defined_content = false
+	show_section_notification_chart = false
+	show_section_dashboard_links = false
+	show_section_alert_details = false
+	show_section_capturing_information = false
 }`, name)
 }

--- a/website/docs/r/monitor_notification_channel_slack.md
+++ b/website/docs/r/monitor_notification_channel_slack.md
@@ -31,14 +31,28 @@ resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
 
 * `url` - (Required) URL of the Slack.
 
+* `show_section_runbook_links` - (Optional) Whether to include the runbook links section in the Slack messages. Default: true.
+
+* `show_section_event_details` - (Optional) Whether to include the event details section in the Slack messages. Default: true.
+
+* `show_section_user_defined_content` - (Optional) Whether to include the user defined section in the Slack messages. Default: true.
+
+* `show_section_notification_chart` - (Optional) Whether to include the notification chart section in the Slack messages. Default: true.
+
+* `show_section_dashboard_links` - (Optional) Whether to include the dashboard links section in the Slack messages. Default: true.
+
+* `show_section_alert_details` - (Optional) Whether to include the alert details section in the Slack messages. Default: true.
+
+* `show_section_capturing_information` - (Optional) Whether to include the capturing information section in the Slack messages. Default: true.
+
 * `channel` - (Required) Channel name from this Slack.
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional) Send a new notification when the alert condition is 
+* `notify_when_ok` - (Optional) Send a new notification when the alert condition is
     no longer triggered. Default is false.
 
-* `notify_when_resolved` - (Optional) Send a new notification when the alert is manually 
+* `notify_when_resolved` - (Optional) Send a new notification when the alert is manually
     acknowledged by a user. Default is false.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check


### PR DESCRIPTION
add arguments to `sysdig_monitor_notification_channel_slack` resource to control slack messages format.