### PR TITLE
Rules order in policy showing drift during apply

### DIFF
--- a/sysdig/data_source_sysdig_secure_policy.go
+++ b/sysdig/data_source_sysdig_secure_policy.go
@@ -2,7 +2,6 @@ package sysdig
 
 import (
 	"context"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -155,10 +154,6 @@ func policyDataSourceToResourceData(policy v2.Policy, d *schema.ResourceData) {
 	}
 
 	_ = d.Set("actions", actions)
-
-	sort.SliceStable(policy.Rules, func(i, j int) bool {
-		return policy.Rules[i].Name < policy.Rules[j].Name
-	})
 
 	rules := []map[string]interface{}{}
 

--- a/sysdig/data_source_sysdig_secure_policy.go
+++ b/sysdig/data_source_sysdig_secure_policy.go
@@ -81,7 +81,7 @@ func createPolicyDataSourceSchema() map[string]*schema.Schema {
 						Computed: true,
 					},
 					"capture": {
-						Type:     schema.TypeList,
+						Type:     schema.TypeSet,
 						Optional: true,
 						Computed: true,
 						Elem: &schema.Resource{

--- a/sysdig/data_source_sysdig_secure_policy.go
+++ b/sysdig/data_source_sysdig_secure_policy.go
@@ -2,6 +2,7 @@ package sysdig
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -81,7 +82,7 @@ func createPolicyDataSourceSchema() map[string]*schema.Schema {
 						Computed: true,
 					},
 					"capture": {
-						Type:     schema.TypeSet,
+						Type:     schema.TypeList,
 						Optional: true,
 						Computed: true,
 						Elem: &schema.Resource{
@@ -154,6 +155,10 @@ func policyDataSourceToResourceData(policy v2.Policy, d *schema.ResourceData) {
 	}
 
 	_ = d.Set("actions", actions)
+
+	sort.SliceStable(policy.Rules, func(i, j int) bool {
+		return policy.Rules[i].Name < policy.Rules[j].Name
+	})
 
 	rules := []map[string]interface{}{}
 

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -132,6 +132,7 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 			"enabled": rule.Enabled,
 		})
 	}
+	fmt.Printf("current rules: %+v", newRules)
 	currentRules := make([]map[string]interface{}, len(rules))
 	for _, rule := range rules {
 		currentRules = append(currentRules, map[string]interface{}{
@@ -139,7 +140,7 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 			"enabled": rule.Enabled,
 		})
 	}
-
+	fmt.Printf("current rules: %+v", currentRules)
 	areRulesSame := reflect.DeepEqual(currentRules, newRules)
 	if !areRulesSame {
 		_ = d.Set("rules", newRules)

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -142,6 +142,7 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 	fmt.Printf("New rules: %+v", newRules)
 	areRulesSame := arePolicyRulesEquivalent(currentRules, newRules)
 	if !areRulesSame {
+		fmt.Printf("USING NEW RULES")
 		_ = d.Set("rules", newRules)
 	} else {
 		_ = d.Set("rules", currentRules)

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -164,6 +164,9 @@ func getPolicyRulesFromResourceData(d *schema.ResourceData) []*v2.PolicyRule {
 }
 
 func arePolicyRulesEquivalent(newRules []map[string]interface{}, currentRules []map[string]interface{}) bool {
+	if len(newRules) != len(currentRules) {
+		return false
+	}
 	currentRulesMap := make(map[string]bool, 0)
 	for _, rule := range currentRules {
 		ruleName := rule["name"].(string)

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -125,7 +125,13 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 	}
 
 	currentRules := getPolicyRulesFromResourceData(d)
-	newRules := policy.Rules
+	newRules := make([]map[string]interface{}, len(policy.Rules))
+	for _, rule := range policy.Rules {
+		newRules = append(newRules, map[string]interface{}{
+			"name":    rule.Name,
+			"enabled": rule.Enabled,
+		})
+	}
 
 	areRulesSame := reflect.DeepEqual(currentRules, newRules)
 	if !areRulesSame {

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -136,6 +136,8 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 	areRulesSame := reflect.DeepEqual(currentRules, newRules)
 	if !areRulesSame {
 		_ = d.Set("rules", newRules)
+	} else {
+		_ = d.Set("rules", currentRules)
 	}
 }
 

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -127,13 +127,11 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 	rules := getPolicyRulesFromResourceData(d)
 	newRules := []map[string]interface{}{}
 	for _, rule := range policy.Rules {
-		fmt.Printf("policy.Rules: %+v", rule)
 		newRules = append(newRules, map[string]interface{}{
 			"name":    rule.Name,
 			"enabled": rule.Enabled,
 		})
 	}
-	fmt.Printf("new rules: %+v", newRules)
 	currentRules := []map[string]interface{}{}
 	for _, rule := range rules {
 		currentRules = append(currentRules, map[string]interface{}{
@@ -141,13 +139,10 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 			"enabled": rule.Enabled,
 		})
 	}
-	fmt.Printf("current rules: %+v", currentRules)
 	areRulesSame := reflect.DeepEqual(currentRules, newRules)
 	if !areRulesSame {
-		fmt.Printf("Setting rules to new rules: %+v", newRules)
 		_ = d.Set("rules", newRules)
 	} else {
-		fmt.Printf("Setting rules to current rules: %+v", currentRules)
 		_ = d.Set("rules", currentRules)
 	}
 }

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -127,12 +127,13 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 	rules := getPolicyRulesFromResourceData(d)
 	newRules := make([]map[string]interface{}, len(policy.Rules))
 	for _, rule := range policy.Rules {
+		fmt.Printf("policy.Rules: %+v", rule)
 		newRules = append(newRules, map[string]interface{}{
 			"name":    rule.Name,
 			"enabled": rule.Enabled,
 		})
 	}
-	fmt.Printf("current rules: %+v", newRules)
+	fmt.Printf("new rules: %+v", newRules)
 	currentRules := make([]map[string]interface{}, len(rules))
 	for _, rule := range rules {
 		currentRules = append(currentRules, map[string]interface{}{

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -139,6 +139,8 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 			"enabled": rule.Enabled,
 		})
 	}
+	fmt.Printf("Current rules: %+v", currentRules)
+	fmt.Printf("New rules: %+v", newRules)
 	areRulesSame := reflect.DeepEqual(currentRules, newRules)
 	if !areRulesSame {
 		_ = d.Set("rules", newRules)

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -144,8 +144,10 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 	fmt.Printf("current rules: %+v", currentRules)
 	areRulesSame := reflect.DeepEqual(currentRules, newRules)
 	if !areRulesSame {
+		fmt.Printf("Setting rules to new rules: %+v", newRules)
 		_ = d.Set("rules", newRules)
 	} else {
+		fmt.Printf("Setting rules to current rules: %+v", currentRules)
 		_ = d.Set("rules", currentRules)
 	}
 }

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -132,7 +132,7 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 			"enabled": rule.Enabled,
 		})
 	}
-	currentRules := make([]map[string]interface{}, len(policy.Rules))
+	currentRules := make([]map[string]interface{}, len(rules))
 	for _, rule := range rules {
 		currentRules = append(currentRules, map[string]interface{}{
 			"name":    rule.Name,

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -125,7 +125,7 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 	}
 
 	rules := getPolicyRulesFromResourceData(d)
-	newRules := make([]map[string]interface{}, len(policy.Rules))
+	newRules := []map[string]interface{}{}
 	for _, rule := range policy.Rules {
 		fmt.Printf("policy.Rules: %+v", rule)
 		newRules = append(newRules, map[string]interface{}{
@@ -134,7 +134,7 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 		})
 	}
 	fmt.Printf("new rules: %+v", newRules)
-	currentRules := make([]map[string]interface{}, len(rules))
+	currentRules := []map[string]interface{}{}
 	for _, rule := range rules {
 		currentRules = append(currentRules, map[string]interface{}{
 			"name":    rule.Name,

--- a/sysdig/resource_sysdig_secure_custom_policy.go
+++ b/sysdig/resource_sysdig_secure_custom_policy.go
@@ -138,11 +138,8 @@ func customPolicyToResourceData(policy *v2.Policy, d *schema.ResourceData) {
 			"enabled": rule.Enabled,
 		})
 	}
-	fmt.Printf("Current rules: %+v", currentRules)
-	fmt.Printf("New rules: %+v", newRules)
-	areRulesSame := arePolicyRulesEquivalent(currentRules, newRules)
-	if !areRulesSame {
-		fmt.Printf("USING NEW RULES")
+
+	if !arePolicyRulesEquivalent(currentRules, newRules) {
 		_ = d.Set("rules", newRules)
 	} else {
 		_ = d.Set("rules", currentRules)

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccCustomPolicy(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
-
+	policy1 := rText()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: preCheckAnyEnv(t, SysdigSecureApiTokenEnv),
 		ProviderFactories: map[string]func() (*schema.Provider, error){
@@ -25,7 +25,7 @@ func TestAccCustomPolicy(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: customPolicyWithName(rText()),
+				Config: customPolicyWithName(policy1()),
 			},
 			{
 				ResourceName:      "sysdig_secure_custom_policy.sample",
@@ -33,7 +33,7 @@ func TestAccCustomPolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: customPolicyWithName(rText()),
+				Config: customPolicyWithRulesOrderChange(policy1()),
 			},
 			{
 				ResourceName:      "sysdig_secure_custom_policy.sample",

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -84,7 +84,7 @@ resource "sysdig_secure_custom_policy" "sample" {
   runbook = "https://sysdig.com"
 
   rules {
-    name = "sysdig_secure_rule_falco.termimal_shell_in_container"
+    name = "sysdig_secure_rule_falco.write_below_etc.name"
     enabled = true
   }
   rules {
@@ -119,7 +119,7 @@ resource "sysdig_secure_custom_policy" "sample" {
   runbook = "https://sysdig.com"
 
   rules {
-    name = sysdig_secure_rule_falco.terminal_shell.name
+    name = sysdig_secure_rule_falco.write_below_etc.name
     enabled = true
   }
   rules {

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -84,7 +84,7 @@ resource "sysdig_secure_custom_policy" "sample" {
   runbook = "https://sysdig.com"
 
   rules {
-    name = "sysdig_secure_rule_falco.write_below_etc.name"
+    name = "Write below etc"
     enabled = true
   }
   rules {
@@ -119,11 +119,11 @@ resource "sysdig_secure_custom_policy" "sample" {
   runbook = "https://sysdig.com"
 
   rules {
-    name = sysdig_secure_rule_falco.write_below_etc.name
+    name = sysdig_secure_rule_falco.terminal_shell.name
     enabled = true
   }
   rules {
-    name = "sysdig_secure_rule_falco.termimal_shell_in_container"
+    name = "Write below etc"
     enabled = true
   }
 

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -33,6 +33,14 @@ func TestAccCustomPolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				Config: customPolicyWithName(rText()),
+			},
+			{
+				ResourceName:      "sysdig_secure_custom_policy.sample",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: customPolicyWithoutActions(rText()),
 			},
 			{
@@ -76,7 +84,46 @@ resource "sysdig_secure_custom_policy" "sample" {
   runbook = "https://sysdig.com"
 
   rules {
+    name = "sysdig_secure_rule_falco.termimal_shell_in_container"
+    enabled = true
+  }
+  rules {
     name = sysdig_secure_rule_falco.terminal_shell.name
+    enabled = true
+  }
+
+  actions {
+    container = "stop"
+    capture {
+      seconds_before_event = 5
+      seconds_after_event = 10
+      name = "testcapture"
+    }
+  }
+
+  notification_channels = [sysdig_secure_notification_channel_email.sample_email.id]
+}
+`, secureNotificationChannelEmailWithName(name), ruleFalcoTerminalShell(name), name, name)
+}
+
+func customPolicyWithRulesOrderChange(name string) string {
+	return fmt.Sprintf(`
+%s
+%s
+resource "sysdig_secure_custom_policy" "sample" {
+  name = "TERRAFORM TEST 1 %s"
+  description = "TERRAFORM TEST %s"
+  enabled = true
+  severity = 4
+  scope = "container.id != \"\""
+  runbook = "https://sysdig.com"
+
+  rules {
+    name = sysdig_secure_rule_falco.terminal_shell.name
+    enabled = true
+  }
+  rules {
+    name = "sysdig_secure_rule_falco.termimal_shell_in_container"
     enabled = true
   }
 

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -25,7 +25,7 @@ func TestAccCustomPolicy(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: customPolicyWithName(policy1()),
+				Config: customPolicyWithName(policy1),
 			},
 			{
 				ResourceName:      "sysdig_secure_custom_policy.sample",
@@ -33,7 +33,7 @@ func TestAccCustomPolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: customPolicyWithRulesOrderChange(policy1()),
+				Config: customPolicyWithRulesOrderChange(policy1),
 			},
 			{
 				ResourceName:      "sysdig_secure_custom_policy.sample",

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -36,11 +36,6 @@ func TestAccCustomPolicy(t *testing.T) {
 				Config: customPolicyWithRulesOrderChange(policy1),
 			},
 			{
-				ResourceName:      "sysdig_secure_custom_policy.sample",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: customPolicyWithoutActions(rText()),
 			},
 			{


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->