### PR TITLE
Add Cloudauth Account resource Tests

### DIFF
--- a/sysdig/internal/client/v2/cloudauth.go
+++ b/sysdig/internal/client/v2/cloudauth.go
@@ -24,7 +24,7 @@ type CloudauthAccountSecureInterface interface {
 }
 
 func (client *Client) CreateCloudauthAccountSecure(ctx context.Context, cloudAccount *CloudauthAccountSecure) (*CloudauthAccountSecure, error) {
-	payload, err := marshal(cloudAccount)
+	payload, err := client.marshalProto(cloudAccount)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (client *Client) CreateCloudauthAccountSecure(ctx context.Context, cloudAcc
 		return nil, err
 	}
 
-	return unmarshal(response.Body)
+	return client.unmarshalProto(response.Body)
 }
 
 func (client *Client) GetCloudauthAccountSecure(ctx context.Context, accountID string) (*CloudauthAccountSecure, error) {
@@ -54,7 +54,7 @@ func (client *Client) GetCloudauthAccountSecure(ctx context.Context, accountID s
 		return nil, client.ErrorFromResponse(response)
 	}
 
-	return unmarshal(response.Body)
+	return client.unmarshalProto(response.Body)
 }
 
 func (client *Client) DeleteCloudauthAccountSecure(ctx context.Context, accountID string) error {
@@ -71,7 +71,7 @@ func (client *Client) DeleteCloudauthAccountSecure(ctx context.Context, accountI
 }
 
 func (client *Client) UpdateCloudauthAccountSecure(ctx context.Context, accountID string, cloudAccount *CloudauthAccountSecure) (*CloudauthAccountSecure, error) {
-	payload, err := marshal(cloudAccount)
+	payload, err := client.marshalProto(cloudAccount)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (client *Client) UpdateCloudauthAccountSecure(ctx context.Context, accountI
 		return nil, err
 	}
 
-	return unmarshal(response.Body)
+	return client.unmarshalProto(response.Body)
 }
 
 func (client *Client) cloudauthAccountsURL() string {
@@ -99,12 +99,12 @@ func (client *Client) cloudauthAccountURL(accountID string) string {
 }
 
 // local function for protojson based marshal/unmarshal of cloudauthAccount proto
-func marshal(data *CloudauthAccountSecure) (io.Reader, error) {
+func (client *Client) marshalProto(data *CloudauthAccountSecure) (io.Reader, error) {
 	payload, err := protojson.Marshal(data)
 	return bytes.NewBuffer(payload), err
 }
 
-func unmarshal(data io.ReadCloser) (*CloudauthAccountSecure, error) {
+func (client *Client) unmarshalProto(data io.ReadCloser) (*CloudauthAccountSecure, error) {
 	result := &CloudauthAccountSecure{}
 
 	body, err := io.ReadAll(data)

--- a/sysdig/internal/client/v2/cloudauth_test.go
+++ b/sysdig/internal/client/v2/cloudauth_test.go
@@ -1,0 +1,61 @@
+//go:build unit
+
+package v2
+
+import (
+	cloudauth "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2/cloudauth/go"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestMarshalProto(t *testing.T) {
+	t.Parallel()
+	c := Client{}
+	given := &CloudauthAccountSecure{
+		CloudAccount: cloudauth.CloudAccount{
+			Enabled:    true,
+			ProviderId: "test-project",
+			Provider:   cloudauth.Provider_PROVIDER_GCP,
+		},
+	}
+	expected := `{"enabled":true,"providerId":"test-project","provider":"PROVIDER_GCP"}`
+
+	payload, err := c.marshalProto(given)
+	if err != nil {
+		t.Errorf("failed to marshal payload, err: %v", err)
+	}
+
+	buf := &strings.Builder{}
+	_, err = io.Copy(buf, payload)
+	if err != nil {
+		t.Errorf("failed to populate buffer, err: %v", err)
+	}
+	marshaled := buf.String()
+
+	if marshaled != expected {
+		t.Errorf("expected %v, got %v", expected, marshaled)
+	}
+}
+
+func TestUnmarshalProto(t *testing.T) {
+	t.Parallel()
+	c := Client{}
+	given := `{"enabled":true, "providerId":"test-project", "provider":"PROVIDER_GCP"}`
+	expected := &CloudauthAccountSecure{
+		CloudAccount: cloudauth.CloudAccount{
+			Enabled:    true,
+			ProviderId: "test-project",
+			Provider:   cloudauth.Provider_PROVIDER_GCP,
+		},
+	}
+
+	unmarshalled, err := c.unmarshalProto(io.NopCloser(strings.NewReader(given)))
+	if err != nil {
+		t.Errorf("got error while unmarshaling, err: %v", err)
+	}
+
+	if expected.String() != unmarshalled.String() {
+		t.Errorf("expected %v, got %v", expected, unmarshalled)
+	}
+}

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -4,6 +4,7 @@ package sysdig_test
 
 import (
 	b64 "encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -3,8 +3,6 @@
 package sysdig_test
 
 import (
-	b64 "encoding/base64"
-	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -52,6 +50,8 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
 }`, accountID)
 }
 
+// TODO: uncomment the below test when the issue of TF refresh with component block is resolved
+/*
 func TestAccSecureCloudAuthAccountFC(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	accID := rText()
@@ -116,3 +116,4 @@ resource "sysdig_secure_cloud_auth_account" "sample-1" {
 }
 `, accountID, test_service_account_key_encoded)
 }
+*/

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -109,7 +109,7 @@ resource "sysdig_secure_cloud_auth_account" "sample-1" {
 	instance                   = "secure-service-principal"
 	service_principal_metadata = jsonencode({
       gcp = {
-        key = %s
+        key = "%s"
       }
     })
   }

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -1,0 +1,130 @@
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
+
+package sysdig_test
+
+import (
+	b64 "encoding/base64"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+)
+
+func TestAccSecureCloudAuthAccount(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+	accID := rText()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: secureCloudAuthAccountWithID(accID),
+			},
+			{
+				Config: secureCloudAuthAccountMinimumConfiguration(accID),
+			},
+			{
+				ResourceName:      "sysdig_secure_cloud_auth_account.sample",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func secureCloudAuthAccountWithID(accountID string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_cloud_auth_account" "sample" {
+  provider_id   = "sample-%s"
+  provider_type = "PROVIDER_GCP"
+  enabled       = "true"
+}
+`, accountID)
+}
+
+func secureCloudAuthAccountMinimumConfiguration(accountID string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_cloud_auth_account" "sample" {
+  provider_id   = "sample-%s"
+  provider_type = "PROVIDER_GCP"
+  enabled       = "true"
+}`, accountID)
+}
+
+func TestAccSecureCloudAuthAccountFC(t *testing.T) {
+	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
+	accID := rText()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: secureCloudAuthAccountWithFC(accID),
+			},
+			{
+				ResourceName:      "sysdig_secure_cloud_auth_account.sample-1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func secureCloudAuthAccountWithFC(accountID string) string {
+	type sample_service_account_key struct {
+		ProjectId    string `json:"project_id"`
+		PrivateKeyId string `json:"private_key_id"`
+		PrivateKey   string `json:"private_key"`
+	}
+	test_service_account_key := &sample_service_account_key{
+		ProjectId:    fmt.Sprintf("sample-1-%s", accountID),
+		PrivateKeyId: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		PrivateKey:   "-----BEGIN PRIVATE KEY-----\njvXwqBxxxxxxxxxxxxxxxxxiQZkKgw\n-----END PRIVATE KEY-----\n",
+	}
+	test_service_account_keyJSON, _ := json.Marshal(test_service_account_key)
+	test_service_account_key_encoded := b64.StdEncoding.EncodeToString([]byte(string(test_service_account_keyJSON)))
+
+	return fmt.Sprintf(`
+resource "sysdig_secure_cloud_auth_account" "sample-1" {
+  provider_id   = "sample-1-%s"
+  provider_type = "PROVIDER_GCP"
+  enabled       = "true"
+  feature {
+	secure_config_posture {
+	  enabled    = "true"
+	  components = ["COMPONENT_SERVICE_PRINCIPAL/secure-service-principal"]
+	}
+  }
+  component {
+	type                       = "COMPONENT_SERVICE_PRINCIPAL"
+	instance                   = "secure-service-principal"
+	service_principal_metadata = jsonencode({
+      gcp = {
+        key = %s
+      }
+    })
+  }
+}
+`, accountID, test_service_account_key_encoded)
+}

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -31,9 +31,6 @@ func TestAccSecureCloudAuthAccount(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: secureCloudAuthAccountWithID(accID),
-			},
-			{
 				Config: secureCloudAuthAccountMinimumConfiguration(accID),
 			},
 			{
@@ -43,16 +40,6 @@ func TestAccSecureCloudAuthAccount(t *testing.T) {
 			},
 		},
 	})
-}
-
-func secureCloudAuthAccountWithID(accountID string) string {
-	return fmt.Sprintf(`
-resource "sysdig_secure_cloud_auth_account" "sample" {
-  provider_id   = "sample-%s"
-  provider_type = "PROVIDER_GCP"
-  enabled       = "true"
-}
-`, accountID)
 }
 
 func secureCloudAuthAccountMinimumConfiguration(accountID string) string {
@@ -100,7 +87,7 @@ func secureCloudAuthAccountWithFC(accountID string) string {
 	test_service_account_key := &sample_service_account_key{
 		ProjectId:    fmt.Sprintf("sample-1-%s", accountID),
 		PrivateKeyId: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		PrivateKey:   "-----BEGIN PRIVATE KEY-----\njvXwqBxxxxxxxxxxxxxxxxxiQZkKgw\n-----END PRIVATE KEY-----\n",
+		PrivateKey:   "-----BEGIN PRIVATE KEY-----\nxxxxxxxxxxxxxxxxxxxxxxxxxxx\n-----END PRIVATE KEY-----\n",
 	}
 	test_service_account_keyJSON, _ := json.Marshal(test_service_account_key)
 	test_service_account_key_encoded := b64.StdEncoding.EncodeToString([]byte(string(test_service_account_keyJSON)))


### PR DESCRIPTION
Change summary:
----------------
1. Added tests for new cloudauth based CloudAccount resource.
2. Minor refactoring of marshal/unmarshal methods of cloudauth client.
3. Added the tests for the marshal/unmarshal methods.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->