### PR TITLE
feat(onboarding): Add validation support for GCP CDR onboarding

### DIFF
--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -387,7 +387,7 @@ func constructAccountComponents(data *schema.ResourceData) []*cloudauth.AccountC
 					if data.Get(SchemaCloudProviderType).(string) == cloudauth.Provider_PROVIDER_GCP.String() {
 						spGcp := &internalServicePrincipalMetadata{}
 						err = json.Unmarshal([]byte(value.(string)), spGcp)
-						// if GCP service principal key is present, decode and unmarshal it before populating metadata
+						// special handling if GCP service principal key is present, decode and unmarshal it before populating all the metadata
 						var spGcpKey *cloudauth.ServicePrincipalMetadata_GCP_Key
 						if len(spGcp.Gcp.Key) > 0 {
 							var spGcpKeyBytes []byte

--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
@@ -391,7 +390,6 @@ func constructAccountComponents(data *schema.ResourceData) []*cloudauth.AccountC
 						// if GCP service principal key is present, decode and unmarshal it before populating metadata
 						var spGcpKey *cloudauth.ServicePrincipalMetadata_GCP_Key
 						if len(spGcp.Gcp.Key) > 0 {
-							log.Printf("SP component has a key...")
 							var spGcpKeyBytes []byte
 							spGcpKeyBytes, err = base64.StdEncoding.DecodeString(spGcp.Gcp.Key)
 							if err != nil {
@@ -399,7 +397,6 @@ func constructAccountComponents(data *schema.ResourceData) []*cloudauth.AccountC
 							}
 							err = json.Unmarshal(spGcpKeyBytes, &spGcpKey)
 						}
-						log.Printf("Setting key: %v ; wif: %v ; email: %v", spGcpKey, spGcp.Gcp.WorkloadIdentityFederation, spGcp.Gcp.Email)
 						component.Metadata = &cloudauth.AccountComponent_ServicePrincipalMetadata{
 							ServicePrincipalMetadata: &cloudauth.ServicePrincipalMetadata{
 								Provider: &cloudauth.ServicePrincipalMetadata_Gcp{

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -250,7 +250,6 @@ func TestAccGCPSecureCloudAuthAccountAgentlesScanningWithInventory(t *testing.T)
 	})
 }
 
-// XXX: add project_number to this test
 func TestAccGCPSecureCloudAuthAccountThreatDetection(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	accountID := rText()
@@ -300,6 +299,7 @@ func TestAccGCPSecureCloudAuthAccountThreatDetection(t *testing.T) {
 						workload_identity_federation = {
 							pool_id          = "pool_id_value"
 							pool_provider_id = "pool_provider_id_value"
+							project_number   = "123456789011"
 						}
 						email = "email_value"
 					}


### PR DESCRIPTION
Change summary:
-----------------
1. Support for GCP CDR validation during onboarding using WIF. Mainly fixed the case for metadata population when WIF is passed.
2. Added GCP CDR tests.
3. Modified the structure and organization of acceptance test suite for sysdig_secure_cloud_auth_account resource.

Testing done:
---------------
- Validated this end to end using local TF sysdig provider plugin on staging.
- Validated the acceptance tests against staging.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->