### PR TITLE
fix(secure-cloud-account): Support parsing JSON encoded string inputs for Component metadata

### DIFF
--- a/sysdig/common.go
+++ b/sysdig/common.go
@@ -54,8 +54,9 @@ const (
 	SchemaCloudLogsMetadata         = "cloud_logs_metadata"
 	SchemaEnabled                   = "enabled"
 	SchemaComponents                = "components"
+	SchemaComponent                 = "component"
 	SchemaId                        = "id"
-	SchemaCloudProviderId           = "cloud_provider_id"
-	SchemaCloudProviderType         = "cloud_provider_type"
+	SchemaCloudProviderId           = "provider_id"
+	SchemaCloudProviderType         = "provider_type"
 	SchemaFeature                   = "feature"
 )

--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -148,7 +148,7 @@ func resourceSysdigSecureCloudauthAccount() *schema.Resource {
 				Optional: true,
 				Elem:     accountFeatures,
 			},
-			SchemaComponents: {
+			SchemaComponent: {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     accountComponents,
@@ -309,7 +309,7 @@ cloudauthAccountFromResourceData() function
 func constructAccountComponents(accountComponents []*cloudauth.AccountComponent, data *schema.ResourceData) []*cloudauth.AccountComponent {
 	provider := data.Get(SchemaCloudProviderType).(string)
 
-	for _, rc := range data.Get(SchemaComponents).([]interface{}) {
+	for _, rc := range data.Get(SchemaComponent).([]interface{}) {
 		resourceComponent := rc.(map[string]interface{})
 		component := &cloudauth.AccountComponent{}
 
@@ -518,7 +518,7 @@ func cloudauthAccountToResourceData(data *schema.ResourceData, cloudAccount *v2.
 		})
 	}
 
-	err = data.Set(SchemaComponents, components)
+	err = data.Set(SchemaComponent, components)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Current (and working) TF snippet expected from `onboarding-api` :-

```
terraform {
  required_providers {
    sysdig = {
      source = "local/sysdiglabs/sysdig"
      version = "~> 1.0.0"
    }
  }
}

provider "sysdig" {
  sysdig_secure_url          = "https://secure-staging.sysdig.com"
  sysdig_secure_api_token    = "fgb6xxxx-xxxxx-xxxxx-xxxxxxxx"
}

provider "google" {
  project = "mygcpproject"
  region  = "us-west1"
}

module "single-project-cspm" {
  source               = "sysdiglabs/secure/google//modules/services/service-principal"
  project_id           = "mygcpproject"
  service_account_name = "ravina-test-sa"
}

resource "sysdig_secure_cloud_auth_account" "gcp_account_provider_id" {
  provider_id   = "mygcpproject"
  provider_type = "PROVIDER_GCP"
  enabled       = true
  feature {
      secure_config_posture {
        enabled    = "true"
        components = ["COMPONENT_SERVICE_PRINCIPAL/secure-service-principal"]
      }
  }
  component {
      type                       = "COMPONENT_SERVICE_PRINCIPAL"
      instance                   = "secure-service-principal"
      service_principal_metadata = "{\"gcp\":{\"key\":\"${module.single-project-cspm.service_account_key}\"}}"
  }
}
```
**Some points to note:**

- The provider source will change ofcourse once released.
- Both below formats for `service_principal_metadata` work currently. (targeting the latter during TF snippet generation which is more readable)
```
service_principal_metadata = "{\"gcp\":{\"key\":\"${module.single-project-cspm.service_account_key}\"}}"
```
 and
```
      service_principal_metadata = jsonencode({
        gcp = {
          key = module.single-project-cspm.service_account_key
        }
      })
```

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->