### PR TITLE
Pass provider alias to cloud account creation call

### DIFF
--- a/sysdig/common.go
+++ b/sysdig/common.go
@@ -62,4 +62,5 @@ const (
 	SchemaOrganizationIDKey         = "organization_id"
 	SchemaOrganizationalUnitIds     = "organizational_unit_ids"
 	SchemaCloudProviderTenantId     = "provider_tenant_id"
+	SchemaCloudProviderAlias        = "provider_alias"
 )

--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -163,6 +163,10 @@ func resourceSysdigSecureCloudauthAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			SchemaCloudProviderAlias: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -521,6 +525,7 @@ func cloudauthAccountFromResourceData(data *schema.ResourceData) *v2.CloudauthAc
 			Components:       accountComponents,
 			Feature:          accountFeatures,
 			ProviderTenantId: data.Get(SchemaCloudProviderTenantId).(string),
+			ProviderAlias:    data.Get(SchemaCloudProviderAlias).(string),
 		},
 	}
 }
@@ -739,6 +744,11 @@ func cloudauthAccountToResourceData(data *schema.ResourceData, cloudAccount *v2.
 
 	if cloudAccount.Provider == cloudauth.Provider_PROVIDER_AZURE {
 		err = data.Set(SchemaCloudProviderTenantId, cloudAccount.ProviderTenantId)
+		if err != nil {
+			return err
+		}
+
+		err = data.Set(SchemaCloudProviderAlias, cloudAccount.ProviderAlias)
 		if err != nil {
 			return err
 		}

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -190,6 +190,7 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
 	  provider_type = "PROVIDER_AZURE"
 	  enabled       = true
 	  provider_tenant_id = "%s"
+	  provider_alias = "some-alias"
 	}`, accountId, randomTenantId)
 }
 
@@ -231,6 +232,7 @@ func secureAzureCloudAuthAccountWithFC(accountID string) string {
 			provider_type = "PROVIDER_AZURE"
 			enabled       = true
 			provider_tenant_id = "%s"
+			provider_alias = "some-alias"
 			feature {
 				secure_config_posture {
 					enabled    = true


### PR DESCRIPTION
This PR is to pass `provider_alias` field as part of cloud account creation call to support org onboarding.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->