### PR TITLE
fix(alerts): use correct type un api for downtime alerts

### DIFF
--- a/sysdig/internal/client/v2/alerts_v2.go
+++ b/sysdig/internal/client/v2/alerts_v2.go
@@ -30,6 +30,7 @@ const (
 	AlertV2TypeChange              AlertV2Type = "PERCENTAGE_OF_CHANGE"
 	AlertV2TypeFormBasedPrometheus AlertV2Type = "FORM_BASED_PROMETHEUS"
 	AlertV2TypeGroupOutlier        AlertV2Type = "GROUP_OUTLIERS"
+	AlertV2TypeDowntime            AlertV2Type = "DOWNTIME"
 
 	AlertV2SeverityHigh   AlertV2Severity = "high"
 	AlertV2SeverityMedium AlertV2Severity = "medium"

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -813,7 +813,6 @@ type AlertV2ConfigDowntime struct {
 	GroupAggregation string                  `json:"groupAggregation"`
 	TimeAggregation  string                  `json:"timeAggregation"`
 	Metric           AlertMetricDescriptorV2 `json:"metric"`
-	NoDataBehaviour  string                  `json:"noDataBehaviour"`
 }
 
 type AlertV2Downtime struct {

--- a/sysdig/resource_sysdig_monitor_alert_v2_downtime.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_downtime.go
@@ -175,8 +175,6 @@ func buildAlertV2DowntimeStruct(d *schema.ResourceData) *v2.AlertV2Downtime {
 	metric := d.Get("metric").(string)
 	config.Metric.ID = metric
 
-	config.NoDataBehaviour = "DO_NOTHING"
-
 	var unreportedAlertNotificationsRetentionSec *int
 	if unreportedAlertNotificationsRetentionSecInterface, ok := d.GetOk("unreported_alert_notifications_retention_seconds"); ok {
 		u := unreportedAlertNotificationsRetentionSecInterface.(int)

--- a/sysdig/resource_sysdig_monitor_alert_v2_downtime.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_downtime.go
@@ -154,7 +154,7 @@ func resourceSysdigMonitorAlertV2DowntimeDelete(ctx context.Context, d *schema.R
 
 func buildAlertV2DowntimeStruct(d *schema.ResourceData) *v2.AlertV2Downtime {
 	alertV2Common := buildAlertV2CommonStruct(d)
-	alertV2Common.Type = string(v2.AlertV2TypeManual)
+	alertV2Common.Type = string(v2.AlertV2TypeDowntime)
 	config := v2.AlertV2ConfigDowntime{}
 
 	buildScopedSegmentedConfigStruct(d, &config.ScopedSegmentedConfig)


### PR DESCRIPTION
An alert of type downtime is actually an alert of type manual with specific aggregations on specific metrics, so, to create a downtime alert, we could use either the manual alert type or the more specific downtime alert type.

This is no true anymore with recent changes in the v2 api. This PR fixes the problem using the correct alert type for the downtime alerts.