### PR TITLE
Populate all fields of component metadata in Cloudauth Account resource

### DIFF
--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -347,7 +347,8 @@ func constructAccountComponents(accountComponents []*cloudauth.AccountComponent,
 					if provider == cloudauth.Provider_PROVIDER_GCP.String() {
 						encodedServicePrincipalKey, ok := servicePrincipalMetadata["gcp"].(map[string]interface{})["key"].(string)
 						if !ok {
-							fmt.Printf("Component metadata for provider %s is invalid and not as expected", provider)
+							fmt.Printf("Resource input for component metadata for provider %s is invalid and not as expected", provider)
+							break
 						}
 						servicePrincipalKey := getGcpServicePrincipalKey(encodedServicePrincipalKey)
 						component.Metadata = &cloudauth.AccountComponent_ServicePrincipalMetadata{
@@ -355,9 +356,16 @@ func constructAccountComponents(accountComponents []*cloudauth.AccountComponent,
 								Provider: &cloudauth.ServicePrincipalMetadata_Gcp{
 									Gcp: &cloudauth.ServicePrincipalMetadata_GCP{
 										Key: &cloudauth.ServicePrincipalMetadata_GCP_Key{
-											ProjectId:    data.Get(SchemaCloudProviderId).(string),
-											PrivateKeyId: servicePrincipalKey["private_key_id"],
-											PrivateKey:   servicePrincipalKey["private_key"],
+											Type:                    servicePrincipalKey["type"],
+											ProjectId:               servicePrincipalKey["project_id"],
+											PrivateKeyId:            servicePrincipalKey["private_key_id"],
+											PrivateKey:              servicePrincipalKey["private_key"],
+											ClientEmail:             servicePrincipalKey["client_email"],
+											ClientId:                servicePrincipalKey["client_id"],
+											AuthUri:                 servicePrincipalKey["auth_uri"],
+											TokenUri:                servicePrincipalKey["token_uri"],
+											AuthProviderX509CertUrl: servicePrincipalKey["auth_provider_x509_cert_url"],
+											ClientX509CertUrl:       servicePrincipalKey["client_x509_cert_url"],
 										},
 									},
 								},


### PR DESCRIPTION
Change summary:
----------------
Populating all the fields to fill in the GCP `service_principal_metadata` proto struct (and not just the required fields), since we want to store enough metadata information for potential usecases allowing us to run any future workflows.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->