### PR TITLE
Add support for Secure policy capture fields

### DIFF
--- a/sysdig/data_source_sysdig_secure_policy.go
+++ b/sysdig/data_source_sysdig_secure_policy.go
@@ -98,6 +98,18 @@ func createPolicyDataSourceSchema() map[string]*schema.Schema {
 									Type:     schema.TypeString,
 									Computed: true,
 								},
+								"filter": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"bucket_name": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"folder": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
 							},
 						},
 					},
@@ -134,6 +146,9 @@ func policyDataSourceToResourceData(policy v2.Policy, d *schema.ResourceData) {
 				"seconds_after_event":  action.AfterEventNs / 1000000000,
 				"seconds_before_event": action.BeforeEventNs / 1000000000,
 				"name":                 action.Name,
+				"filter":               action.Filter,
+				"bucket_name":          action.BucketName,
+				"folder":               action.Folder,
 			}}
 		}
 	}

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -260,10 +260,15 @@ type PolicyRule struct {
 	Enabled bool   `json:"enabled"`
 }
 
+// Did not add support storageId because FE does not support it yet
 type Action struct {
 	AfterEventNs         int    `json:"afterEventNs,omitempty"`
 	BeforeEventNs        int    `json:"beforeEventNs,omitempty"`
 	Name                 string `json:"name,omitempty"`
+	Filter               string `json:"filter,omitempty"`
+	StorageType          string `json:"storageType,omitempty"`
+	BucketName           string `json:"bucketName,omitempty"`
+	Folder               string `json:"folder,omitempty"`
 	IsLimitedToContainer bool   `json:"isLimitedToContainer"`
 	Type                 string `json:"type"`
 }

--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -91,6 +91,21 @@ var policyActionBlockSchema = &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"filter": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"bucket_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"folder": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "/",
+						},
 					},
 				},
 			},
@@ -194,6 +209,9 @@ func commonPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 				"seconds_after_event":  action.AfterEventNs / 1000000000,
 				"seconds_before_event": action.BeforeEventNs / 1000000000,
 				"name":                 action.Name,
+				"filter":               action.Filter,
+				"bucket_name":          action.BucketName,
+				"folder":               action.Folder,
 			}}
 		}
 	}
@@ -276,12 +294,19 @@ func addActionsToPolicy(d *schema.ResourceData, policy *v2.Policy) {
 		afterEventNs := d.Get("actions.0.capture.0.seconds_after_event").(int) * 1000000000
 		beforeEventNs := d.Get("actions.0.capture.0.seconds_before_event").(int) * 1000000000
 		name := d.Get("actions.0.capture.0.name").(string)
+		filter := d.Get("actions.0.capture.0.filter").(string)
+		bucketName := d.Get("actions.0.capture.0.bucket_name").(string)
+		folder := d.Get("actions.0.capture.0.folder").(string)
 		policy.Actions = append(policy.Actions, v2.Action{
 			Type:                 "POLICY_ACTION_CAPTURE",
 			IsLimitedToContainer: false,
 			AfterEventNs:         afterEventNs,
 			BeforeEventNs:        beforeEventNs,
 			Name:                 name,
+			Filter:               filter,
+			StorageType:          "S3",
+			BucketName:           bucketName,
+			Folder:               folder,
 		})
 	}
 }

--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -79,6 +79,9 @@ resource "sysdig_secure_policy" "sample" {
       seconds_before_event = 5
       seconds_after_event = 10
       name = "testcapture"
+      filter = "proc.name=cat"
+      bucket_name = "testbucket"
+      folder = "testfolder"
     }
   }
 
@@ -147,6 +150,8 @@ resource "sysdig_secure_policy" "sample_%d" {
       seconds_before_event = 5
       seconds_after_event = 10
       name = "capture_name"
+      filter = "proc.name=cat"
+      bucket_name = "testbucket"
     }
   }
 }

--- a/website/docs/d/secure_custom_policy.md
+++ b/website/docs/d/secure_custom_policy.md
@@ -63,4 +63,9 @@ The actions block is optional and supports:
     amount of seconds before the policy was triggered.
     * `seconds_after_event` - (Required) Captures the system calls for the amount
     of seconds after the policy was triggered.
-    * `name` - (Optional) The name of the capture file
+    * `name` - (Required) The name of the capture file
+    * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name=cat`
+    * `bucket_name` - (Optional) Custom bucket to store capture in, 
+    bucket should be onboarded in Integrations > S3 Capture Storage. Default is to use Sysdig Secure Storage 
+    * `folder` - (Optional) Name of folder to store capture inside the bucket. 
+    By default we will store the capture file at the root of the bucket

--- a/website/docs/d/secure_managed_policy.md
+++ b/website/docs/d/secure_managed_policy.md
@@ -63,4 +63,9 @@ The actions block is optional and supports:
     amount of seconds before the policy was triggered.
     * `seconds_after_event` - (Required) Captures the system calls for the amount
     of seconds after the policy was triggered.
-    * `name` - (Optional) The name of the capture file
+    * `name` - (Required) The name of the capture file
+    * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name=cat`
+    * `bucket_name` - (Optional) Custom bucket to store capture in, 
+    bucket should be onboarded in Integrations > S3 Capture Storage. Default is to use Sysdig Secure Storage 
+    * `folder` - (Optional) Name of folder to store capture inside the bucket. 
+    By default we will store the capture file at the root of the bucket

