### PR TITLE
add support for awscloudtrail, okta, and github rules and policies

### DIFF
--- a/sysdig/resource_sysdig_secure_policy.go
+++ b/sysdig/resource_sysdig_secure_policy.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var validatePolicyType = validation.StringInSlice([]string{"falco", "list_matching", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", "azure_platformlogs"}, false)
+var validatePolicyType = validation.StringInSlice([]string{"falco", "list_matching", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", "azure_platformlogs", "awscloudtrail", "okta", "github"}, false)
 
 // Creates the common policy schema that is shared between policy resources
 func createPolicySchema(original map[string]*schema.Schema) map[string]*schema.Schema {

--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -56,6 +56,15 @@ func TestAccPolicy(t *testing.T) {
 			{
 				Config: policiesForAzurePlatformlogs(rText()),
 			},
+      {
+        Config: policiesForFalcoCloudAWSCloudtrail(rText()),
+      },
+      {
+        Config: policiesForOkta(rText()),
+      },
+      {
+        Config: policiesForGithub(rText()),
+      }
 		},
 	})
 }
@@ -206,6 +215,39 @@ resource "sysdig_secure_policy" "sample6" {
   name = "TERRAFORM TEST %s"
   description = "TERRAFORM TEST %s"
   type = "azure_platformlogs"
+  actions {}
+}
+`, name, name)
+}
+
+func policiesForFalcoCloudAWSCloudtrail(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_policy" "sample7" {
+  name = "TERRAFORM TEST 4 %s"
+  description = "TERRAFORM TEST %s"
+  type = "awscloudtrail"
+  actions {}
+}
+`, name, name)
+}
+
+func policiesForOkta(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_policy" "sample8" {
+  name = "TERRAFORM TEST 4 %s"
+  description = "TERRAFORM TEST %s"
+  type = "okta"
+  actions {}
+}
+`, name, name)
+}
+
+func policiesForGithub(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_policy" "sample9" {
+  name = "TERRAFORM TEST 4 %s"
+  description = "TERRAFORM TEST %s"
+  type = "github"
   actions {}
 }
 `, name, name)

--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -56,15 +56,15 @@ func TestAccPolicy(t *testing.T) {
 			{
 				Config: policiesForAzurePlatformlogs(rText()),
 			},
-      {
-        Config: policiesForFalcoCloudAWSCloudtrail(rText()),
-      },
-      {
-        Config: policiesForOkta(rText()),
-      },
-      {
-        Config: policiesForGithub(rText()),
-      }
+			{
+				Config: policiesForFalcoCloudAWSCloudtrail(rText()),
+			},
+			{
+				Config: policiesForOkta(rText()),
+			},
+			{
+				Config: policiesForGithub(rText()),
+			},
 		},
 	})
 }

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cast"
 )
 
