### PR TITLE
fix(dashboards) prevent false drift with optional legend and query format

### DIFF
--- a/sysdig/internal/client/v2/model_dashboard.go
+++ b/sysdig/internal/client/v2/model_dashboard.go
@@ -120,7 +120,7 @@ func NewFormat(
 	}
 }
 
-func newPercentFormat() Format {
+func NewPercentFormat() Format {
 	return *NewFormat(
 		FormatUnitPercentage,
 		"0-100",
@@ -132,7 +132,7 @@ func newPercentFormat() Format {
 	)
 }
 
-func newDataFormat() Format {
+func NewDataFormat() Format {
 	return *NewFormat(
 		FormatUnitData,
 		"B",
@@ -144,7 +144,7 @@ func newDataFormat() Format {
 	)
 }
 
-func newDataRateFormat() Format {
+func NewDataRateFormat() Format {
 	return *NewFormat(
 		FormatUnitDataRate,
 		"B/s",
@@ -156,7 +156,7 @@ func newDataRateFormat() Format {
 	)
 }
 
-func newNumberFormat() Format {
+func NewNumberFormat() Format {
 	return *NewFormat(
 		FormatUnitNumber,
 		"1",
@@ -168,7 +168,7 @@ func newNumberFormat() Format {
 	)
 }
 
-func newNumberRateFormat() Format {
+func NewNumberRateFormat() Format {
 	return *NewFormat(
 		FormatUnitNumberRate,
 		"/s",
@@ -180,7 +180,7 @@ func newNumberRateFormat() Format {
 	)
 }
 
-func newTimeFormat() Format {
+func NewTimeFormat() Format {
 	return *NewFormat(
 		FormatUnitTime,
 		"ns",
@@ -209,7 +209,7 @@ func NewPromqlQuery(query string, parentPanel *Panels, displayInfo DisplayInfo) 
 			TimeSeriesDisplayNameTemplate: displayInfo.TimeSeriesDisplayNameTemplate,
 			Type:                          displayInfo.Type,
 		},
-		Format:      newPercentFormat(),
+		Format:      NewPercentFormat(),
 		Query:       query,
 		ID:          0,
 		ParentPanel: parentPanel,
@@ -263,37 +263,37 @@ func (q *AdvancedQueries) updateFormat(f *Format) {
 }
 
 func (q *AdvancedQueries) WithPercentFormat(f *Format) *AdvancedQueries {
-	q.Format = newPercentFormat()
+	q.Format = NewPercentFormat()
 	q.updateFormat(f)
 	return q
 }
 
 func (q *AdvancedQueries) WithDataFormat(f *Format) *AdvancedQueries {
-	q.Format = newDataFormat()
+	q.Format = NewDataFormat()
 	q.updateFormat(f)
 	return q
 }
 
 func (q *AdvancedQueries) WithDataRateFormat(f *Format) *AdvancedQueries {
-	q.Format = newDataRateFormat()
+	q.Format = NewDataRateFormat()
 	q.updateFormat(f)
 	return q
 }
 
 func (q *AdvancedQueries) WithNumberFormat(f *Format) *AdvancedQueries {
-	q.Format = newNumberFormat()
+	q.Format = NewNumberFormat()
 	q.updateFormat(f)
 	return q
 }
 
 func (q *AdvancedQueries) WithNumberRateFormat(f *Format) *AdvancedQueries {
-	q.Format = newNumberRateFormat()
+	q.Format = NewNumberRateFormat()
 	q.updateFormat(f)
 	return q
 }
 
 func (q *AdvancedQueries) WithTimeFormat(f *Format) *AdvancedQueries {
-	q.Format = newTimeFormat()
+	q.Format = NewTimeFormat()
 	q.updateFormat(f)
 	return q
 }

--- a/sysdig/resource_sysdig_monitor_dashboard_test.go
+++ b/sysdig/resource_sysdig_monitor_dashboard_test.go
@@ -384,6 +384,7 @@ resource "sysdig_monitor_dashboard" "dashboard_2" {
 			unit = "percent"
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "0-100"
                 y_axis = "auto"
@@ -439,6 +440,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			unit = "percent"
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "0-100"
                 y_axis = "auto"
@@ -450,6 +452,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			unit = "number"
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "1"
                 y_axis = "auto"
@@ -472,6 +475,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			unit = "time"
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "ns"
                 y_axis = "auto"
@@ -522,6 +526,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			unit = "percent"
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "0-100"
                 y_axis = "auto"
@@ -533,6 +538,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			unit = "number"
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "1"
                 y_axis = "auto"
@@ -607,6 +613,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			unit = "percent"
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "0-100"
                 y_axis = "auto"
@@ -674,6 +681,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			}
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "0-100"
                 y_axis = "auto"
@@ -689,6 +697,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			}
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "1"
                 y_axis = "auto"
@@ -711,6 +720,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			unit = "time"
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "ns"
                 y_axis = "auto"
@@ -785,6 +795,7 @@ resource "sysdig_monitor_dashboard" "dashboard" {
 			}
 
             format {
+				decimals= 2
                 display_format = "auto"
                 input_format = "0-100"
                 y_axis = "auto"


### PR DESCRIPTION
The resource `sysdig_monitor_dashboard` has the `panel.legend` and `panel.query.format` fields that are optional. If the user doesn't configure these fields, the provider initializes those with some default values.

Currently, if the user runs `terraform plan/apply` without a legend, or a query format, the provider always shows some diffs even if the dashboard was not changed.

This PR fixes the mapping in `resourceSysdigDashboardRead` to prevent these drifts.