### PR TITLE
add option to skip policyv2msg in policy/rule/list/macro mutating operations

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,5 +7,9 @@ import (
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{ProviderFunc: sysdig.Provider})
+	sysdigClient := sysdig.NewSysdigClients()
+	defer sysdigClient.Close()
+
+	provider := &sysdig.SysdigProvider{SysdigClient: sysdigClient}
+	plugin.Serve(&plugin.ServeOpts{ProviderFunc: provider.Provider})
 }

--- a/sysdig/internal/client/v2/config.go
+++ b/sysdig/internal/client/v2/config.go
@@ -1,16 +1,17 @@
 package v2
 
 type config struct {
-	url            string
-	token          string
-	insecure       bool
-	extraHeaders   map[string]string
-	ibmInstanceID  string
-	ibmAPIKey      string
-	ibmIamURL      string
-	sysdigTeamName string
-	sysdigTeamID   *int
-	product        string
+	url                   string
+	token                 string
+	insecure              bool
+	extraHeaders          map[string]string
+	ibmInstanceID         string
+	ibmAPIKey             string
+	ibmIamURL             string
+	sysdigTeamName        string
+	sysdigTeamID          *int
+	product               string
+	secureSkipPolicyV2Msg bool
 }
 
 type Product string
@@ -94,4 +95,10 @@ func configure(opts ...ClientOption) *config {
 		opt(cfg)
 	}
 	return cfg
+}
+
+func WithSkipPolicyV2Msg(skipPolicyV2Msg bool) ClientOption {
+	return func(c *config) {
+		c.secureSkipPolicyV2Msg = skipPolicyV2Msg
+	}
 }

