### PR TITLE
Remove provider_type from the org documentation

### DIFF
--- a/sysdig/internal/client/v2/organization.go
+++ b/sysdig/internal/client/v2/organization.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -101,7 +100,6 @@ func (client *Client) organizationURL(orgId string) string {
 
 // local function for protojson based marshal/unmarshal of organization proto
 func (client *Client) marshalOrg(data *OrganizationSecure) (io.Reader, error) {
-	log.Printf("Payload %v", data)
 	payload, err := protojson.Marshal(data)
 	return bytes.NewBuffer(payload), err
 }
@@ -115,6 +113,5 @@ func (client *Client) unmarshalOrg(data io.ReadCloser) (*OrganizationSecure, err
 	}
 
 	err = protojson.Unmarshal(body, result)
-	log.Printf("Result: %v", result)
 	return result, err
 }

--- a/sysdig/internal/client/v2/organization.go
+++ b/sysdig/internal/client/v2/organization.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -100,6 +101,7 @@ func (client *Client) organizationURL(orgId string) string {
 
 // local function for protojson based marshal/unmarshal of organization proto
 func (client *Client) marshalOrg(data *OrganizationSecure) (io.Reader, error) {
+	log.Printf("Payload %v", data)
 	payload, err := protojson.Marshal(data)
 	return bytes.NewBuffer(payload), err
 }
@@ -113,5 +115,6 @@ func (client *Client) unmarshalOrg(data io.ReadCloser) (*OrganizationSecure, err
 	}
 
 	err = protojson.Unmarshal(body, result)
+	log.Printf("Result: %v", result)
 	return result, err
 }

--- a/website/docs/r/secure_organization.md
+++ b/website/docs/r/secure_organization.md
@@ -22,14 +22,12 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
 }
 resource "sysdig_secure_organization" "sample" {
   management_account_id	    = sysdig_secure_cloud_auth_account.sample.id 
-  provider_type	            = "PROVIDER_GCP"
 }
 ```
 
 ## Argument Reference
 
 * `management_account_id` - (Required) Cloud Account created using resource sysdig_secure_cloud_auth_account.
-* `provider_type` - (Required) Only `PROVIDER_GCP` is currently supported.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->