### PR TITLE
feat(alerts): add form based prometheus alert type 

### DIFF
--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -643,6 +643,27 @@ type AlertV2ConfigChange struct {
 	LongerRangeSec  int `json:"longerRangeSec"`
 }
 
+type AlertV2ConfigFormBasedPrometheus struct {
+	ScopedSegmentedConfig
+
+	Query                    string   `json:"query"`
+	ConditionOperator        string   `json:"conditionOperator"`
+	Threshold                float64  `json:"threshold"`
+	WarningConditionOperator string   `json:"warningConditionOperator,omitempty"`
+	WarningThreshold         *float64 `json:"warningThreshold,omitempty"`
+	NoDataBehaviour          string   `json:"noDataBehaviour"`
+}
+
+type AlertV2FormBasedPrometheus struct {
+	AlertV2Common
+	DurationSec int                              `json:"durationSec"` // not really used but the api wants it set to 0 in POST/PUT
+	Config      AlertV2ConfigFormBasedPrometheus `json:"config"`
+}
+
+type alertV2FormBasedPrometheusWrapper struct {
+	Alert AlertV2FormBasedPrometheus `json:"alert"`
+}
+
 type AlertV2Change struct {
 	AlertV2Common
 	DurationSec int                 `json:"durationSec"` // not really used but the api wants it set to 0 in POST/PUT

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -146,6 +146,7 @@ func Provider() *schema.Provider {
 			"sysdig_monitor_alert_v2_downtime":                             resourceSysdigMonitorAlertV2Downtime(),
 			"sysdig_monitor_alert_v2_prometheus":                           resourceSysdigMonitorAlertV2Prometheus(),
 			"sysdig_monitor_alert_v2_change":                               resourceSysdigMonitorAlertV2Change(),
+			"sysdig_monitor_alert_v2_form_based_prometheus":                resourceSysdigMonitorAlertV2FormBasedPrometheus(),
 			"sysdig_monitor_dashboard":                                     resourceSysdigMonitorDashboard(),
 			"sysdig_monitor_notification_channel_email":                    resourceSysdigMonitorNotificationChannelEmail(),
 			"sysdig_monitor_notification_channel_opsgenie":                 resourceSysdigMonitorNotificationChannelOpsGenie(),

--- a/sysdig/resource_sysdig_monitor_alert_v2_change_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_change_test.go
@@ -269,7 +269,7 @@ resource "sysdig_monitor_alert_v2_change" "sample" {
 	longer_time_range_seconds = 3600
 	link {
 		type = "runbook"
-		href = "http://ciao2.com"
+		href = "http://example.com"
 	}
 	link {
 		type = "dashboard"

--- a/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus.go
@@ -1,0 +1,229 @@
+package sysdig
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceSysdigMonitorAlertV2FormBasedPrometheus() *schema.Resource {
+
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		CreateContext: resourceSysdigMonitorAlertV2FormBasedPrometheusCreate,
+		UpdateContext: resourceSysdigMonitorAlertV2FormBasedPrometheusUpdate,
+		ReadContext:   resourceSysdigMonitorAlertV2FormBasedPrometheusRead,
+		DeleteContext: resourceSysdigMonitorAlertV2FormBasedPrometheusDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(timeout),
+			Update: schema.DefaultTimeout(timeout),
+			Read:   schema.DefaultTimeout(timeout),
+			Delete: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: createScopedSegmentedAlertV2Schema(createAlertV2Schema(map[string]*schema.Schema{
+			"operator": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{">", ">=", "<", "<=", "=", "!="}, false),
+			},
+			"threshold": {
+				Type:     schema.TypeFloat,
+				Required: true,
+			},
+			"warning_threshold": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"query": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"no_data_behaviour": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "DO_NOTHING",
+				ValidateFunc: validation.StringInSlice([]string{"DO_NOTHING", "TRIGGER"}, false),
+			},
+		})),
+	}
+}
+
+func getAlertV2FormBasedPrometheusClient(c SysdigClients) (v2.AlertV2FormBasedPrometheusInterface, error) {
+	return getAlertV2Client(c)
+}
+
+func resourceSysdigMonitorAlertV2FormBasedPrometheusCreate(ctx context.Context, d *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client, err := getAlertV2FormBasedPrometheusClient(i.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	a, err := buildAlertV2FormBasedPrometheusStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	aCreated, err := client.CreateAlertV2FormBasedPrometheus(ctx, *a)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(strconv.Itoa(aCreated.ID))
+
+	err = updateAlertV2FormBasedPrometheusState(d, &aCreated)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceSysdigMonitorAlertV2FormBasedPrometheusRead(ctx context.Context, d *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client, err := getAlertV2FormBasedPrometheusClient(i.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	a, err := client.GetAlertV2FormBasedPrometheus(ctx, id)
+	if err != nil {
+		if err == v2.AlertV2NotFound {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	err = updateAlertV2FormBasedPrometheusState(d, &a)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceSysdigMonitorAlertV2FormBasedPrometheusUpdate(ctx context.Context, d *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client, err := getAlertV2FormBasedPrometheusClient(i.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	a, err := buildAlertV2FormBasedPrometheusStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	a.ID, _ = strconv.Atoi(d.Id())
+
+	aUpdated, err := client.UpdateAlertV2FormBasedPrometheus(ctx, *a)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = updateAlertV2FormBasedPrometheusState(d, &aUpdated)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceSysdigMonitorAlertV2FormBasedPrometheusDelete(ctx context.Context, d *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client, err := getAlertV2FormBasedPrometheusClient(i.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.DeleteAlertV2FormBasedPrometheus(ctx, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func buildAlertV2FormBasedPrometheusStruct(d *schema.ResourceData) (*v2.AlertV2FormBasedPrometheus, error) {
+	alertV2Common := buildAlertV2CommonStruct(d)
+	alertV2Common.Type = string(v2.AlertV2TypeFormBasedPrometheus)
+	config := v2.AlertV2ConfigFormBasedPrometheus{}
+
+	buildScopedSegmentedConfigStruct(d, &config.ScopedSegmentedConfig)
+
+	//ConditionOperator
+	config.ConditionOperator = d.Get("operator").(string)
+
+	//threshold
+	config.Threshold = d.Get("threshold").(float64)
+
+	//WarningThreshold
+	if warningThreshold, ok := d.GetOk("warning_threshold"); ok {
+		wts := warningThreshold.(string)
+		wt, err := strconv.ParseFloat(wts, 64)
+		if err != nil {
+			return nil, fmt.Errorf("cannot convert warning_threshold to a number: %w", err)
+		}
+		config.WarningThreshold = &wt
+		config.WarningConditionOperator = config.ConditionOperator
+	}
+
+	//Query
+	config.Query = d.Get("query").(string)
+
+	config.NoDataBehaviour = d.Get("no_data_behaviour").(string)
+
+	alert := &v2.AlertV2FormBasedPrometheus{
+		AlertV2Common: *alertV2Common,
+		DurationSec:   0,
+		Config:        config,
+	}
+	return alert, nil
+}
+
+func updateAlertV2FormBasedPrometheusState(d *schema.ResourceData, alert *v2.AlertV2FormBasedPrometheus) error {
+	err := updateAlertV2CommonState(d, &alert.AlertV2Common)
+	if err != nil {
+		return err
+	}
+
+	err = updateScopedSegmentedConfigState(d, &alert.Config.ScopedSegmentedConfig)
+	if err != nil {
+		return err
+	}
+
+	_ = d.Set("operator", alert.Config.ConditionOperator)
+
+	_ = d.Set("threshold", alert.Config.Threshold)
+
+	if alert.Config.WarningThreshold != nil {
+		_ = d.Set("warning_threshold", fmt.Sprintf("%v", *alert.Config.WarningThreshold))
+	}
+
+	_ = d.Set("query", alert.Config.Query)
+
+	_ = d.Set("no_data_behaviour", alert.Config.NoDataBehaviour)
+
+	return nil
+}

--- a/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus_test.go
@@ -1,0 +1,264 @@
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+
+package sysdig_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccAlertV2FormBasedPrometheusTest(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: preCheckAnyEnv(t, SysdigMonitorApiTokenEnv, SysdigIBMMonitorAPIKeyEnv),
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: alertV2FormBasedPrometheusTest(rText()),
+			},
+			{
+				Config: alertV2FormBasedPrometheusTestWithNoData(rText()),
+			},
+			{
+				Config: alertV2FormBasedPrometheusTestWithNotificationChannels(rText()),
+			},
+			{
+				Config: alertV2FormBasedPrometheusTestWithDescription(rText()),
+			},
+			{
+				Config: alertV2FormBasedPrometheusTestWithSeverity(rText()),
+			},
+			{
+				Config: alertV2FormBasedPrometheusTestWithGroup(rText()),
+			},
+			{
+				Config: alertV2FormBasedPrometheusTestWithCustomNotifications(rText()),
+			},
+			{
+				Config: alertV2FormBasedPrometheusTestWithLink(rText()),
+			},
+			{
+				Config: alertV2FormBasedPrometheusTestWithEnabled(rText()),
+			},
+			{
+				Config: alertV2FormBasedPrometheusTestWithWarningThreshold(rText()),
+			},
+			{
+				ResourceName:      "sysdig_monitor_alert_v2_form_based_prometheus.sample",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func alertV2FormBasedPrometheusTest(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+}
+`, name)
+}
+
+func alertV2FormBasedPrometheusTestWithNoData(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+	no_data_behaviour = "TRIGGER"
+}
+`, name)
+}
+
+func alertV2FormBasedPrometheusTestWithNotificationChannels(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_notification_channel_email" "nc_email_1" {
+	name = "%s1"
+	recipients = ["root@localhost.com"]
+}
+
+resource "sysdig_monitor_notification_channel_email" "nc_email_2" {
+	name = "%s2"
+	recipients = ["root@localhost.com"]
+}
+
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+	enabled = false
+	notification_channels {
+		id = sysdig_monitor_notification_channel_email.nc_email_1.id
+		notify_on_resolve = false
+	}
+	notification_channels {
+		id = sysdig_monitor_notification_channel_email.nc_email_2.id
+		renotify_every_minutes = 30
+	}
+}
+`, name, name, name)
+}
+
+func alertV2FormBasedPrometheusTestWithDescription(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+	description = "description"
+}
+`, name)
+}
+
+func alertV2FormBasedPrometheusTestWithSeverity(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+	severity = "high"
+}
+`, name)
+}
+
+func alertV2FormBasedPrometheusTestWithGroup(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+	group = "customgroup"
+}
+`, name)
+}
+
+func alertV2FormBasedPrometheusTestWithCustomNotifications(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+	custom_notification {
+		subject = "test"
+		prepend = "pre"
+		append = "post"
+	}
+}
+`, name)
+}
+
+func alertV2FormBasedPrometheusTestWithLink(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_dashboard" "dashboard_1" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	description = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	panel {
+		pos_x = 0
+		pos_y = 0
+		width = 12 # Maximum size: 24
+		height = 6
+		type = "timechart"
+		name = "example panel"
+		description = "description"
+
+        legend {
+            show_current = true
+            position = "bottom"
+            layout = "inline"
+        }
+
+		query {
+			promql = "avg(avg_over_time(sysdig_host_cpu_used_percent[$__interval]))"
+			unit = "percent"
+
+            format {
+                display_format = "auto"
+                input_format = "0-100"
+                y_axis = "auto"
+                null_value_display_mode = "nullGap"
+            }
+		}
+	}
+}
+
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+	link {
+		type = "runbook"
+		href = "http://example.com"
+	}
+	link {
+		type = "dashboard"
+		id = sysdig_monitor_dashboard.dashboard_1.id
+	}
+}
+`, name, name, name)
+}
+
+func alertV2FormBasedPrometheusTestWithEnabled(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+	enabled = false
+}
+`, name)
+}
+
+func alertV2FormBasedPrometheusTestWithWarningThreshold(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_notification_channel_email" "nc_email_3" {
+	name = "%s3"
+	recipients = ["root@localhost.com"]
+}
+
+resource "sysdig_monitor_notification_channel_email" "nc_email_4" {
+	name = "%s4"
+	recipients = ["root@localhost.com"]
+}
+
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{}[59s])"
+	operator = ">="
+	threshold = 50
+	enabled = false
+	warning_threshold = 10
+	notification_channels {
+		id = sysdig_monitor_notification_channel_email.nc_email_3.id
+	}
+	notification_channels {
+		id = sysdig_monitor_notification_channel_email.nc_email_4.id
+		warning_threshold = true
+	}
+}
+`, name, name, name)
+}

--- a/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
@@ -317,7 +317,7 @@ resource "sysdig_monitor_alert_v2_metric" "sample" {
 	trigger_after_minutes = 15
 	link {
 		type = "runbook"
-		href = "http://ciao2.com"
+		href = "http://example.com"
 	}
 	link {
 		type = "dashboard"

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -248,6 +248,7 @@ When IBM Workload Protection resources are to be created, this authentication mu
 > - `sysdig_monitor_alert_v2_metric`
 > - `sysdig_monitor_alert_v2_prometheus`
 > - `sysdig_monitor_alert_v2_change`
+> - `sysdig_monitor_alert_v2_form_based_prometheus`
 > - `sysdig_monitor_dashboard`
 > - `sysdig_secure_posture_zone`
 >

--- a/website/docs/r/monitor_alert_v2_event.md
+++ b/website/docs/r/monitor_alert_v2_event.md
@@ -110,7 +110,7 @@ Enables the creation of a capture file of the syscalls during the event.
 * `group_by` - (Optional) List of segments to trigger a separate alert on. Example: `["kube_cluster_name", "kube_pod_name"]`.
 * `operator` - (Required) Condition operator of the event count. It can be `>`, `>=`, `<`, `<=`, `=` or `!=`.
 * `threshold` - (Required) Number of events to match with `op`.
-* `warning_threshold` - (Optional) Number of events to match with `op` to trigger a warning alert. Must be a number lower than `threshold`.
+* `warning_threshold` - (Optional) Warning threshold used together with `op` to trigger the alert if crossed. Must be a number that triggers the alert before reaching the main `threshold`.
 * `filter` - (Required) String that matches part of name, tag or the description of Sysdig Events.
 * `sources` - (Required) List of sources of the event. It can be `kubernetes`, `containerd`, `docker` or arbitrary custom sources.
 

--- a/website/docs/r/monitor_alert_v2_metric.md
+++ b/website/docs/r/monitor_alert_v2_metric.md
@@ -111,7 +111,7 @@ Enables the creation of a capture file of the syscalls during the event.
 * `group_aggregation` - (Required) group aggregation function for data. It can be `avg`, `sum`, `min`, `max`.
 * `operator` - (Required) Operator for the condition to alert on. It can be `>`, `>=`, `<`, `<=`, `=` or `!=`.
 * `threshold` - (Required) Threshold used together with `op` to trigger the alert if crossed.
-* `warning_threshold` - (Optional) Warning threshold used together with `op` to trigger the alert if crossed. Must be a number lower than `threshold`.
+* `warning_threshold` - (Optional) Warning threshold used together with `op` to trigger the alert if crossed. Must be a number that triggers the alert before reaching the main `threshold`.
 * `no_data_behaviour` - (Optional) behaviour in case of missing data. Can be `DO_NOTHING`, i.e. ignore, or `TRIGGER`, i.e. notify on main threshold. Default: `DO_NOTHING`.
 
 ### `scope`

--- a/website/docs/r/monitor_alert_v2_prometheus.md
+++ b/website/docs/r/monitor_alert_v2_prometheus.md
@@ -44,7 +44,7 @@ These arguments are common to all alerts in Sysdig Monitor.
 * `custom_notification` - (Optional) Allows to define a custom notification title, prepend and append text.
 * `link` - (Optional) List of links to add to notifications.
 
-### `notification_channels` -
+### `notification_channels`
 
 By defining this field, the user can choose to which notification channels send the events when the alert fires.
 


### PR DESCRIPTION
add new alert type: `sysdig_monitor_alert_v2_form_based_prometheus`, implementing the feature described in https://docs.sysdig.com/en/docs/sysdig-monitor/alerts/alert-types/metric-alerts/#translate-to-promql.