### PR TITLE
feat(secure-rule, secure-policy) use status code to determine if resource needs to be recreated

### DIFF
--- a/sysdig/internal/client/v2/rules.go
+++ b/sysdig/internal/client/v2/rules.go
@@ -18,7 +18,7 @@ const (
 type RuleInterface interface {
 	Base
 	CreateRule(ctx context.Context, rule Rule) (Rule, error)
-	GetRuleByID(ctx context.Context, ruleID int) (Rule, error, int)
+	GetRuleByID(ctx context.Context, ruleID int) (Rule, int, error)
 	UpdateRule(ctx context.Context, rule Rule) (Rule, error)
 	DeleteRule(ctx context.Context, ruleID int) error
 	GetRuleGroup(ctx context.Context, ruleName string, ruleType string) ([]Rule, error)
@@ -43,19 +43,19 @@ func (client *Client) CreateRule(ctx context.Context, rule Rule) (Rule, error) {
 	return Unmarshal[Rule](response.Body)
 }
 
-func (client *Client) GetRuleByID(ctx context.Context, ruleID int) (Rule, error, int) {
+func (client *Client) GetRuleByID(ctx context.Context, ruleID int) (Rule, int, error) {
 	response, err := client.requester.Request(ctx, http.MethodGet, client.GetRuleByIDURL(ruleID), nil)
 	if err != nil {
-		return Rule{}, err, 0
+		return Rule{}, 0, err
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return Rule{}, client.ErrorFromResponse(response), response.StatusCode
+		return Rule{}, response.StatusCode, client.ErrorFromResponse(response)
 	}
 
 	rule, err := Unmarshal[Rule](response.Body)
-	return rule, err, 0
+	return rule, 0, err
 }
 
 func (client *Client) UpdateRule(ctx context.Context, rule Rule) (Rule, error) {

--- a/sysdig/internal/client/v2/rules.go
+++ b/sysdig/internal/client/v2/rules.go
@@ -18,7 +18,7 @@ const (
 type RuleInterface interface {
 	Base
 	CreateRule(ctx context.Context, rule Rule) (Rule, error)
-	GetRuleByID(ctx context.Context, ruleID int) (Rule, error)
+	GetRuleByID(ctx context.Context, ruleID int) (Rule, error, int)
 	UpdateRule(ctx context.Context, rule Rule) (Rule, error)
 	DeleteRule(ctx context.Context, ruleID int) error
 	GetRuleGroup(ctx context.Context, ruleName string, ruleType string) ([]Rule, error)
@@ -43,18 +43,19 @@ func (client *Client) CreateRule(ctx context.Context, rule Rule) (Rule, error) {
 	return Unmarshal[Rule](response.Body)
 }
 
-func (client *Client) GetRuleByID(ctx context.Context, ruleID int) (Rule, error) {
+func (client *Client) GetRuleByID(ctx context.Context, ruleID int) (Rule, error, int) {
 	response, err := client.requester.Request(ctx, http.MethodGet, client.GetRuleByIDURL(ruleID), nil)
 	if err != nil {
-		return Rule{}, err
+		return Rule{}, err, 0
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return Rule{}, client.ErrorFromResponse(response)
+		return Rule{}, client.ErrorFromResponse(response), response.StatusCode
 	}
 
-	return Unmarshal[Rule](response.Body)
+	rule, err := Unmarshal[Rule](response.Body)
+	return rule, err, 0
 }
 
 func (client *Client) UpdateRule(ctx context.Context, rule Rule) (Rule, error) {

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -141,8 +141,9 @@ func resourceSysdigCustomPolicyRead(ctx context.Context, d *schema.ResourceData,
 	policy, statusCode, err := client.GetPolicyByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
 		if statusCode == http.StatusNotFound {
+			d.SetId("")
+		} else {
 			return diag.FromErr(err)
 		}
 	}

--- a/sysdig/resource_sysdig_secure_managed_policy.go
+++ b/sysdig/resource_sysdig_secure_managed_policy.go
@@ -112,8 +112,9 @@ func resourceSysdigManagedPolicyRead(ctx context.Context, d *schema.ResourceData
 	policy, statusCode, err := client.GetPolicyByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
 		if statusCode == http.StatusNotFound {
+			d.SetId("")
+		} else {
 			return diag.FromErr(err)
 		}
 	}
@@ -134,8 +135,9 @@ func resourceSysdigManagedPolicyDelete(ctx context.Context, d *schema.ResourceDa
 	// Reset everything back to default values for managed policy
 	policy, statusCode, err := client.GetPolicyByID(ctx, id)
 	if err != nil {
-		d.SetId("")
 		if statusCode == http.StatusNotFound {
+			d.SetId("")
+		} else {
 			return diag.FromErr(err)
 		}
 	}
@@ -169,8 +171,9 @@ func resourceSysdigManagedPolicyUpdate(ctx context.Context, d *schema.ResourceDa
 	policy, statusCode, err := client.GetPolicyByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
 		if statusCode == http.StatusNotFound {
+			d.SetId("")
+		} else {
 			return diag.FromErr(err)
 		}
 	}

--- a/sysdig/resource_sysdig_secure_managed_ruleset.go
+++ b/sysdig/resource_sysdig_secure_managed_ruleset.go
@@ -149,8 +149,9 @@ func resourceSysdigManagedRulesetRead(ctx context.Context, d *schema.ResourceDat
 	policy, statusCode, err := client.GetPolicyByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
 		if statusCode == http.StatusNotFound {
+			d.SetId("")
+		} else {
 			return diag.FromErr(err)
 		}
 	}
@@ -187,8 +188,9 @@ func resourceSysdigManagedRulesetUpdate(ctx context.Context, d *schema.ResourceD
 	policy, statusCode, err := client.GetPolicyByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
 		if statusCode == http.StatusNotFound {
+			d.SetId("")
+		} else {
 			return diag.FromErr(err)
 		}
 	}

--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -291,8 +291,9 @@ func resourceSysdigPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	policy, statusCode, err := client.GetPolicyByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
 		if statusCode == http.StatusNotFound {
+			d.SetId("")
+		} else {
 			return diag.FromErr(err)
 		}
 	}

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -79,10 +79,14 @@ func resourceSysdigRuleContainerRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	rule, err := client.GetRuleByID(ctx, id)
+	rule, err, statusCode := client.GetRuleByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
+		if statusCode == 404 {
+			d.SetId("")
+		} else {
+			return diag.FromErr(err)
+		}
 	}
 
 	if rule.Details.Containers == nil {

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -2,6 +2,7 @@ package sysdig
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -82,7 +83,7 @@ func resourceSysdigRuleContainerRead(ctx context.Context, d *schema.ResourceData
 	rule, statusCode, err := client.GetRuleByID(ctx, id)
 
 	if err != nil {
-		if statusCode == 404 {
+		if statusCode == http.StatusNotFound {
 			d.SetId("")
 		} else {
 			return diag.FromErr(err)

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -79,7 +79,7 @@ func resourceSysdigRuleContainerRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	rule, err, statusCode := client.GetRuleByID(ctx, id)
+	rule, statusCode, err := client.GetRuleByID(ctx, id)
 
 	if err != nil {
 		if statusCode == 404 {

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -133,9 +133,13 @@ func resourceSysdigRuleFalcoRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	rule, err := client.GetRuleByID(ctx, id)
+	rule, err, statusCode := client.GetRuleByID(ctx, id)
 	if err != nil {
-		d.SetId("")
+		if statusCode == 404 {
+			d.SetId("")
+		} else {
+			return diag.FromErr(err)
+		}
 	}
 
 	if rule.Details.Append != nil && !(*(rule.Details.Append)) {

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -135,7 +136,7 @@ func resourceSysdigRuleFalcoRead(ctx context.Context, d *schema.ResourceData, me
 
 	rule, statusCode, err := client.GetRuleByID(ctx, id)
 	if err != nil {
-		if statusCode == 404 {
+		if statusCode == http.StatusNotFound {
 			d.SetId("")
 		} else {
 			return diag.FromErr(err)

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -133,7 +133,7 @@ func resourceSysdigRuleFalcoRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	rule, err, statusCode := client.GetRuleByID(ctx, id)
+	rule, statusCode, err := client.GetRuleByID(ctx, id)
 	if err != nil {
 		if statusCode == 404 {
 			d.SetId("")

--- a/sysdig/resource_sysdig_secure_rule_filesystem.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem.go
@@ -110,9 +110,13 @@ func resourceSysdigRuleFilesystemRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	rule, err := client.GetRuleByID(ctx, id)
+	rule, err, statusCode := client.GetRuleByID(ctx, id)
 	if err != nil {
-		d.SetId("")
+		if statusCode == 404 {
+			d.SetId("")
+		} else {
+			return diag.FromErr(err)
+		}
 	}
 
 	updateResourceDataForRule(d, rule)

--- a/sysdig/resource_sysdig_secure_rule_filesystem.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem.go
@@ -110,7 +110,7 @@ func resourceSysdigRuleFilesystemRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	rule, err, statusCode := client.GetRuleByID(ctx, id)
+	rule, statusCode, err := client.GetRuleByID(ctx, id)
 	if err != nil {
 		if statusCode == 404 {
 			d.SetId("")

--- a/sysdig/resource_sysdig_secure_rule_filesystem.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem.go
@@ -2,6 +2,7 @@ package sysdig
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -112,7 +113,7 @@ func resourceSysdigRuleFilesystemRead(ctx context.Context, d *schema.ResourceDat
 
 	rule, statusCode, err := client.GetRuleByID(ctx, id)
 	if err != nil {
-		if statusCode == 404 {
+		if statusCode == http.StatusNotFound {
 			d.SetId("")
 		} else {
 			return diag.FromErr(err)

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -2,6 +2,7 @@ package sysdig
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -121,7 +122,7 @@ func resourceSysdigRuleNetworkRead(ctx context.Context, d *schema.ResourceData, 
 	rule, statusCode, err := client.GetRuleByID(ctx, id)
 
 	if err != nil {
-		if statusCode == 404 {
+		if statusCode == http.StatusNotFound {
 			d.SetId("")
 		} else {
 			return diag.FromErr(err)

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -118,10 +118,14 @@ func resourceSysdigRuleNetworkRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	rule, err := client.GetRuleByID(ctx, id)
+	rule, err, statusCode := client.GetRuleByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
+		if statusCode == 404 {
+			d.SetId("")
+		} else {
+			return diag.FromErr(err)
+		}
 	}
 	updateResourceDataForRule(d, rule)
 

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -118,7 +118,7 @@ func resourceSysdigRuleNetworkRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	rule, err, statusCode := client.GetRuleByID(ctx, id)
+	rule, statusCode, err := client.GetRuleByID(ctx, id)
 
 	if err != nil {
 		if statusCode == 404 {

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -79,7 +79,7 @@ func resourceSysdigRuleProcessRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	rule, err, statusCode := client.GetRuleByID(ctx, id)
+	rule, statusCode, err := client.GetRuleByID(ctx, id)
 
 	if err != nil {
 		if statusCode == 404 {

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -2,6 +2,7 @@ package sysdig
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -82,7 +83,7 @@ func resourceSysdigRuleProcessRead(ctx context.Context, d *schema.ResourceData, 
 	rule, statusCode, err := client.GetRuleByID(ctx, id)
 
 	if err != nil {
-		if statusCode == 404 {
+		if statusCode == http.StatusNotFound {
 			d.SetId("")
 		} else {
 			return diag.FromErr(err)

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -79,10 +79,14 @@ func resourceSysdigRuleProcessRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	rule, err := client.GetRuleByID(ctx, id)
+	rule, err, statusCode := client.GetRuleByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
+		if statusCode == 404 {
+			d.SetId("")
+		} else {
+			return diag.FromErr(err)
+		}
 	}
 
 	if rule.Details.Processes == nil {

--- a/sysdig/resource_sysdig_secure_rule_syscall.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall.go
@@ -78,7 +78,7 @@ func resourceSysdigRuleSyscallRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	rule, err, statusCode := client.GetRuleByID(ctx, id)
+	rule, statusCode, err := client.GetRuleByID(ctx, id)
 
 	if err != nil {
 		if statusCode == 404 {

--- a/sysdig/resource_sysdig_secure_rule_syscall.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall.go
@@ -78,10 +78,14 @@ func resourceSysdigRuleSyscallRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	rule, err := client.GetRuleByID(ctx, id)
+	rule, err, statusCode := client.GetRuleByID(ctx, id)
 
 	if err != nil {
-		d.SetId("")
+		if statusCode == 404 {
+			d.SetId("")
+		} else {
+			return diag.FromErr(err)
+		}
 	}
 
 	if rule.Details.Syscalls == nil {

--- a/sysdig/resource_sysdig_secure_rule_syscall.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall.go
@@ -2,6 +2,7 @@ package sysdig
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -81,7 +82,7 @@ func resourceSysdigRuleSyscallRead(ctx context.Context, d *schema.ResourceData, 
 	rule, statusCode, err := client.GetRuleByID(ctx, id)
 
 	if err != nil {
-		if statusCode == 404 {
+		if statusCode == http.StatusNotFound {
 			d.SetId("")
 		} else {
 			return diag.FromErr(err)


### PR DESCRIPTION
We should differentiate between 404 errors and all other errors when trying to get a rule from the backend. If the response is non 404, we should not try to re-create the resource, as it might already exist. 
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->