### PR TITLE
feat(codeowners): add codeowners for internal components

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,11 @@
 
 # policies/rules
 *secure*policy* @jacklongsd @kmvachhani @ben-m-lucas @ombellare @miguelgordo @ivanlysiuk-sysdig
+
+# internal components
+/sysdig/internal/client/v2/client.go @filiptubic @mbarbieri @draraksysdig
+/sysdig/internal/client/v2/config.go @filiptubic @mbarbieri @draraksysdig
+/sysdig/internal/client/v2/ibm.go @filiptubic @mbarbieri @draraksysdig
+/main.go @filiptubic @mbarbieri @draraksysdig
+/.goreleaser.yml @filiptubic @mbarbieri @draraksysdig
+/.github/ @filiptubic @mbarbieri @draraksysdig


### PR DESCRIPTION
Add platform team as codeowner for internal code.
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->