### PR TITLE
Uncomment and add TestAccSecureCloudAuthAccountFC

### DIFF
--- a/sysdig/internal/client/v2/cloudauth_test.go
+++ b/sysdig/internal/client/v2/cloudauth_test.go
@@ -19,7 +19,7 @@ func TestMarshalProto(t *testing.T) {
 			Provider:   cloudauth.Provider_PROVIDER_GCP,
 		},
 	}
-	expected := `{"enabled":true,"providerId":"test-project","provider":"PROVIDER_GCP"}`
+	expected := `{"enabled":true, "providerId":"test-project", "provider":"PROVIDER_GCP"}`
 
 	payload, err := c.marshalProto(given)
 	if err != nil {

--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -517,5 +517,19 @@ func cloudauthAccountToResourceData(data *schema.ResourceData, cloudAccount *v2.
 		return err
 	}
 
+	components := []map[string]interface{}{}
+
+	for _, comp := range cloudAccount.Components {
+		components = append(components, map[string]interface{}{
+			SchemaType:     comp.Type.String(),
+			SchemaInstance: comp.Instance,
+		})
+	}
+
+	err = data.Set(SchemaComponent, components)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -517,19 +517,5 @@ func cloudauthAccountToResourceData(data *schema.ResourceData, cloudAccount *v2.
 		return err
 	}
 
-	components := []map[string]interface{}{}
-
-	for _, comp := range cloudAccount.Components {
-		components = append(components, map[string]interface{}{
-			SchemaType:     comp.Type.String(),
-			SchemaInstance: comp.Instance,
-		})
-	}
-
-	err = data.Set(SchemaComponent, components)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -3,6 +3,8 @@
 package sysdig_test
 
 import (
+	b64 "encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -50,8 +52,6 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
 }`, accountID)
 }
 
-// TODO: uncomment the below test when the issue of TF refresh with component block is resolved
-/*
 func TestAccSecureCloudAuthAccountFC(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	accID := rText()
@@ -71,9 +71,10 @@ func TestAccSecureCloudAuthAccountFC(t *testing.T) {
 				Config: secureCloudAuthAccountWithFC(accID),
 			},
 			{
-				ResourceName:      "sysdig_secure_cloud_auth_account.sample-1",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "sysdig_secure_cloud_auth_account.sample-1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"component"},
 			},
 		},
 	})
@@ -116,4 +117,3 @@ resource "sysdig_secure_cloud_auth_account" "sample-1" {
 }
 `, accountID, test_service_account_key_encoded)
 }
-*/

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -71,10 +71,9 @@ func TestAccSecureCloudAuthAccountFC(t *testing.T) {
 				Config: secureCloudAuthAccountWithFC(accID),
 			},
 			{
-				ResourceName:            "sysdig_secure_cloud_auth_account.sample-1",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"component"},
+				ResourceName:      "sysdig_secure_cloud_auth_account.sample-1",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -113,6 +112,9 @@ resource "sysdig_secure_cloud_auth_account" "sample-1" {
         key = "%s"
       }
     })
+  }
+  lifecycle {
+	ignore_changes = [component]
   }
 }
 `, accountID, test_service_account_key_encoded)


### PR DESCRIPTION
Fixed and updated `TestAccSecureCloudAuthAccountFC` with `feature` and `component{}` payload in the resource request.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->