### PR TITLE
(Internal) Skip unsupported policy types on IBM

### DIFF
--- a/sysdig/data_source_sysdig_secure_aws_ml_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_aws_ml_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_drift_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_drift_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_malware_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_malware_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_ml_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_ml_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
+++ b/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
@@ -26,9 +26,15 @@ func TestAccAWSMLPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: awsMLPolicyWithName(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: awsMLPolicyWithoutNotificationChannel(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 		},
 	})

--- a/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
+++ b/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
@@ -1,4 +1,4 @@
-//go:build (tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure) && !tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
+++ b/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/draios/terraform-provider-sysdig/buildinfo"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
+++ b/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
@@ -1,12 +1,10 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
+//go:build (tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure) && !tf_acc_ibm_secure
 
 package sysdig_test
 
 import (
 	"fmt"
 	"testing"
-
-	"github.com/draios/terraform-provider-sysdig/buildinfo"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -28,15 +26,9 @@ func TestAccAWSMLPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: awsMLPolicyWithName(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: awsMLPolicyWithoutNotificationChannel(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 		},
 	})

--- a/sysdig/resource_sysdig_secure_drift_policy_test.go
+++ b/sysdig/resource_sysdig_secure_drift_policy_test.go
@@ -1,4 +1,4 @@
-//go:build (tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure) && !tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_drift_policy_test.go
+++ b/sysdig/resource_sysdig_secure_drift_policy_test.go
@@ -26,15 +26,27 @@ func TestAccDriftPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: driftPolicyWithName(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: driftPolicyWithAllActions(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: driftPolicyWithoutActions(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: driftPolicyWithoutNotificationChannel(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 		},
 	})

--- a/sysdig/resource_sysdig_secure_drift_policy_test.go
+++ b/sysdig/resource_sysdig_secure_drift_policy_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/draios/terraform-provider-sysdig/buildinfo"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/sysdig/resource_sysdig_secure_drift_policy_test.go
+++ b/sysdig/resource_sysdig_secure_drift_policy_test.go
@@ -1,12 +1,10 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
+//go:build (tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure) && !tf_acc_ibm_secure
 
 package sysdig_test
 
 import (
 	"fmt"
 	"testing"
-
-	"github.com/draios/terraform-provider-sysdig/buildinfo"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -28,27 +26,15 @@ func TestAccDriftPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: driftPolicyWithName(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: driftPolicyWithAllActions(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: driftPolicyWithoutActions(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: driftPolicyWithoutNotificationChannel(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 		},
 	})

--- a/sysdig/resource_sysdig_secure_malware_policy_test.go
+++ b/sysdig/resource_sysdig_secure_malware_policy_test.go
@@ -1,4 +1,4 @@
-//go:build (tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure) && !tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_malware_policy_test.go
+++ b/sysdig/resource_sysdig_secure_malware_policy_test.go
@@ -1,12 +1,10 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
+//go:build (tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure) && !tf_acc_ibm_secure
 
 package sysdig_test
 
 import (
 	"fmt"
 	"testing"
-
-	"github.com/draios/terraform-provider-sysdig/buildinfo"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -28,39 +26,21 @@ func TestAccMalwarePolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: malwarePolicyWithName(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: malwarePolicyWithoutAnyHashes(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: malwarePolicyWithoutAdditionalHashes(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: malwarePolicyWithoutIgnoreHashes(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: malwarePolicyWithAllActions(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: malwarePolicyWithoutNotificationChannel(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 		},
 	})

--- a/sysdig/resource_sysdig_secure_malware_policy_test.go
+++ b/sysdig/resource_sysdig_secure_malware_policy_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/draios/terraform-provider-sysdig/buildinfo"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/sysdig/resource_sysdig_secure_malware_policy_test.go
+++ b/sysdig/resource_sysdig_secure_malware_policy_test.go
@@ -26,21 +26,39 @@ func TestAccMalwarePolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: malwarePolicyWithName(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: malwarePolicyWithoutAnyHashes(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: malwarePolicyWithoutAdditionalHashes(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: malwarePolicyWithoutIgnoreHashes(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: malwarePolicyWithAllActions(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: malwarePolicyWithoutNotificationChannel(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 		},
 	})

--- a/sysdig/resource_sysdig_secure_ml_policy_test.go
+++ b/sysdig/resource_sysdig_secure_ml_policy_test.go
@@ -1,4 +1,4 @@
-//go:build (tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure) && !tf_acc_ibm_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_ml_policy_test.go
+++ b/sysdig/resource_sysdig_secure_ml_policy_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/draios/terraform-provider-sysdig/buildinfo"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/sysdig/resource_sysdig_secure_ml_policy_test.go
+++ b/sysdig/resource_sysdig_secure_ml_policy_test.go
@@ -26,9 +26,15 @@ func TestAccMLPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: mlPolicyWithName(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 			{
 				Config: mlPolicyWithoutNotificationChannel(rText()),
+				SkipFunc: func() (bool, error) {
+					return buildinfo.IBMSecure, nil
+				},
 			},
 		},
 	})

--- a/sysdig/resource_sysdig_secure_ml_policy_test.go
+++ b/sysdig/resource_sysdig_secure_ml_policy_test.go
@@ -1,12 +1,10 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
+//go:build (tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure) && !tf_acc_ibm_secure
 
 package sysdig_test
 
 import (
 	"fmt"
 	"testing"
-
-	"github.com/draios/terraform-provider-sysdig/buildinfo"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -28,15 +26,9 @@ func TestAccMLPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: mlPolicyWithName(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 			{
 				Config: mlPolicyWithoutNotificationChannel(rText()),
-				SkipFunc: func() (bool, error) {
-					return buildinfo.IBMSecure, nil
-				},
 			},
 		},
 	})


### PR DESCRIPTION
- Create new build tag "tf_acc_policies_aws" so these will not be built during IBM test runs
- Needs to be combined with a PR for Jenkins job to use the new build tag for AWS, IBM will continue using existing tags