### PR TITLE
fix(team-service-account):  api key not set 

### DIFF
--- a/sysdig/resource_sysdig_team_service_account.go
+++ b/sysdig/resource_sysdig_team_service_account.go
@@ -104,6 +104,10 @@ func resourceSysdigTeamServiceAccountCreate(ctx context.Context, d *schema.Resou
 	}
 
 	d.SetId(strconv.Itoa(teamServiceAccount.ID))
+	err = d.Set(SchemaApiKeyKey, teamServiceAccount.ApiKey)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	resourceSysdigTeamServiceAccountRead(ctx, d, m)
 
@@ -186,10 +190,6 @@ func teamServiceAccountToResourceData(teamServiceAccount *v2.TeamServiceAccount,
 		return err
 	}
 	err = d.Set(SchemaCreatedDateKey, teamServiceAccount.DateCreated)
-	if err != nil {
-		return err
-	}
-	err = d.Set(SchemaApiKeyKey, teamServiceAccount.ApiKey)
 	if err != nil {
 		return err
 	}

--- a/sysdig/resource_sysdig_team_service_account.go
+++ b/sysdig/resource_sysdig_team_service_account.go
@@ -34,19 +34,23 @@ func resourceSysdigTeamServiceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "ROLE_TEAM_READ",
+				ForceNew: true,
 			},
 			SchemaExpirationDateKey: {
 				Type:     schema.TypeInt,
 				Required: true,
+				ForceNew: true,
 			},
 			SchemaTeamIDKey: {
 				Type:     schema.TypeInt,
 				Required: true,
+				ForceNew: true,
 			},
 			SchemaSystemRoleKey: {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "ROLE_SERVICE_ACCOUNT",
+				ForceNew: true,
 			},
 			SchemaCreatedDateKey: {
 				Type:     schema.TypeInt,

--- a/sysdig/resource_sysdig_team_service_account_test.go
+++ b/sysdig/resource_sysdig_team_service_account_test.go
@@ -36,6 +36,33 @@ func TestAccTeamServiceAccount(t *testing.T) {
 						"role",
 						"ROLE_TEAM_READ",
 					),
+					resource.TestCheckResourceAttrSet("sysdig_team_service_account.service-account-monitor",
+						"api_key",
+					),
+					resource.TestCheckResourceAttr("sysdig_team_service_account.service-account-monitor",
+						"expiration_date",
+						"4070908800",
+					),
+				),
+			},
+			{
+				Config: teamServiceAccountMonitorTeamNewExpirationDate(monitorsvc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sysdig_team_service_account.service-account-monitor",
+						"name",
+						monitorsvc,
+					),
+					resource.TestCheckResourceAttr("sysdig_team_service_account.service-account-monitor",
+						"role",
+						"ROLE_TEAM_READ",
+					),
+					resource.TestCheckResourceAttrSet("sysdig_team_service_account.service-account-monitor",
+						"api_key",
+					),
+					resource.TestCheckResourceAttr("sysdig_team_service_account.service-account-monitor",
+						"expiration_date",
+						"4070995200",
+					),
 				),
 			},
 			{
@@ -49,6 +76,9 @@ func TestAccTeamServiceAccount(t *testing.T) {
 						"role",
 						"ROLE_TEAM_READ",
 					),
+					resource.TestCheckResourceAttrSet("sysdig_team_service_account.service-account-secure",
+						"api_key",
+					),
 				),
 			},
 		},
@@ -59,6 +89,28 @@ func teamServiceAccountMonitorTeam(name string) string {
 	return fmt.Sprintf(`
 resource "time_static" "example" {
   rfc3339 = "2099-01-01T00:00:00Z"
+}
+
+resource "sysdig_monitor_team" "sample" {
+  name      = "monitor-sample-%s"
+
+  entrypoint {
+	type = "Explore"
+  }
+}
+
+resource "sysdig_team_service_account" "service-account-monitor" {
+  name = "%s"
+  expiration_date = time_static.example.unix
+  team_id = sysdig_monitor_team.sample.id
+}
+`, name, name)
+}
+
+func teamServiceAccountMonitorTeamNewExpirationDate(name string) string {
+	return fmt.Sprintf(`
+resource "time_static" "example" {
+  rfc3339 = "2099-01-02T00:00:00Z"
 }
 
 resource "sysdig_monitor_team" "sample" {

--- a/website/docs/r/team_service_account.md
+++ b/website/docs/r/team_service_account.md
@@ -31,7 +31,7 @@ resource "sysdig_team_service_account" "service-account" {
   name = "read only"
   role = "ROLE_TEAM_READ"
   expiration_date = time_static.example.unix
-  team_id = sysdig_monitor_teamt.sample.id
+  team_id = sysdig_monitor_team.devops.id
 }
 
 ```
@@ -64,4 +64,3 @@ Sysdig team service account can be imported using the ID, e.g.
 ```
 $ terraform import sysdig_team_service_account.my_team_service_account 10
 ```
-


### PR DESCRIPTION
The `api_key` was not set because the rest endpoint returns it only after resource creation.

In the old implementation a user was allowed to update only the service account `name` because the BE endpoint that handles the resource update accepts only the `name`.
Was introduced the `ForceNew` schema behaviour that when a field different than name is updated requires the resource to be destroyed and recreated.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->