### PR TITLE
feat(tests): Add tags to run the proper set of tests on onprem

### DIFF
--- a/buildinfo/info.go
+++ b/buildinfo/info.go
@@ -6,4 +6,6 @@ var (
 	SysdigSecure  bool
 	IBMMonitor    bool
 	IBMSecure     bool
+	OnpremMonitor bool
+	OnpremSecure  bool
 )

--- a/buildinfo/onprem_monitor.go
+++ b/buildinfo/onprem_monitor.go
@@ -1,0 +1,7 @@
+//go:build tf_acc_onprem_monitor
+
+package buildinfo
+
+func init() {
+	OnpremMonitor = true
+}

--- a/buildinfo/onprem_secure.go
+++ b/buildinfo/onprem_secure.go
@@ -1,0 +1,7 @@
+//go:build tf_acc_onprem_secure
+
+package buildinfo
+
+func init() {
+	OnpremSecure = true
+}

--- a/sysdig/data_source_sysdig_current_user_test.go
+++ b/sysdig/data_source_sysdig_current_user_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm_monitor || tf_acc_onprem_monitor || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_custom_role_test.go
+++ b/sysdig/data_source_sysdig_custom_role_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_onprem_monitor || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_fargate_workload_agent_test.go
+++ b/sysdig/data_source_sysdig_fargate_workload_agent_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_onprem_monitor || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_custom_role_permissions_test.go
+++ b/sysdig/data_source_sysdig_monitor_custom_role_permissions_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_custom_webhook_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_custom_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_google_chat_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_google_chat_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_ibm_event_notification_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_ibm_event_notification_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_ibm_function_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_ibm_function_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_msteams_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_msteams_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_opsgenie_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_prometheus_alert_manager_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_prometheus_alert_manager_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_sns_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_team_email_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_team_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_victorops_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_monitor_notification_channel_webhook_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_current_connection_test.go
+++ b/sysdig/data_source_sysdig_secure_current_connection_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_custom_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_custom_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_custom_role_permissions_test.go
+++ b/sysdig/data_source_sysdig_secure_custom_role_permissions_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_managed_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_managed_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_managed_ruleset_test.go
+++ b/sysdig/data_source_sysdig_secure_managed_ruleset_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_email_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_msteams_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_msteams_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_opsgenie_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_pagerduty_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_prometheus_alert_manager_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_prometheus_alert_manager_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_slack_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_sns_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_team_email_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_team_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_victorops_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_webhook_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_ibm_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rule_container_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_container_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rule_falco_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rule_filesystem_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_filesystem_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rule_network_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_network_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rule_process_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_process_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_rule_syscall_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_syscall_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig || tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_trusted_cloud_identity_test.go
+++ b/sysdig/data_source_sysdig_secure_trusted_cloud_identity_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_secure || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_user_test.go
+++ b/sysdig/data_source_sysdig_user_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_onprem_monitor || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/provider_test.go
+++ b/sysdig/provider_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_ibm_monitor || tf_acc_onprem_monitor || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_custom_role_test.go
+++ b/sysdig/resource_sysdig_custom_role_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_onprem_monitor || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_group_mapping_config_test.go
+++ b/sysdig/resource_sysdig_group_mapping_config_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_group_mapping_test.go
+++ b/sysdig/resource_sysdig_group_mapping_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_onprem_monitor || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_anomaly_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_downtime_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_downtime_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_event_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_event_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_group_outlier_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_group_outlier_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_metric_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_promql_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_promql_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_change_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_change_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_downtime_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_event_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_event_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_group_outlier_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_group_outlier_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_prometheus_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_dashboard_test.go
+++ b/sysdig/resource_sysdig_monitor_dashboard_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_custom_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_custom_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_google_chat_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_google_chat_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_ibm_cloud_function_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_ibm_cloud_function_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_msteams_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_msteams_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_prometheus_alert_manager_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_prometheus_alert_manager_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_team_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_team_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_ibm_monitor || tf_acc_ibm_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_silence_rule_test.go
+++ b/sysdig/resource_sysdig_monitor_silence_rule_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor
+//go:build tf_acc_sysdig_monitor || tf_acc_ibm_monitor || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_monitor_team_test.go
+++ b/sysdig/resource_sysdig_monitor_team_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_common || tf_acc_onprem_monitor
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_cloud_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_account_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_list_test.go
+++ b/sysdig/resource_sysdig_secure_list_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_macro_test.go
+++ b/sysdig/resource_sysdig_secure_macro_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_managed_policy_test.go
+++ b/sysdig/resource_sysdig_secure_managed_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_managed_ruleset_test.go
+++ b/sysdig/resource_sysdig_secure_managed_ruleset_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_email_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_msteams_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_msteams_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_opsgenie_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_pagerduty_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_prometheus_alert_manager_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_prometheus_alert_manager_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_sns_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_team_email_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_team_email_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_victorops_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_container_test.go
+++ b/sysdig/resource_sysdig_secure_rule_container_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_filesystem_test.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_network_test.go
+++ b/sysdig/resource_sysdig_secure_rule_network_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_process_test.go
+++ b/sysdig/resource_sysdig_secure_rule_process_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_rule_syscall_test.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_team_test.go
+++ b/sysdig/resource_sysdig_secure_team_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common
+//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common || tf_acc_ibm_secure || tf_acc_ibm_common || tf_acc_onprem_secure
 
 package sysdig_test
 
@@ -38,9 +38,15 @@ func TestAccSecureTeam(t *testing.T) {
 			},
 			{
 				Config: secureTeamWithPostureZones(randomText(10)),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.OnpremSecure, nil
+				},
 			},
 			{
 				Config: secureTeamWithPostureZonesAndAllZones(randomText(10)),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.OnpremSecure, nil
+				},
 				ExpectError: regexp.MustCompile(
 					fmt.Sprintf("if %s is enabled, %s must be omitted",
 						sysdig.SchemaAllZones,

--- a/sysdig/resource_sysdig_team_service_account_test.go
+++ b/sysdig/resource_sysdig_team_service_account_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_onprem_monitor || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_user_test.go
+++ b/sysdig/resource_sysdig_user_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure
+//go:build tf_acc_sysdig_monitor || tf_acc_sysdig_secure || tf_acc_onprem_monitor || tf_acc_onprem_secure
 
 package sysdig_test
 


### PR DESCRIPTION
Add the `tf_acc_onprem_monitor` and `tf_acc_onprem_secure` tags to the tests that can run against an onprem deployment. Currently, some of the tests tagged as `tf_acc_sysdig_xxx` fail against onprem because it lacks some components (e.g. posture) or they can be conditionally installed (e.g. legacy scanning)