### PR TITLE
fix(secure-onboarding) Fixing the resource schema during reads

### DIFF
--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -103,6 +103,10 @@ resource "sysdig_secure_cloud_auth_account" "sample-1" {
 	  enabled    = "true"
 	  components = ["COMPONENT_SERVICE_PRINCIPAL/secure-posture"]
 	}
+	secure_identity_entitlement {
+	  enabled    = true
+	  components = ["COMPONENT_SERVICE_PRINCIPAL/secure-posture"]
+	}
   }
   component {
 	type                       = "COMPONENT_SERVICE_PRINCIPAL"

--- a/sysdig/resource_sysdig_secure_organization_test.go
+++ b/sysdig/resource_sysdig_secure_organization_test.go
@@ -53,6 +53,10 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
 	  enabled    = "true"
 	  components = ["COMPONENT_SERVICE_PRINCIPAL/secure-posture"]
 	}
+	secure_identity_entitlement {
+	  enabled    = true
+	  components = ["COMPONENT_SERVICE_PRINCIPAL/secure-posture"]
+	}
   }
   component {
 	type                       = "COMPONENT_SERVICE_PRINCIPAL"


### PR DESCRIPTION
Fix summary:
--------------
Currently the provider reads and returns one of the fields in the resource schema with incorrect structure. This results in unexpected diff during terraform re-apply.
- Fixing the interface conversion during reads for the same.
- Also updated the acceptance tests accordingly to test this.

Testing done:
--------------
Validated this using TF Acceptance tests as well as e2e manually.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->