### PR TITLE
(secure-onboarding) Handle and populate errors from secure backend

### DIFF
--- a/sysdig/internal/client/v2/cloudauth.go
+++ b/sysdig/internal/client/v2/cloudauth.go
@@ -19,30 +19,34 @@ const (
 
 type CloudauthAccountSecureInterface interface {
 	Base
-	CreateCloudauthAccountSecure(ctx context.Context, cloudAccount *CloudauthAccountSecure) (*CloudauthAccountSecure, error)
+	CreateCloudauthAccountSecure(ctx context.Context, cloudAccount *CloudauthAccountSecure) (*CloudauthAccountSecure, string, error)
 	GetCloudauthAccountSecure(ctx context.Context, accountID string) (*CloudauthAccountSecure, string, error)
 	DeleteCloudauthAccountSecure(ctx context.Context, accountID string) (string, error)
 	UpdateCloudauthAccountSecure(ctx context.Context, accountID string, cloudAccount *CloudauthAccountSecure) (*CloudauthAccountSecure, string, error)
 }
 
-func (client *Client) CreateCloudauthAccountSecure(ctx context.Context, cloudAccount *CloudauthAccountSecure) (*CloudauthAccountSecure, error) {
+func (client *Client) CreateCloudauthAccountSecure(ctx context.Context, cloudAccount *CloudauthAccountSecure) (*CloudauthAccountSecure, string, error) {
 	payload, err := client.marshalProto(cloudAccount)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	response, err := client.requester.Request(ctx, http.MethodPost, client.cloudauthAccountsURL(), payload)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
-		err = client.ErrorFromResponse(response)
-		return nil, err
+		errStatus, err := client.ErrorAndStatusFromResponse(response)
+		return nil, errStatus, err
 	}
 
-	return client.unmarshalProto(response.Body)
+	cloudauthAccount, err := client.unmarshalProto(response.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	return cloudauthAccount, "", nil
 }
 
 func (client *Client) GetCloudauthAccountSecure(ctx context.Context, accountID string) (*CloudauthAccountSecure, string, error) {

--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -181,9 +181,9 @@ func resourceSysdigSecureCloudauthAccountCreate(ctx context.Context, data *schem
 		return diag.FromErr(err)
 	}
 
-	cloudauthAccount, err := client.CreateCloudauthAccountSecure(ctx, cloudauthAccountFromResourceData(data))
+	cloudauthAccount, errStatus, err := client.CreateCloudauthAccountSecure(ctx, cloudauthAccountFromResourceData(data))
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("Error creating resource: %s %s", errStatus, err)
 	}
 
 	data.SetId(cloudauthAccount.Id)
@@ -206,11 +206,10 @@ func resourceSysdigSecureCloudauthAccountRead(ctx context.Context, data *schema.
 		if strings.Contains(errStatus, "404") {
 			return nil
 		}
-		return diag.FromErr(err)
+		return diag.Errorf("Error reading resource: %s %s", errStatus, err)
 	}
 
 	err = cloudauthAccountToResourceData(data, cloudauthAccount)
-
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -229,7 +228,7 @@ func resourceSysdigSecureCloudauthAccountUpdate(ctx context.Context, data *schem
 		if strings.Contains(errStatus, "404") {
 			return nil
 		}
-		return diag.FromErr(err)
+		return diag.Errorf("Error reading resource: %s %s", errStatus, err)
 	}
 
 	newCloudAccount := cloudauthAccountFromResourceData(data)
@@ -237,7 +236,7 @@ func resourceSysdigSecureCloudauthAccountUpdate(ctx context.Context, data *schem
 	// validate and reject non-updatable resource schema fields upfront
 	err = validateCloudauthAccountUpdate(existingCloudAccount, newCloudAccount)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("Error updating resource: %s", err)
 	}
 
 	_, errStatus, err = client.UpdateCloudauthAccountSecure(ctx, data.Id(), newCloudAccount)
@@ -245,7 +244,7 @@ func resourceSysdigSecureCloudauthAccountUpdate(ctx context.Context, data *schem
 		if strings.Contains(errStatus, "404") {
 			return nil
 		}
-		return diag.FromErr(err)
+		return diag.Errorf("Error updating resource: %s %s", errStatus, err)
 	}
 
 	return nil
@@ -263,7 +262,7 @@ func resourceSysdigSecureCloudauthAccountDelete(ctx context.Context, data *schem
 		if strings.Contains(errStatus, "404") {
 			return nil
 		}
-		return diag.FromErr(err)
+		return diag.Errorf("Error deleting resource: %s %s", errStatus, err)
 	}
 
 	return nil

--- a/sysdig/resource_sysdig_secure_organization.go
+++ b/sysdig/resource_sysdig_secure_organization.go
@@ -61,9 +61,9 @@ func resourceSysdigSecureOrganizationCreate(ctx context.Context, data *schema.Re
 
 	org := secureOrganizationFromResourceData(data)
 
-	orgCreated, err := client.CreateOrganizationSecure(ctx, org)
+	orgCreated, errStatus, err := client.CreateOrganizationSecure(ctx, org)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("Error creating resource: %s %s", errStatus, err)
 	}
 
 	data.SetId(orgCreated.Id)
@@ -82,7 +82,7 @@ func resourceSysdigSecureOrganizationDelete(ctx context.Context, data *schema.Re
 		if strings.Contains(errStatus, "404") {
 			return nil
 		}
-		return diag.FromErr(err)
+		return diag.Errorf("Error deleting resource: %s %s", errStatus, err)
 	}
 
 	return nil
@@ -99,7 +99,7 @@ func resourceSysdigSecureOrganizationRead(ctx context.Context, data *schema.Reso
 		if strings.Contains(errStatus, "404") {
 			return nil
 		}
-		return diag.FromErr(err)
+		return diag.Errorf("Error reading resource: %s %s", errStatus, err)
 	}
 
 	err = secureOrganizationToResourceData(data, org)
@@ -123,7 +123,7 @@ func resourceSysdigSecureOrganizationUpdate(ctx context.Context, data *schema.Re
 		if strings.Contains(errStatus, "404") {
 			return nil
 		}
-		return diag.FromErr(err)
+		return diag.Errorf("Error updating resource: %s %s", errStatus, err)
 	}
 
 	return nil


### PR DESCRIPTION
Fix summary:
-------------
Currently any of the backend API errors are returned by the provider as: `"Error: Empty Summary: This is always a bug in the provider and should be reported to the provider developers."` This is not useful at all.

Hence, surfacing up the errors coming from backend during Create/Read/Update/Delete operations for `secure_cloud_auth_account` and `secure_organization` resources.

Currently:
```
sysdig_secure_cloud_auth_account.gcp_project_foo: Creating...
╷
│ Error: Empty Summary: This is always a bug in the provider and should be reported to the provider developers.
```

With this change:
```
sysdig_secure_cloud_auth_account.gcp_project_foo: Creating...
╷
│ Error: Error creating resource: 409 Conflict {"error":"entity already exists","accountId":"76xxxxxxx-xxxx-xxxx-xx-xx"}
```

Testing done:
---------------
Tested on an actual setup that errors are populated appropriately.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->