-var validateFalcoRuleSource = validation.StringInSlice([]string{"syscall", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", "azure_platformlogs"}, false)
+var validateFalcoRuleSource = validation.StringInSlice([]string{"syscall", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", "azure_platformlogs", "awscloudtrail", "okta", "github"}, false)
 
 func resourceSysdigSecureRuleFalco() *schema.Resource {
 	timeout := 5 * time.Minute

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -306,7 +306,7 @@ resource "sysdig_secure_rule_falco" "awscloudtrail" {
 
 func ruleFalcoCloudAWSCloudtrailWithAppend() string {
 	return fmt.Sprintf(`
-resource "sysdig_secure_rule_falco" "awscloudtrail" {
+resource "sysdig_secure_rule_falco" "awscloudtrail_append" {
   name = "Amplify Create App"
   source = "awscloudtrail"
   append = true
@@ -335,7 +335,7 @@ resource "sysdig_secure_rule_falco" "okta" {
 
 func ruleOktaWithAppend() string {
 	return fmt.Sprintf(`
-resource "sysdig_secure_rule_falco" "okta" {
+resource "sysdig_secure_rule_falco" "okta_append" {
   name = "User changing password in to Okta"
   source = "okta"
   append = true
@@ -364,7 +364,7 @@ resource "sysdig_secure_rule_falco" "github" {
 
 func ruleGithubWithAppend() string {
 	return fmt.Sprintf(`
-resource "sysdig_secure_rule_falco" "github" {
+resource "sysdig_secure_rule_falco" "github_append" {
   name = "Github Webhook Connected"
   source = "github"
   append = true

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -98,19 +98,19 @@ func TestAccRuleFalco(t *testing.T) {
 				Config: ruleFalcoCloudAWSCloudtrail(randomText),
 			},
 			{
-				Config: ruleFalcoCloudAWSCloudtrailWithAppend(randomText),
+				Config: ruleFalcoCloudAWSCloudtrailWithAppend(),
 			},
 			{
 				Config: ruleOkta(randomText),
 			},
 			{
-				Config: ruleOktaWithAppend(randomText),
+				Config: ruleOktaWithAppend(),
 			},
 			{
 				Config: ruleGithub(randomText),
 			},
 			{
-				Config: ruleGithubWithAppend(randomText),
+				Config: ruleGithubWithAppend(),
 			},
 		},
 	})
@@ -304,10 +304,10 @@ resource "sysdig_secure_rule_falco" "awscloudtrail" {
 }`, name, name)
 }
 
-func ruleFalcoCloudAWSCloudtrailWithAppend(name string) string {
+func ruleFalcoCloudAWSCloudtrailWithAppend() string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "awscloudtrail" {
-  name = "TERRAFORM TEST %[1]s - AWSCloudtrail"
+  name = "Amplify Create App"
   source = "awscloudtrail"
   append = true
   exceptions {
@@ -316,7 +316,7 @@ resource "sysdig_secure_rule_falco" "awscloudtrail" {
 	comps = ["="]
 	values = jsonencode([ ["user_a"] ])
    }
-}`, name)
+}`)
 }
 
 func ruleOkta(name string) string {
@@ -333,10 +333,10 @@ resource "sysdig_secure_rule_falco" "okta" {
 }`, name, name)
 }
 
-func ruleOktaWithAppend(name string) string {
+func ruleOktaWithAppend() string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "okta" {
-  name = "TERRAFORM TEST %[1]s - Okta"
+  name = "User changing password in to Okta"
   source = "okta"
   append = true
   exceptions {
@@ -345,7 +345,7 @@ resource "sysdig_secure_rule_falco" "okta" {
 	comps = ["="]
 	values = jsonencode([ ["user_b"] ])
    }
-}`, name)
+}`)
 }
 
 func ruleGithub(name string) string {
@@ -362,10 +362,10 @@ resource "sysdig_secure_rule_falco" "github" {
 }`, name, name)
 }
 
-func ruleGithubWithAppend(name string) string {
+func ruleGithubWithAppend() string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "github" {
-  name = "TERRAFORM TEST %[1]s - Github"
+  name = "Github Webhook Connected"
   source = "github"
   append = true
   exceptions {
@@ -374,5 +374,5 @@ resource "sysdig_secure_rule_falco" "github" {
 	comps = ["="]
 	values = jsonencode([ ["user_c"] ])
    }
-}`, name)
+}`)
 }

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -305,7 +305,7 @@ resource "sysdig_secure_rule_falco" "awscloudtrail" {
 }
 
 func ruleFalcoCloudAWSCloudtrailWithAppend() string {
-	return fmt.Sprintf(`
+	return `
 resource "sysdig_secure_rule_falco" "awscloudtrail_append" {
   name = "Amplify Create App"
   source = "awscloudtrail"
@@ -316,7 +316,7 @@ resource "sysdig_secure_rule_falco" "awscloudtrail_append" {
 	comps = ["="]
 	values = jsonencode([ ["user_a"] ])
    }
-}`)
+}`
 }
 
 func ruleOkta(name string) string {
@@ -334,7 +334,7 @@ resource "sysdig_secure_rule_falco" "okta" {
 }
 
 func ruleOktaWithAppend() string {
-	return fmt.Sprintf(`
+	return `
 resource "sysdig_secure_rule_falco" "okta_append" {
   name = "User changing password in to Okta"
   source = "okta"
@@ -345,7 +345,7 @@ resource "sysdig_secure_rule_falco" "okta_append" {
 	comps = ["="]
 	values = jsonencode([ ["user_b"] ])
    }
-}`)
+}`
 }
 
 func ruleGithub(name string) string {
@@ -363,7 +363,7 @@ resource "sysdig_secure_rule_falco" "github" {
 }
 
 func ruleGithubWithAppend() string {
-	return fmt.Sprintf(`
+	return `
 resource "sysdig_secure_rule_falco" "github_append" {
   name = "Github Webhook Connected"
   source = "github"
@@ -374,5 +374,5 @@ resource "sysdig_secure_rule_falco" "github_append" {
 	comps = ["="]
 	values = jsonencode([ ["user_c"] ])
    }
-}`)
+}`
 }

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -301,7 +301,7 @@ resource "sysdig_secure_rule_falco" "awscloudtrail" {
   output = "AWSCloudtrail Event received (requesting user=%ct.user)"
   priority = "debug"
   source = "awscloudtrail"
-}`, name)
+}`, name, name)
 }
 
 func ruleFalcoCloudAWSCloudtrailWithAppend(name string) string {
@@ -329,7 +329,7 @@ resource "sysdig_secure_rule_falco" "okta" {
   output = "Okta Event received (okta.severity=%okta.severity)"
   priority = "debug"
   source = "okta"
-}`, name)
+}`, name, name)
 }
 
 func ruleOktaWithAppend(name string) string {
@@ -357,7 +357,7 @@ resource "sysdig_secure_rule_falco" "github" {
   output = "Github Event received (github.user=%github.user)"
   priority = "debug"
   source = "github"
-}`, name)
+}`, name, name)
 }
 
 func ruleGithubWithAppend(name string) string {

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -298,7 +298,7 @@ resource "sysdig_secure_rule_falco" "awscloudtrail" {
   tags = ["awscloudtrail"]
 
   condition = "ct.name=\"CreateApp\""
-  output = "AWSCloudtrail Event received (requesting user=%ct.user)"
+  output = "AWSCloudtrail Event received (requesting user=%%ct.user)"
   priority = "debug"
   source = "awscloudtrail"
 }`, name, name)
@@ -326,7 +326,7 @@ resource "sysdig_secure_rule_falco" "okta" {
   tags = ["okta"]
 
   condition = "okta.evt.type=\"user.account.update_password\""
-  output = "Okta Event received (okta.severity=%okta.severity)"
+  output = "Okta Event received (okta.severity=%%okta.severity)"
   priority = "debug"
   source = "okta"
 }`, name, name)
@@ -354,7 +354,7 @@ resource "sysdig_secure_rule_falco" "github" {
   tags = ["github"]
 
   condition = "github.action=\"delete\""
-  output = "Github Event received (github.user=%github.user)"
+  output = "Github Event received (github.user=%%github.user)"
   priority = "debug"
   source = "github"
 }`, name, name)

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -309,6 +309,7 @@ func ruleFalcoCloudAWSCloudtrailWithAppend(name string) string {
 resource "sysdig_secure_rule_falco" "awscloudtrail" {
   name = "TERRAFORM TEST %[1]s - AWSCloudtrail"
   source = "awscloudtrail"
+  append = true
   exceptions {
 	name = "user_name"
 	fields = ["ct.user"]
@@ -337,6 +338,7 @@ func ruleOktaWithAppend(name string) string {
 resource "sysdig_secure_rule_falco" "okta" {
   name = "TERRAFORM TEST %[1]s - Okta"
   source = "okta"
+  append = true
   exceptions {
 	name = "actor_name"
 	fields = ["okta.actor.name"]
@@ -365,6 +367,7 @@ func ruleGithubWithAppend(name string) string {
 resource "sysdig_secure_rule_falco" "github" {
   name = "TERRAFORM TEST %[1]s - Github"
   source = "github"
+  append = true
   exceptions {
 	name = "user_name"
 	fields = ["github.user"]

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -111,7 +111,7 @@ func TestAccRuleFalco(t *testing.T) {
 			},
 			{
 				Config: ruleGithubWithAppend(randomText),
-			}
+			},
 		},
 	})
 }

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -94,6 +94,24 @@ func TestAccRuleFalco(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: ruleFalcoCloudAWSCloudtrail(randomText),
+			},
+			{
+				Config: ruleFalcoCloudAWSCloudtrailWithAppend(randomText),
+			},
+			{
+				Config: ruleOkta(randomText),
+			},
+			{
+				Config: ruleOktaWithAppend(randomText),
+			},
+			{
+				Config: ruleGithub(randomText),
+			},
+			{
+				Config: ruleGithubWithAppend(randomText),
+			}
 		},
 	})
 }
@@ -270,4 +288,88 @@ resource "sysdig_secure_rule_falco" "terminal_shell" {
   priority = "notice"
   source = "syscall" // syscall or k8s_audit
 }`, name, name)
+}
+
+func ruleFalcoCloudAWSCloudtrail(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_rule_falco" "awscloudtrail" {
+  name = "TERRAFORM TEST %[1]s - AWSCloudtrail"
+  description = "TERRAFORM TEST %[1]s"
+  tags = ["awscloudtrail"]
+
+  condition = "ct.name=\"CreateApp\""
+  output = "AWSCloudtrail Event received (requesting user=%ct.user)"
+  priority = "debug"
+  source = "awscloudtrail"
+}`, name)
+}
+
+func ruleFalcoCloudAWSCloudtrailWithAppend(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_rule_falco" "awscloudtrail" {
+  name = "TERRAFORM TEST %[1]s - AWSCloudtrail"
+  source = "awscloudtrail"
+  exceptions {
+	name = "user_name"
+	fields = ["ct.user"]
+	comps = ["="]
+	values = jsonencode([ ["user_a"] ])
+   }
+}`, name)
+}
+
+func ruleOkta(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_rule_falco" "okta" {
+  name = "TERRAFORM TEST %[1]s - Okta"
+  description = "TERRAFORM TEST %[1]s"
+  tags = ["okta"]
+
+  condition = "okta.evt.type=\"user.account.update_password\""
+  output = "Okta Event received (okta.severity=%okta.severity)"
+  priority = "debug"
+  source = "okta"
+}`, name)
+}
+
+func ruleOktaWithAppend(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_rule_falco" "okta" {
+  name = "TERRAFORM TEST %[1]s - Okta"
+  source = "okta"
+  exceptions {
+	name = "actor_name"
+	fields = ["okta.actor.name"]
+	comps = ["="]
+	values = jsonencode([ ["user_b"] ])
+   }
+}`, name)
+}
+
+func ruleGithub(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_rule_falco" "github" {
+  name = "TERRAFORM TEST %[1]s - Github"
+  description = "TERRAFORM TEST %[1]s"
+  tags = ["github"]
+
+  condition = "github.action=\"delete\""
+  output = "Github Event received (github.user=%github.user)"
+  priority = "debug"
+  source = "github"
+}`, name)
+}
+
+func ruleGithubWithAppend(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_rule_falco" "github" {
+  name = "TERRAFORM TEST %[1]s - Github"
+  source = "github"
+  exceptions {
+	name = "user_name"
+	fields = ["github.user"]
+	comps = ["="]
+	values = jsonencode([ ["user_c"] ])
+   }
+}`, name)
 }

--- a/website/docs/d/secure_custom_policy.md
+++ b/website/docs/d/secure_custom_policy.md
@@ -26,7 +26,7 @@ data "sysdig_secure_custom_policy" "example" {
 * `name` - (Required) The name of the Secure custom policy.
 
 * `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
-  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`. By default it is `falco`.
 
 ## Attributes Reference
 

--- a/website/docs/d/secure_managed_policy.md
+++ b/website/docs/d/secure_managed_policy.md
@@ -26,7 +26,7 @@ data "sysdig_secure_managed_policy" "example" {
 * `name` - (Required) The name of the Secure managed policy.
 
 * `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
-  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`. By default it is `falco`.
 
 ## Attributes Reference
 

--- a/website/docs/d/secure_managed_ruleset.md
+++ b/website/docs/d/secure_managed_ruleset.md
@@ -26,7 +26,7 @@ data "sysdig_secure_managed_ruleset" "example" {
 * `name` - (Required) The name of the Secure managed ruleset.
 
 * `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
-  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`. By default it is `falco`.
 
 ## Attributes Reference
 

--- a/website/docs/r/secure_custom_policy.md
+++ b/website/docs/r/secure_custom_policy.md
@@ -60,7 +60,7 @@ resource "sysdig_secure_custom_policy" "write_apt_database" {
 * `enabled` - (Optional) Will secure process with this rule?. By default this is true.
 
 * `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
-  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`. By default it is `falco`.
 
 * `runbook` - (Optional) Customer provided url that provides a runbook for a given policy. 
 - - -

--- a/website/docs/r/secure_managed_policy.md
+++ b/website/docs/r/secure_managed_policy.md
@@ -51,7 +51,7 @@ resource "sysdig_secure_managed_policy" "sysdig_runtime_threat_detection" {
 * `name` - (Required) The name of the Secure managed policy. It must match the name of an existing managed policy.
 
 * `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
-  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`. By default it is `falco`.
 
 * `enabled` - (Optional) Will secure process with this policy?. By default this is true.
 

--- a/website/docs/r/secure_managed_ruleset.md
+++ b/website/docs/r/secure_managed_ruleset.md
@@ -59,7 +59,7 @@ resource "sysdig_secure_managed_ruleset" "sysdig_runtime_threat_detection_manage
 
 * `enabled` - (Optional) Will secure process with this rule?. By default this is true.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`, `aws_cloudtrail`. By default it is `falco`.
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`, `aws_cloudtrail`, `awscloudtrail`, `okta`, `github`. By default it is `falco`.
 
 * `runbook` - (Optional) Customer provided url that provides a runbook for a given policy. 
 - - -
@@ -70,7 +70,7 @@ The `inherited_from` block is required and identifies the managed policy that th
 
 * `name` - (Required) The name of the Secure managed policy. It must match the name of an existing managed policy.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`, `aws_cloudtrail`. By default it is `falco`.
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`, `aws_cloudtrail`, `awscloudtrail`, `okta`, `github`. By default it is `falco`.
 
 - - -
 

--- a/website/docs/r/secure_policy.md
+++ b/website/docs/r/secure_policy.md
@@ -60,7 +60,7 @@ resource "sysdig_secure_policy" "write_apt_database" {
 * `enabled` - (Optional) Will secure process with this rule?. By default this is true.
 
 * `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
-  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`. By default it is `falco`.
+  `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`. By default it is `falco`.
 
 * `runbook` - (Optional) Customer provided url that provides a runbook for a given policy. 
 - - -

--- a/website/docs/r/secure_rule_falco.md
+++ b/website/docs/r/secure_rule_falco.md
@@ -23,7 +23,7 @@ resource "sysdig_secure_rule_falco" "example" {
   condition = "spawned_process and container and shell_procs and proc.tty != 0 and container_entrypoint"
   output    = "A shell was spawned in a container with an attached terminal (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository)"
   priority  = "notice"
-  source    = "syscall" // syscall, k8s_audit, aws_cloudtrail, gcp_auditlog or azure_platformlogs
+  source    = "syscall" // syscall, k8s_audit, aws_cloudtrail, gcp_auditlog, azure_platformlogs, awscloudtrail okta, github
 
 
   exceptions {
@@ -64,7 +64,7 @@ The following arguments are supported:
 * `condition` - (Required) A [Falco condition](https://falco.org/docs/rules/) is simply a Boolean predicate on Sysdig events expressed using the Sysdig [filter syntax](http://www.sysdig.org/wiki/sysdig-user-guide/#filtering) and macro terms. 
 * `output` - (Optional) Add additional information to each Falco notification's output. Required if append is false.
 * `priority` - (Optional) The priority of the Falco rule. It can be: "emergency", "alert", "critical", "error", "warning", "notice", "info" or "debug". By default is "warning".
-* `source` - (Optional) The source of the event. It can be either "syscall", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", or "azure_platformlogs". Required if append is false.
+* `source` - (Optional) The source of the event. It can be either "syscall", "k8s_audit", "aws_cloudtrail", "gcp_auditlog", "azure_platformlogs", "awscloudtrail", "okta", or "github". Required if append is false.
 * `exceptions` - (Optional) The exceptions key is a list of identifier plus list of tuples of filtercheck fields. See below for details.
 * `append` - (Optional) This indicates that the rule being created appends the condition to an existing Sysdig-provided
   rule. By default this is false. Appending to user-created rules is not supported by the API.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->

adding support for secure policy and rules of new falco cloud policy types, (awscloudtrail, okta, and github)