### PR TITLE
fix(alerts): treat notification_channels as set

### DIFF
--- a/sysdig/resource_sysdig_monitor_alert_common.go
+++ b/sysdig/resource_sysdig_monitor_alert_common.go
@@ -61,7 +61,7 @@ func createAlertSchema(original map[string]*schema.Schema) map[string]*schema.Sc
 			Default:  true,
 		},
 		"notification_channels": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeInt},
 			Optional: true,
 		},
@@ -170,7 +170,8 @@ func alertFromResourceData(d *schema.ResourceData) (alert *v2.Alert, err error) 
 	}
 
 	if channels, ok := d.GetOk("notification_channels"); ok {
-		for _, channel := range channels.([]interface{}) {
+		channelSet := channels.(*schema.Set)
+		for _, channel := range channelSet.List() {
 			alert.NotificationChannelIds = append(alert.NotificationChannelIds, channel.(int))
 		}
 	}


### PR DESCRIPTION
`notification_channels` attribute is considered a set in the backend, we should also treat it as set in the terraform provider so that drifts are not wrongly reported like in this example: 
```
  # sysdig_monitor_alert_metric.alert will be updated in-place
  ~ resource "sysdig_monitor_alert_metric" "alert" {
        id                    = "44198694"
        name                  = "test"
      ~ notification_channels = [
          - 1610269,
            1742117,
          + 1610269,
        ]
        # (9 unchanged attributes hidden)
    }
```
The underlying representation of list and set is the same in the state, so this is retro compatible.
