### PR TITLE
feat(alerts): add unreported_alert_notifications_retention_seconds argument to alerts

### DIFF
--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -597,8 +597,9 @@ type AlertV2ConfigMetric struct {
 
 type AlertV2Metric struct {
 	AlertV2Common
-	DurationSec int                 `json:"durationSec"`
-	Config      AlertV2ConfigMetric `json:"config"`
+	DurationSec                              int                 `json:"durationSec"`
+	Config                                   AlertV2ConfigMetric `json:"config"`
+	UnreportedAlertNotificationsRetentionSec *int                `json:"unreportedAlertNotificationsRetentionSec"`
 }
 
 type alertV2MetricWrapper struct {
@@ -619,8 +620,9 @@ type AlertV2ConfigDowntime struct {
 
 type AlertV2Downtime struct {
 	AlertV2Common
-	DurationSec int                   `json:"durationSec"`
-	Config      AlertV2ConfigDowntime `json:"config"`
+	DurationSec                              int                   `json:"durationSec"`
+	Config                                   AlertV2ConfigDowntime `json:"config"`
+	UnreportedAlertNotificationsRetentionSec *int                  `json:"unreportedAlertNotificationsRetentionSec"`
 }
 
 type alertV2DowntimeWrapper struct {
@@ -656,8 +658,9 @@ type AlertV2ConfigFormBasedPrometheus struct {
 
 type AlertV2FormBasedPrometheus struct {
 	AlertV2Common
-	DurationSec int                              `json:"durationSec"` // not really used but the api wants it set to 0 in POST/PUT
-	Config      AlertV2ConfigFormBasedPrometheus `json:"config"`
+	DurationSec                              int                              `json:"durationSec"` // not really used but the api wants it set to 0 in POST/PUT
+	Config                                   AlertV2ConfigFormBasedPrometheus `json:"config"`
+	UnreportedAlertNotificationsRetentionSec *int                             `json:"unreportedAlertNotificationsRetentionSec"`
 }
 
 type alertV2FormBasedPrometheusWrapper struct {
@@ -666,8 +669,9 @@ type alertV2FormBasedPrometheusWrapper struct {
 
 type AlertV2Change struct {
 	AlertV2Common
-	DurationSec int                 `json:"durationSec"` // not really used but the api wants it set to 0 in POST/PUT
-	Config      AlertV2ConfigChange `json:"config"`
+	DurationSec                              int                 `json:"durationSec"` // not really used but the api wants it set to 0 in POST/PUT
+	Config                                   AlertV2ConfigChange `json:"config"`
+	UnreportedAlertNotificationsRetentionSec *int                `json:"unreportedAlertNotificationsRetentionSec"`
 }
 
 type alertV2ChangeWrapper struct {

--- a/sysdig/resource_sysdig_monitor_alert_v2_change_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_change_test.go
@@ -55,6 +55,9 @@ func TestAccAlertV2Change(t *testing.T) {
 				Config: alertV2ChangeWithEnabled(rText()),
 			},
 			{
+				Config: alertV2ChangeWithUnreportedAlertNotificationsRetentionSec(rText()),
+			},
+			{
 				Config: alertV2ChangeWithWarningThreshold(rText()),
 			},
 			{
@@ -291,6 +294,22 @@ resource "sysdig_monitor_alert_v2_change" "sample" {
 	shorter_time_range_seconds = 300
 	longer_time_range_seconds = 3600
 	enabled = false
+}
+`, name)
+}
+
+func alertV2ChangeWithUnreportedAlertNotificationsRetentionSec(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_change" "sample" {
+	name = "TERRAFORM TEST - CHANGE %s"
+	metric = "sysdig_container_cpu_used_percent"
+	group_aggregation = "avg"
+	time_aggregation = "avg"
+	operator = ">="
+	threshold = 50
+	shorter_time_range_seconds = 300
+	longer_time_range_seconds = 3600
+	unreported_alert_notifications_retention_seconds = 60 * 60 * 24 * 30
 }
 `, name)
 }

--- a/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
@@ -28,6 +28,9 @@ func TestAccAlertV2Downtime(t *testing.T) {
 				Config: alertV2DowntimeWithName(rText()),
 			},
 			{
+				Config: alertV2DowntimeWithWithUnreportedAlertNotificationsRetentionSec(rText()),
+			},
+			{
 				Config: alertV2DowntimeWithGroupBy(rText()),
 			},
 			{
@@ -54,6 +57,28 @@ resource "sysdig_monitor_alert_v2_downtime" "sample" {
 	}
 
 	trigger_after_minutes = 15
+
+}
+
+`, name)
+}
+
+func alertV2DowntimeWithWithUnreportedAlertNotificationsRetentionSec(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_downtime" "sample" {
+
+	name = "TERRAFORM TEST - DOWNTIMEV2 %s"
+  metric = "sysdig_container_up"
+  threshold = 75
+
+	scope {
+		label = "kube_cluster_name"
+		operator = "in"
+		values = ["thom-cluster1", "demo-env-prom"]
+	}
+
+	trigger_after_minutes = 15
+	unreported_alert_notifications_retention_seconds = 60 * 60 * 24 * 30
 
 }
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus.go
@@ -58,6 +58,11 @@ func resourceSysdigMonitorAlertV2FormBasedPrometheus() *schema.Resource {
 				Default:      "DO_NOTHING",
 				ValidateFunc: validation.StringInSlice([]string{"DO_NOTHING", "TRIGGER"}, false),
 			},
+			"unreported_alert_notifications_retention_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(60),
+			},
 		})),
 	}
 }
@@ -194,10 +199,17 @@ func buildAlertV2FormBasedPrometheusStruct(d *schema.ResourceData) (*v2.AlertV2F
 
 	config.NoDataBehaviour = d.Get("no_data_behaviour").(string)
 
+	var unreportedAlertNotificationsRetentionSec *int
+	if unreportedAlertNotificationsRetentionSecInterface, ok := d.GetOk("unreported_alert_notifications_retention_seconds"); ok {
+		u := unreportedAlertNotificationsRetentionSecInterface.(int)
+		unreportedAlertNotificationsRetentionSec = &u
+	}
+
 	alert := &v2.AlertV2FormBasedPrometheus{
-		AlertV2Common: *alertV2Common,
-		DurationSec:   0,
-		Config:        config,
+		AlertV2Common:                            *alertV2Common,
+		DurationSec:                              0,
+		Config:                                   config,
+		UnreportedAlertNotificationsRetentionSec: unreportedAlertNotificationsRetentionSec,
 	}
 	return alert, nil
 }
@@ -224,6 +236,12 @@ func updateAlertV2FormBasedPrometheusState(d *schema.ResourceData, alert *v2.Ale
 	_ = d.Set("query", alert.Config.Query)
 
 	_ = d.Set("no_data_behaviour", alert.Config.NoDataBehaviour)
+
+	if alert.UnreportedAlertNotificationsRetentionSec != nil {
+		_ = d.Set("unreported_alert_notifications_retention_seconds", *alert.UnreportedAlertNotificationsRetentionSec)
+	} else {
+		_ = d.Set("unreported_alert_notifications_retention_seconds", nil)
+	}
 
 	return nil
 }

--- a/sysdig/resource_sysdig_monitor_alert_v2_metric.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_metric.go
@@ -72,6 +72,11 @@ func resourceSysdigMonitorAlertV2Metric() *schema.Resource {
 				Default:      "DO_NOTHING",
 				ValidateFunc: validation.StringInSlice([]string{"DO_NOTHING", "TRIGGER"}, false),
 			},
+			"unreported_alert_notifications_retention_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(60),
+			},
 		})),
 	}
 }
@@ -215,10 +220,17 @@ func buildAlertV2MetricStruct(d *schema.ResourceData) (*v2.AlertV2Metric, error)
 
 	config.NoDataBehaviour = d.Get("no_data_behaviour").(string)
 
+	var unreportedAlertNotificationsRetentionSec *int
+	if unreportedAlertNotificationsRetentionSecInterface, ok := d.GetOk("unreported_alert_notifications_retention_seconds"); ok {
+		u := unreportedAlertNotificationsRetentionSecInterface.(int)
+		unreportedAlertNotificationsRetentionSec = &u
+	}
+
 	alert := &v2.AlertV2Metric{
-		AlertV2Common: *alertV2Common,
-		DurationSec:   minutesToSeconds(d.Get("trigger_after_minutes").(int)),
-		Config:        config,
+		AlertV2Common:                            *alertV2Common,
+		DurationSec:                              minutesToSeconds(d.Get("trigger_after_minutes").(int)),
+		Config:                                   config,
+		UnreportedAlertNotificationsRetentionSec: unreportedAlertNotificationsRetentionSec,
 	}
 	return alert, nil
 }
@@ -251,6 +263,12 @@ func updateAlertV2MetricState(d *schema.ResourceData, alert *v2.AlertV2Metric) e
 	_ = d.Set("metric", alert.Config.Metric.ID)
 
 	_ = d.Set("no_data_behaviour", alert.Config.NoDataBehaviour)
+
+	if alert.UnreportedAlertNotificationsRetentionSec != nil {
+		_ = d.Set("unreported_alert_notifications_retention_seconds", *alert.UnreportedAlertNotificationsRetentionSec)
+	} else {
+		_ = d.Set("unreported_alert_notifications_retention_seconds", nil)
+	}
 
 	return nil
 }

--- a/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
@@ -61,6 +61,9 @@ func TestAccAlertV2Metric(t *testing.T) {
 				Config: alertV2MetricWithEnabled(rText()),
 			},
 			{
+				Config: alertV2MetricWithUnreportedAlertNotificationsRetentionSec(rText()),
+			},
+			{
 				Config: alertV2MetricWithWarningThreshold(rText()),
 			},
 			{
@@ -340,6 +343,22 @@ resource "sysdig_monitor_alert_v2_metric" "sample" {
 	trigger_after_minutes = 15
 	enabled = false
 
+}
+`, name)
+}
+
+func alertV2MetricWithUnreportedAlertNotificationsRetentionSec(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_metric" "sample" {
+
+	name = "TERRAFORM TEST - METRICV2 %s"
+	metric = "sysdig_container_cpu_used_percent"
+	group_aggregation = "avg"
+	time_aggregation = "avg"
+	operator = ">="
+	threshold = 50
+	trigger_after_minutes = 15
+	unreported_alert_notifications_retention_seconds = 60 * 60 * 24 * 30
 }
 `, name)
 }

--- a/website/docs/r/monitor_alert_v2_change.md
+++ b/website/docs/r/monitor_alert_v2_change.md
@@ -104,6 +104,7 @@ By defining this field, the user can add link to notifications.
 * `warning_threshold` - (Optional) Warning threshold used together with `op` to trigger the alert if crossed. Must be a number that triggers the alert before reaching the main `threshold`.
 * `shorter_time_range_seconds` - (Required) Time range for which data is compared to a longer, previous period. Can be one of `300` (5 minutes), `600` (10 minutes), `3600` (1 hour), `14400` (4 hours), `86400` (1 day).
 * `longer_time_range_seconds` - (Required) Time range for which data will be used as baseline for comparisons with data in the time range defined in `shorter_time_range_seconds`. Possible values depend on `shorter_time_range_seconds`: for a shorter time range of 5 minutes, longer time range can be 1, 2 or 3 hours, for a shorter time range or 10 minutes, it can be from 1 to 8 hours, for a shorter time range or one hour, it can be from 4 to 24 hours, for a shorter time range of 4 hours, it can be from 1 to 7 days, for a shorter time range of one day, it can only be 7 days.
+* `unreported_alert_notifications_retention_seconds` - (Optional) Period after which any alerts triggered for entities (such as containers or hosts) that are no longer reporting data will be automatically marked as 'deactivated'. By default there is no deactivation.
 
 ### `scope`
 

--- a/website/docs/r/monitor_alert_v2_downtime.md
+++ b/website/docs/r/monitor_alert_v2_downtime.md
@@ -96,6 +96,7 @@ Enables the creation of a capture file of the syscalls during the event.
 * `group_by` - (Optional) List of segments to trigger a separate alert on. Example: `["kube_cluster_name", "kube_pod_name"]`.
 * `metric` - (Required) Metric the alert will act upon. Can be: `sysdig_container_up`, `sysdig_program_up`, `sysdig_host_up`.
 * `threshold` - (Required) Below of this percentage of downtime the alert will be triggered. Defaults to 100.
+* `unreported_alert_notifications_retention_seconds` - (Optional) Period after which any alerts triggered for entities (such as containers or hosts) that are no longer reporting data will be automatically marked as 'deactivated'. By default there is no deactivation.
 
 ### `scope`
 

--- a/website/docs/r/monitor_alert_v2_form_based_prometheus.md
+++ b/website/docs/r/monitor_alert_v2_form_based_prometheus.md
@@ -78,6 +78,7 @@ By defining this field, the user can add link to notifications.
 * `threshold` - (Required) Threshold used together with `op` to trigger the alert if crossed.
 * `warning_threshold` - (Optional) Warning threshold used together with `op` to trigger the alert if crossed. Must be a number that triggers the alert before reaching the main `threshold`.
 * `no_data_behaviour` - (Optional) behaviour in case of missing data. Can be `DO_NOTHING`, i.e. ignore, or `TRIGGER`, i.e. notify on main threshold. Default: `DO_NOTHING`.
+* `unreported_alert_notifications_retention_seconds` - (Optional) Period after which any alerts triggered for entities (such as containers or hosts) that are no longer reporting data will be automatically marked as 'deactivated'. By default there is no deactivation.
 
 ## Attributes Reference
 

--- a/website/docs/r/monitor_alert_v2_metric.md
+++ b/website/docs/r/monitor_alert_v2_metric.md
@@ -113,6 +113,7 @@ Enables the creation of a capture file of the syscalls during the event.
 * `threshold` - (Required) Threshold used together with `op` to trigger the alert if crossed.
 * `warning_threshold` - (Optional) Warning threshold used together with `op` to trigger the alert if crossed. Must be a number that triggers the alert before reaching the main `threshold`.
 * `no_data_behaviour` - (Optional) behaviour in case of missing data. Can be `DO_NOTHING`, i.e. ignore, or `TRIGGER`, i.e. notify on main threshold. Default: `DO_NOTHING`.
+* `unreported_alert_notifications_retention_seconds` - (Optional) Period after which any alerts triggered for entities (such as containers or hosts) that are no longer reporting data will be automatically marked as 'deactivated'. By default there is no deactivation.
 
 ### `scope`
 


### PR DESCRIPTION
add `unreported_alert_notifications_retention_seconds` argument to alerts of type `monitor_alert_v2_metric`, `monitor_alert_v2_change`, `monitor_alert_v2_downtime`, `sysdig_monitor_alert_v2_form_based_prometheus`.