--- a/website/docs/d/secure_managed_ruleset.md
+++ b/website/docs/d/secure_managed_ruleset.md
@@ -63,4 +63,9 @@ The actions block is optional and supports:
     amount of seconds before the policy was triggered.
     * `seconds_after_event` - (Required) Captures the system calls for the amount
     of seconds after the policy was triggered.
-    * `name` - (Optional) The name of the capture file
+    * `name` - (Required) The name of the capture file
+    * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name=cat`
+    * `bucket_name` - (Optional) Custom bucket to store capture in, 
+    bucket should be onboarded in Integrations > S3 Capture Storage. Default is to use Sysdig Secure Storage 
+    * `folder` - (Optional) Name of folder to store capture inside the bucket. 
+    By default we will store the capture file at the root of the bucket

--- a/website/docs/r/secure_custom_policy.md
+++ b/website/docs/r/secure_custom_policy.md
@@ -86,7 +86,12 @@ The actions block is optional and supports:
     amount of seconds before the policy was triggered.
     * `seconds_after_event` - (Required) Captures the system calls for the amount
     of seconds after the policy was triggered.
-    * `name` - (Optional) The name of the capture file
+    * `name` - (Required) The name of the capture file
+    * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name=cat`
+    * `bucket_name` - (Optional) Custom bucket to store capture in, 
+    bucket should be onboarded in Integrations > S3 Capture Storage. Default is to use Sysdig Secure Storage 
+    * `folder` - (Optional) Name of folder to store capture inside the bucket. 
+    By default we will store the capture file at the root of the bucket
 
 - - -
 

--- a/website/docs/r/secure_managed_policy.md
+++ b/website/docs/r/secure_managed_policy.md
@@ -80,7 +80,12 @@ The actions block is optional and supports:
     amount of seconds before the policy was triggered.
     * `seconds_after_event` - (Required) Captures the system calls for the amount
     of seconds after the policy was triggered.
-    * `name` - (Optional) The name of the capture file
+    * `name` - (Required) The name of the capture file
+    * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name=cat`
+    * `bucket_name` - (Optional) Custom bucket to store capture in, 
+    bucket should be onboarded in Integrations > S3 Capture Storage. Default is to use Sysdig Secure Storage 
+    * `folder` - (Optional) Name of folder to store capture inside the bucket. 
+    By default we will store the capture file at the root of the bucket
 
 - - -
 

--- a/website/docs/r/secure_managed_ruleset.md
+++ b/website/docs/r/secure_managed_ruleset.md
@@ -95,7 +95,12 @@ The actions block is optional and supports:
     amount of seconds before the policy was triggered.
     * `seconds_after_event` - (Required) Captures the system calls for the amount
     of seconds after the policy was triggered.
-    * `name` - (Optional) The name of the capture file
+    * `name` - (Required) The name of the capture file
+    * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name=cat`
+    * `bucket_name` - (Optional) Custom bucket to store capture in, 
+    bucket should be onboarded in Integrations > S3 Capture Storage. Default is to use Sysdig Secure Storage 
+    * `folder` - (Optional) Name of folder to store capture inside the bucket. 
+    By default we will store the capture file at the root of the bucket
 
 - - -
 

--- a/website/docs/r/secure_policy.md
+++ b/website/docs/r/secure_policy.md
@@ -86,7 +86,12 @@ The actions block is optional and supports:
     amount of seconds before the policy was triggered.
     * `seconds_after_event` - (Required) Captures the system calls for the amount
     of seconds after the policy was triggered.
-    * `name` - (Optional) The name of the capture file
+    * `name` - (Required) The name of the capture file
+    * `filter` - (Optional) Additional filter to apply to the capture. For example: `proc.name=cat`
+    * `bucket_name` - (Optional) Custom bucket to store capture in, 
+    bucket should be onboarded in Integrations > S3 Capture Storage. Default is to use Sysdig Secure Storage 
+    * `folder` - (Optional) Name of folder to store capture inside the bucket. 
+    By default we will store the capture file at the root of the bucket
 
 - - -
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->
This PR adds support for the following three Secure Policy capture related optional fields:
- Filter (Filter string to reduce scope of a capture, eg. `proc.name=vi`)
- Bucket Name (to provide a custom S3 bucket to store the capture files)
- Folder (to provide a folder inside the S3 bucket)