--- a/sysdig/internal/client/v2/list.go
+++ b/sysdig/internal/client/v2/list.go
@@ -7,10 +7,10 @@ import (
 )
 
 const (
-	CreateListPath = "%s/api/secure/falco/lists"
+	CreateListPath = "%s/api/secure/falco/lists?skipPolicyV2Msg=%t"
 	GetListPath    = "%s/api/secure/falco/lists/%d"
-	UpdateListPath = "%s/api/secure/falco/lists/%d"
-	DeleteListPath = "%s/api/secure/falco/lists/%d"
+	UpdateListPath = "%s/api/secure/falco/lists/%d?skipPolicyV2Msg=%t"
+	DeleteListPath = "%s/api/secure/falco/lists/%d?skipPolicyV2Msg=%t"
 )
 
 type ListInterface interface {
@@ -97,7 +97,7 @@ func (client *Client) DeleteList(ctx context.Context, id int) error {
 }
 
 func (client *Client) CreateListURL() string {
-	return fmt.Sprintf(CreateListPath, client.config.url)
+	return fmt.Sprintf(CreateListPath, client.config.url, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) GetListURL(id int) string {
@@ -105,9 +105,9 @@ func (client *Client) GetListURL(id int) string {
 }
 
 func (client *Client) UpdateListURL(id int) string {
-	return fmt.Sprintf(UpdateListPath, client.config.url, id)
+	return fmt.Sprintf(UpdateListPath, client.config.url, id, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) DeleteListURL(id int) string {
-	return fmt.Sprintf(DeleteListPath, client.config.url, id)
+	return fmt.Sprintf(DeleteListPath, client.config.url, id, client.config.secureSkipPolicyV2Msg)
 }

--- a/sysdig/internal/client/v2/macros.go
+++ b/sysdig/internal/client/v2/macros.go
@@ -7,10 +7,10 @@ import (
 )
 
 const (
-	CreateMacroPath  = "%s/api/secure/falco/macros"
+	CreateMacroPath  = "%s/api/secure/falco/macros?skipPolicyV2Msg=%t"
 	GetMacroByIDPath = "%s/api/secure/falco/macros/%d"
-	UpdateMacroPath  = "%s/api/secure/falco/macros/%d"
-	DeleteMacroPath  = "%s/api/secure/falco/macros/%d"
+	UpdateMacroPath  = "%s/api/secure/falco/macros/%d?skipPolicyV2Msg=%t"
+	DeleteMacroPath  = "%s/api/secure/falco/macros/%d?skipPolicyV2Msg=%t"
 )
 
 type MacroInterface interface {
@@ -96,7 +96,7 @@ func (client *Client) DeleteMacro(ctx context.Context, id int) error {
 }
 
 func (client *Client) CreateMacroURL() string {
-	return fmt.Sprintf(CreateMacroPath, client.config.url)
+	return fmt.Sprintf(CreateMacroPath, client.config.url, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) GetMacroByIDURL(id int) string {
@@ -104,9 +104,9 @@ func (client *Client) GetMacroByIDURL(id int) string {
 }
 
 func (client *Client) UpdateMacroURL(id int) string {
-	return fmt.Sprintf(UpdateMacroPath, client.config.url, id)
+	return fmt.Sprintf(UpdateMacroPath, client.config.url, id, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) DeleteMacroURL(id int) string {
-	return fmt.Sprintf(DeleteMacroPath, client.config.url, id)
+	return fmt.Sprintf(DeleteMacroPath, client.config.url, id, client.config.secureSkipPolicyV2Msg)
 }

--- a/sysdig/internal/client/v2/policies.go
+++ b/sysdig/internal/client/v2/policies.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	CreatePolicyPath = "%s/api/v2/policies"
-	DeletePolicyPath = "%s/api/v2/policies/%d"
-	UpdatePolicyPath = "%s/api/v2/policies/%d"
+	CreatePolicyPath = "%s/api/v2/policies?skipPolicyV2Msg=%t"
+	DeletePolicyPath = "%s/api/v2/policies/%d?skipPolicyV2Msg=%t"
+	UpdatePolicyPath = "%s/api/v2/policies/%d?skipPolicyV2Msg=%t"
 	GetPolicyPath    = "%s/api/v2/policies/%d"
 	GetPoliciesPath  = "%s/api/v2/policies"
 )
@@ -116,15 +116,15 @@ func (client *Client) GetPolicies(ctx context.Context) ([]Policy, int, error) {
 }
 
 func (client *Client) CreatePolicyURL() string {
-	return fmt.Sprintf(CreatePolicyPath, client.config.url)
+	return fmt.Sprintf(CreatePolicyPath, client.config.url, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) DeletePolicyURL(policyID int) string {
-	return fmt.Sprintf(DeletePolicyPath, client.config.url, policyID)
+	return fmt.Sprintf(DeletePolicyPath, client.config.url, policyID, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) UpdatePolicyURL(policyID int) string {
-	return fmt.Sprintf(UpdatePolicyPath, client.config.url, policyID)
+	return fmt.Sprintf(UpdatePolicyPath, client.config.url, policyID, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) GetPolicyURL(policyID int) string {

--- a/sysdig/internal/client/v2/rules.go
+++ b/sysdig/internal/client/v2/rules.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	CreateRulePath   = "%s/api/secure/rules"
+	CreateRulePath   = "%s/api/secure/rules?skipPolicyV2Msg=%t"
 	GetRuleByIDPath  = "%s/api/secure/rules/%d"
-	UpdateRulePath   = "%s/api/secure/rules/%d"
-	DeleteURLPath    = "%s/api/secure/rules/%d"
+	UpdateRulePath   = "%s/api/secure/rules/%d?skipPolicyV2Msg=%t"
+	DeleteURLPath    = "%s/api/secure/rules/%d?skipPolicyV2Msg=%t"
 	GetRuleGroupPath = "%s/api/secure/rules/groups?name=%s&type=%s"
 )
 
@@ -108,7 +108,7 @@ func (client *Client) GetRuleGroup(ctx context.Context, ruleName string, ruleTyp
 }
 
 func (client *Client) CreateRuleURL() string {
-	return fmt.Sprintf(CreateRulePath, client.config.url)
+	return fmt.Sprintf(CreateRulePath, client.config.url, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) GetRuleByIDURL(ruleID int) string {
@@ -116,11 +116,11 @@ func (client *Client) GetRuleByIDURL(ruleID int) string {
 }
 
 func (client *Client) UpdateRuleURL(ruleID int) string {
-	return fmt.Sprintf(UpdateRulePath, client.config.url, ruleID)
+	return fmt.Sprintf(UpdateRulePath, client.config.url, ruleID, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) DeleteRuleURL(ruleID int) string {
-	return fmt.Sprintf(DeleteURLPath, client.config.url, ruleID)
+	return fmt.Sprintf(DeleteURLPath, client.config.url, ruleID, client.config.secureSkipPolicyV2Msg)
 }
 
 func (client *Client) GetRuleGroupURL(ruleName string, ruleType string) string {

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -11,6 +11,13 @@ type SysdigProvider struct {
 	SysdigClient SysdigClients
 }
 
+// Used by tests to get the provider
+func Provider() *schema.Provider {
+	sysdigClient := NewSysdigClients()
+	provider := &SysdigProvider{SysdigClient: sysdigClient}
+	return provider.Provider()
+}
+
 func (p *SysdigProvider) Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -10,6 +10,11 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
+			"sysdig_secure_skip_policyv2msg": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_SECURE_SKIP_POLICYV2MSG", false),
+			},
 			"sysdig_secure_api_token": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -7,13 +7,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func Provider() *schema.Provider {
+type SysdigProvider struct {
+	SysdigClient SysdigClients
+}
+
+func (p *SysdigProvider) Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"sysdig_secure_skip_policyv2msg": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_SECURE_SKIP_POLICYV2MSG", false),
+				DefaultFunc: schema.EnvDefaultFunc("SYSDIG_SECURE_SKIP_POLICYV2MSG", true),
 			},
 			"sysdig_secure_api_token": {
 				Type:        schema.TypeString,
@@ -219,11 +223,11 @@ func Provider() *schema.Provider {
 			"sysdig_monitor_notification_channel_ibm_function":             dataSourceSysdigMonitorNotificationChannelIBMFunction(),
 			"sysdig_monitor_custom_role_permissions":                       dataSourceSysdigMonitorCustomRolePermissions(),
 		},
-		ConfigureContextFunc: providerConfigure,
+		ConfigureContextFunc: p.providerConfigure,
 	}
 }
 
-func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	sysdigClient := &sysdigClients{d: d}
-	return sysdigClient, nil
+func (p *SysdigProvider) providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	p.SysdigClient.Configure(ctx, d)
+	return p.SysdigClient, nil
 }

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -72,7 +72,8 @@ func resourceSysdigSecureCustomPolicy() *schema.Resource {
 }
 
 func resourceSysdigCustomPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -82,6 +83,7 @@ func resourceSysdigCustomPolicyCreate(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	customPolicyToResourceData(&policy, d)
 
@@ -154,7 +156,8 @@ func resourceSysdigCustomPolicyRead(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceSysdigCustomPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -165,12 +168,14 @@ func resourceSysdigCustomPolicyDelete(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigCustomPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -185,6 +190,8 @@ func resourceSysdigCustomPolicyUpdate(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 

--- a/sysdig/resource_sysdig_secure_list.go
+++ b/sysdig/resource_sysdig_secure_list.go
@@ -2,10 +2,11 @@ package sysdig
 
 import (
 	"context"
-	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"strconv"
 	"strings"
 	"time"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -61,7 +62,8 @@ func getSecureListClient(c SysdigClients) (v2.ListInterface, error) {
 }
 
 func resourceSysdigListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureListClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureListClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -71,6 +73,7 @@ func resourceSysdigListCreate(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	d.SetId(strconv.Itoa(list.ID))
 	_ = d.Set("version", list.Version)
@@ -79,7 +82,8 @@ func resourceSysdigListCreate(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceSysdigListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureListClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureListClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -94,6 +98,8 @@ func resourceSysdigListUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 
@@ -119,7 +125,8 @@ func resourceSysdigListRead(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceSysdigListDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureListClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureListClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -130,6 +137,8 @@ func resourceSysdigListDelete(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 

--- a/sysdig/resource_sysdig_secure_macro.go
+++ b/sysdig/resource_sysdig_secure_macro.go
@@ -62,7 +62,8 @@ func getSecureMacroClient(c SysdigClients) (v2.MacroInterface, error) {
 }
 
 func resourceSysdigMacroCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureMacroClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureMacroClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -72,6 +73,7 @@ func resourceSysdigMacroCreate(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	d.SetId(strconv.Itoa(macro.ID))
 	_ = d.Set("version", macro.Version)
@@ -80,7 +82,8 @@ func resourceSysdigMacroCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceSysdigMacroUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureMacroClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureMacroClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -95,6 +98,8 @@ func resourceSysdigMacroUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 
@@ -123,7 +128,8 @@ func resourceSysdigMacroRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceSysdigMacroDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureMacroClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureMacroClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -134,6 +140,8 @@ func resourceSysdigMacroDelete(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 

--- a/sysdig/resource_sysdig_secure_managed_policy.go
+++ b/sysdig/resource_sysdig_secure_managed_policy.go
@@ -46,7 +46,8 @@ func resourceSysdigSecureManagedPolicy() *schema.Resource {
 }
 
 func resourceSysdigManagedPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -65,6 +66,7 @@ func resourceSysdigManagedPolicyCreate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	managedPolicyToResourceData(&updatedPolicy, d)
 
@@ -125,7 +127,8 @@ func resourceSysdigManagedPolicyRead(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceSysdigManagedPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -156,12 +159,14 @@ func resourceSysdigManagedPolicyDelete(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigManagedPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -184,6 +189,8 @@ func resourceSysdigManagedPolicyUpdate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 

--- a/sysdig/resource_sysdig_secure_managed_ruleset.go
+++ b/sysdig/resource_sysdig_secure_managed_ruleset.go
@@ -77,7 +77,8 @@ func resourceSysdigSecureManagedRuleset() *schema.Resource {
 }
 
 func resourceSysdigManagedRulesetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -101,6 +102,7 @@ func resourceSysdigManagedRulesetCreate(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	managedRulesetToResourceData(&createdPolicy, d)
 
@@ -162,7 +164,8 @@ func resourceSysdigManagedRulesetRead(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceSysdigManagedRulesetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -173,12 +176,14 @@ func resourceSysdigManagedRulesetDelete(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigManagedRulesetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -201,6 +206,8 @@ func resourceSysdigManagedRulesetUpdate(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 

--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -2,13 +2,16 @@ package sysdig
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -150,7 +153,8 @@ func getSecurePolicyClient(c SysdigClients) (v2.PolicyInterface, error) {
 }
 
 func resourceSysdigPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -160,6 +164,7 @@ func resourceSysdigPolicyCreate(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	policyToResourceData(&policy, d)
 
@@ -304,7 +309,8 @@ func resourceSysdigPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceSysdigPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -315,12 +321,14 @@ func resourceSysdigPolicyDelete(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecurePolicyClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecurePolicyClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -335,5 +343,30 @@ func resourceSysdigPolicyUpdate(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
+}
+
+var sendPoliciesToAgentsOnce sync.Once
+
+func sendPoliciesToAgents(ctx context.Context, clients SysdigClients) error {
+	var err error
+	sendPoliciesToAgentsOnce.Do(func() {
+		tflog.Info(ctx, "Sending policies to agents")
+		var client v2.PolicyInterface
+		client, err = getSecurePolicyClient(clients)
+		if err != nil {
+			return
+		}
+
+		// When running as a cleanup hook, the terraform context is in a cancelled state.
+		// Using a background context with a deadline will allow us to complete this request.
+		backgroundCtx, _ := context.WithDeadline(context.Background(), time.Now().Add(15*time.Second))
+		err = client.SendPoliciesToAgents(backgroundCtx)
+	})
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Error in sendPoliciesToAgents: %s", err.Error()))
+	}
+	return err
 }

--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -362,7 +362,8 @@ func sendPoliciesToAgents(ctx context.Context, clients SysdigClients) error {
 
 		// When running as a cleanup hook, the terraform context is in a cancelled state.
 		// Using a background context with a deadline will allow us to complete this request.
-		backgroundCtx, _ := context.WithDeadline(context.Background(), time.Now().Add(15*time.Second))
+		backgroundCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(15*time.Second))
+		defer cancel()
 		err = client.SendPoliciesToAgents(backgroundCtx)
 	})
 	if err != nil {

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -50,7 +50,8 @@ func resourceSysdigSecureRuleContainer() *schema.Resource {
 }
 
 func resourceSysdigRuleContainerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -61,6 +62,7 @@ func resourceSysdigRuleContainerCreate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	d.SetId(strconv.Itoa(rule.ID))
 	_ = d.Set("version", rule.Version)
@@ -102,7 +104,8 @@ func resourceSysdigRuleContainerRead(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceSysdigRuleContainerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -116,12 +119,14 @@ func resourceSysdigRuleContainerUpdate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigRuleContainerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -135,6 +140,8 @@ func resourceSysdigRuleContainerDelete(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -101,7 +101,8 @@ func resourceSysdigSecureRuleFalco() *schema.Resource {
 }
 
 func resourceSysdigRuleFalcoCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -115,6 +116,7 @@ func resourceSysdigRuleFalcoCreate(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	d.SetId(strconv.Itoa(rule.ID))
 	_ = d.Set("version", rule.Version)
@@ -217,7 +219,8 @@ func fieldOrCompsToStringSlice(fields any) ([]string, error) {
 }
 
 func resourceSysdigRuleFalcoUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -234,12 +237,14 @@ func resourceSysdigRuleFalcoUpdate(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigRuleFalcoDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -253,6 +258,8 @@ func resourceSysdigRuleFalcoDelete(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 

--- a/sysdig/resource_sysdig_secure_rule_filesystem.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem.go
@@ -78,7 +78,8 @@ func resourceSysdigSecureRuleFilesystem() *schema.Resource {
 }
 
 func resourceSysdigRuleFilesystemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -92,6 +93,7 @@ func resourceSysdigRuleFilesystemCreate(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	d.SetId(strconv.Itoa(rule.ID))
 	_ = d.Set("version", rule.Version)
@@ -149,7 +151,8 @@ func resourceSysdigRuleFilesystemRead(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceSysdigRuleFilesystemUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -166,12 +169,14 @@ func resourceSysdigRuleFilesystemUpdate(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigRuleFilesystemDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -185,6 +190,7 @@ func resourceSysdigRuleFilesystemDelete(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -86,7 +86,8 @@ func resourceSysdigSecureRuleNetwork() *schema.Resource {
 }
 
 func resourceSysdigRuleNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -100,6 +101,7 @@ func resourceSysdigRuleNetworkCreate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	d.SetId(strconv.Itoa(rule.ID))
 	_ = d.Set("version", rule.Version)
@@ -174,7 +176,8 @@ func resourceSysdigRuleNetworkRead(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceSysdigRuleNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -191,12 +194,14 @@ func resourceSysdigRuleNetworkUpdate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigRuleNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -210,6 +215,7 @@ func resourceSysdigRuleNetworkDelete(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -50,7 +50,8 @@ func resourceSysdigSecureRuleProcess() *schema.Resource {
 }
 
 func resourceSysdigRuleProcessCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -61,6 +62,7 @@ func resourceSysdigRuleProcessCreate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	d.SetId(strconv.Itoa(rule.ID))
 	_ = d.Set("version", rule.Version)
@@ -102,7 +104,8 @@ func resourceSysdigRuleProcessRead(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceSysdigRuleProcessUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -116,12 +119,14 @@ func resourceSysdigRuleProcessUpdate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigRuleProcessDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -135,6 +140,8 @@ func resourceSysdigRuleProcessDelete(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 

--- a/sysdig/resource_sysdig_secure_rule_syscall.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall.go
@@ -49,7 +49,8 @@ func resourceSysdigSecureRuleSyscall() *schema.Resource {
 }
 
 func resourceSysdigRuleSyscallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -60,6 +61,7 @@ func resourceSysdigRuleSyscallCreate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	d.SetId(strconv.Itoa(rule.ID))
 	_ = d.Set("version", rule.Version)
@@ -101,7 +103,8 @@ func resourceSysdigRuleSyscallRead(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceSysdigRuleSyscallUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -115,12 +118,14 @@ func resourceSysdigRuleSyscallUpdate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
 	return nil
 }
 
 func resourceSysdigRuleSyscallDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getSecureRuleClient(meta.(SysdigClients))
+	sysdigClients := meta.(SysdigClients)
+	client, err := getSecureRuleClient(sysdigClients)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -134,6 +139,8 @@ func resourceSysdigRuleSyscallDelete(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
 	return nil
 }
 

--- a/sysdig/sysdig_clients.go
+++ b/sysdig/sysdig_clients.go
@@ -192,7 +192,9 @@ func (c *sysdigClients) Configure(ctx context.Context, d *schema.ResourceData) {
 }
 
 func (c *sysdigClients) AddCleanupHook(cleanupHook func(context.Context, SysdigClients) error) {
+	c.mu.Lock()
 	c.cleanupHooks = append(c.cleanupHooks, cleanupHook)
+	c.mu.Unlock()
 }
 
 func (c *sysdigClients) Close() error {

--- a/sysdig/sysdig_clients.go
+++ b/sysdig/sysdig_clients.go
@@ -109,9 +109,7 @@ func getSysdigSecureVariables(data *schema.ResourceData) (*sysdigSecureVariables
 	}
 
 	skipPolicyV2Msg := false
-	if skipPolicyV2MsgValue, ok := data.GetOk("sysdig_secure_skip_policyv2msg"); !ok {
-		return nil, errors.New("missing skip value")
-	} else {
+	if skipPolicyV2MsgValue, ok := data.GetOk("sysdig_secure_skip_policyv2msg"); ok {
 		skipPolicyV2Msg = skipPolicyV2MsgValue.(bool)
 	}
 

--- a/sysdig/sysdig_clients.go
+++ b/sysdig/sysdig_clients.go
@@ -49,10 +49,9 @@ type sysdigClients struct {
 }
 
 type globalVariables struct {
-	apiURL          string
-	insecure        bool
-	extraHeaders    map[string]string
-	skipPolicyV2Msg bool
+	apiURL       string
+	insecure     bool
+	extraHeaders map[string]string
 }
 
 type sysdigVariables struct {


### PR DESCRIPTION
when enabled, this new flag will not send a message to the agents with the new contents. applies to all policies/rules/lists/macro creates/deletes/updates
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->