### PR TITLE
fix(cloudauth): component metadata diff

### DIFF
--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -87,30 +87,37 @@ func resourceSysdigSecureCloudauthAccount() *schema.Resource {
 			SchemaCloudConnectorMetadata: {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 			SchemaTrustedRoleMetadata: {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 			SchemaEventBridgeMetadata: {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 			SchemaServicePrincipalMetadata: {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 			SchemaWebhookDatasourceMetadata: {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 			SchemaCryptoKeyMetadata: {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 			SchemaCloudLogsMetadata: {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 		},
 	}


### PR DESCRIPTION
fixes an issue where, during the resource planning phase, cloudauth component set members were not being correctly identified, producing differences during planning where no-op changes were expected.

Adding a default value (empty string) for the unset component metadata field members allows these resources to be considered "equivalent" or "compatible" in terraform parlance.