### PR TITLE
chore(serverless-agent) Rename Sysdig agent access key

### DIFF
--- a/sysdig/data_source_sysdig_fargate_ECS_test.go
+++ b/sysdig/data_source_sysdig_fargate_ECS_test.go
@@ -42,13 +42,13 @@ func sortAndCompare(t *testing.T, expected []byte, actual []byte) {
 // getKiltRecipe returns the default json Kilt recipe
 func getKiltRecipe(t *testing.T) string {
 	recipeConfig := KiltRecipeConfig{
-		SysdigAccessKey:  "sysdig_access_key",
-		AgentImage:       "workload_agent_image",
-		OrchestratorHost: "orchestrator_host",
-		OrchestratorPort: "orchestrator_port",
-		CollectorHost:    "collector_host",
-		CollectorPort:    "collector_port",
-		SysdigLogging:    "sysdig_logging",
+		SysdigAgentAccessKey: "sysdig_agent_access_key",
+		AgentImage:           "workload_agent_image",
+		OrchestratorHost:     "orchestrator_host",
+		OrchestratorPort:     "orchestrator_port",
+		CollectorHost:        "collector_host",
+		CollectorPort:        "collector_port",
+		SysdigLogging:        "sysdig_logging",
 	}
 
 	jsonRecipeConfig, err := json.Marshal(&recipeConfig)

--- a/sysdig/data_source_sysdig_fargate_workload_agent.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent.go
@@ -24,7 +24,7 @@ const agentinoKiltDefinition = `build {
         "SYSDIG_ORCHESTRATOR_PORT": ${config.orchestrator_port}
         "SYSDIG_COLLECTOR": ${config.collector_host}
         "SYSDIG_COLLECTOR_PORT": ${config.collector_port}
-        "SYSDIG_ACCESS_KEY": ${config.sysdig_access_key}
+        "SYSDIG_AGENT_ACCESS_KEY": ${config.sysdig_agent_access_key}
         "SYSDIG_LOGGING": ${config.sysdig_logging}
     }
     mount: [
@@ -47,9 +47,9 @@ func dataSourceSysdigFargateWorkloadAgent() *schema.Resource {
 				Description: "the input Fargate container definitions to instrument with the Sysdig workload agent",
 				Required:    true,
 			},
-			"sysdig_access_key": {
+			"sysdig_agent_access_key": {
 				Type:        schema.TypeString,
-				Description: "the Sysdig access key",
+				Description: "the Sysdig agent access key",
 				Optional:    true,
 			},
 			"workload_agent_image": {
@@ -291,13 +291,13 @@ func patchFargateTaskDefinition(ctx context.Context, containerDefinitions string
 }
 
 type KiltRecipeConfig struct {
-	SysdigAccessKey  string `json:"sysdig_access_key"`
-	AgentImage       string `json:"agent_image"`
-	OrchestratorHost string `json:"orchestrator_host"`
-	OrchestratorPort string `json:"orchestrator_port"`
-	CollectorHost    string `json:"collector_host"`
-	CollectorPort    string `json:"collector_port"`
-	SysdigLogging    string `json:"sysdig_logging"`
+	SysdigAgentAccessKey string `json:"sysdig_agent_access_key"`
+	AgentImage           string `json:"agent_image"`
+	OrchestratorHost     string `json:"orchestrator_host"`
+	OrchestratorPort     string `json:"orchestrator_port"`
+	CollectorHost        string `json:"collector_host"`
+	CollectorPort        string `json:"collector_port"`
+	SysdigLogging        string `json:"sysdig_logging"`
 }
 
 type patchOptions struct {
@@ -338,13 +338,13 @@ func newPatchOptions(d *schema.ResourceData) *patchOptions {
 
 func dataSourceSysdigFargateWorkloadAgentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	recipeConfig := KiltRecipeConfig{
-		SysdigAccessKey:  d.Get("sysdig_access_key").(string),
-		AgentImage:       d.Get("workload_agent_image").(string),
-		OrchestratorHost: d.Get("orchestrator_host").(string),
-		OrchestratorPort: d.Get("orchestrator_port").(string),
-		CollectorHost:    d.Get("collector_host").(string),
-		CollectorPort:    d.Get("collector_port").(string),
-		SysdigLogging:    d.Get("sysdig_logging").(string),
+		SysdigAgentAccessKey: d.Get("sysdig_agent_access_key").(string),
+		AgentImage:           d.Get("workload_agent_image").(string),
+		OrchestratorHost:     d.Get("orchestrator_host").(string),
+		OrchestratorPort:     d.Get("orchestrator_port").(string),
+		CollectorHost:        d.Get("collector_host").(string),
+		CollectorPort:        d.Get("collector_port").(string),
+		SysdigLogging:        d.Get("sysdig_logging").(string),
 	}
 
 	jsonConf, err := json.Marshal(&recipeConfig)

--- a/sysdig/data_source_sysdig_fargate_workload_agent_test.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent_test.go
@@ -35,7 +35,7 @@ data "sysdig_fargate_workload_agent" "test" {
 	image_auth_secret = ""
 	collector_host = "foo"
 	collector_port = 1234
-	sysdig_access_key = "abcdef"
+	sysdig_agent_access_key = "abcdef"
 	workload_agent_image = "busybox"
 	sysdig_logging = "info"
 }

--- a/sysdig/testfiles/ECSInstrumented.json
+++ b/sysdig/testfiles/ECSInstrumented.json
@@ -12,8 +12,8 @@
     ],
     "Environment": [
       {
-        "Name": "SYSDIG_ACCESS_KEY",
-        "Value": "sysdig_access_key"
+        "Name": "SYSDIG_AGENT_ACCESS_KEY",
+        "Value": "sysdig_agent_access_key"
       },
       {
         "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_bare_pdig_expected.json
+++ b/sysdig/testfiles/fargate_bare_pdig_expected.json
@@ -22,8 +22,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",
@@ -79,8 +79,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_cmd_test_expected.json
+++ b/sysdig/testfiles/fargate_cmd_test_expected.json
@@ -25,8 +25,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_combined_test_expected.json
+++ b/sysdig/testfiles/fargate_combined_test_expected.json
@@ -25,8 +25,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_entrypoint_test_expected.json
+++ b/sysdig/testfiles/fargate_entrypoint_test_expected.json
@@ -22,8 +22,8 @@
         "Value": "collector_port"
       },
       {
-        "Name": "SYSDIG_ACCESS_KEY",
-        "Value": "sysdig_access_key"
+        "Name": "SYSDIG_AGENT_ACCESS_KEY",
+        "Value": "sysdig_agent_access_key"
       },
       {
         "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_env_test_expected.json
+++ b/sysdig/testfiles/fargate_env_test_expected.json
@@ -22,8 +22,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_field_case_test_expected.json
+++ b/sysdig/testfiles/fargate_field_case_test_expected.json
@@ -22,8 +22,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",
@@ -71,8 +71,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_ignore_container_test_expected.json
+++ b/sysdig/testfiles/fargate_ignore_container_test_expected.json
@@ -22,8 +22,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_linuxparameters_test_expected.json
+++ b/sysdig/testfiles/fargate_linuxparameters_test_expected.json
@@ -22,8 +22,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_log_group_expected.json
+++ b/sysdig/testfiles/fargate_log_group_expected.json
@@ -25,8 +25,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",

--- a/sysdig/testfiles/fargate_volumesfrom_test_expected.json
+++ b/sysdig/testfiles/fargate_volumesfrom_test_expected.json
@@ -25,8 +25,8 @@
                 "Value": "collector_port"
             },
             {
-                "Name": "SYSDIG_ACCESS_KEY",
-                "Value": "sysdig_access_key"
+                "Name": "SYSDIG_AGENT_ACCESS_KEY",
+                "Value": "sysdig_agent_access_key"
             },
             {
                 "Name": "SYSDIG_LOGGING",


### PR DESCRIPTION
Rename to sysdig_agent_access_key to match BE UI.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->