### PR TITLE
fix(tests): Skip onprem unsupported policy types

### DIFF
--- a/sysdig/data_source_sysdig_secure_aws_ml_policy_test.go
+++ b/sysdig/data_source_sysdig_secure_aws_ml_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws
 
 package sysdig_test
 

--- a/sysdig/data_source_sysdig_secure_trusted_cloud_identity_test.go
+++ b/sysdig/data_source_sysdig_secure_trusted_cloud_identity_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_onprem_secure
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
+++ b/sysdig/resource_sysdig_secure_aws_ml_policy_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies_aws || tf_acc_onprem_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies_aws
 
 package sysdig_test
 

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -82,11 +82,11 @@ resource "sysdig_secure_custom_policy" "sample" {
   runbook = "https://sysdig.com"
 
   rules {
-    name = sysdig_secure_rule_falco.terminal_shell.name
+    name = "Write below etc"
     enabled = true
   }
   rules {
-    name = "Write below etc"
+    name = sysdig_secure_rule_falco.terminal_shell.name
     enabled = true
   }
 

--- a/sysdig/resource_sysdig_secure_custom_policy_test.go
+++ b/sysdig/resource_sysdig_secure_custom_policy_test.go
@@ -10,12 +10,54 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/draios/terraform-provider-sysdig/buildinfo"
 	"github.com/draios/terraform-provider-sysdig/sysdig"
 )
 
 func TestAccCustomPolicy(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	policy1 := rText()
+
+	steps := []resource.TestStep{
+		{
+			Config: customPolicyWithName(policy1),
+		},
+		{
+			ResourceName:      "sysdig_secure_custom_policy.sample",
+			ImportState:       true,
+			ImportStateVerify: true,
+		},
+		{
+			Config: customPolicyWithRulesOrderChange(policy1),
+		},
+		{
+			Config: customPolicyWithoutActions(rText()),
+		},
+		{
+			Config: customPolicyWithoutNotificationChannels(rText()),
+		},
+		{
+			Config: customPolicyWithMinimumConfiguration(rText()),
+		},
+		{
+			Config: customPoliciesWithDifferentSeverities(rText()),
+		},
+		{
+			Config: customPoliciesWithKillAction(rText()),
+		},
+		{
+			Config: customPoliciesWithDisabledRules(rText()),
+		},
+	}
+
+	if !buildinfo.OnpremSecure {
+		steps = append(steps,
+			resource.TestStep{Config: customPoliciesForAWSCloudtrail(rText())},
+			resource.TestStep{Config: customPoliciesForGCPAuditLog(rText())},
+			resource.TestStep{Config: customPoliciesForAzurePlatformlogs(rText())},
+		)
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: preCheckAnyEnv(t, SysdigSecureApiTokenEnv),
 		ProviderFactories: map[string]func() (*schema.Provider, error){
@@ -23,46 +65,7 @@ func TestAccCustomPolicy(t *testing.T) {
 				return sysdig.Provider(), nil
 			},
 		},
-		Steps: []resource.TestStep{
-			{
-				Config: customPolicyWithName(policy1),
-			},
-			{
-				ResourceName:      "sysdig_secure_custom_policy.sample",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: customPolicyWithRulesOrderChange(policy1),
-			},
-			{
-				Config: customPolicyWithoutActions(rText()),
-			},
-			{
-				Config: customPolicyWithoutNotificationChannels(rText()),
-			},
-			{
-				Config: customPolicyWithMinimumConfiguration(rText()),
-			},
-			{
-				Config: customPoliciesWithDifferentSeverities(rText()),
-			},
-			{
-				Config: customPoliciesWithKillAction(rText()),
-			},
-			{
-				Config: customPoliciesForAWSCloudtrail(rText()),
-			},
-			{
-				Config: customPoliciesForGCPAuditLog(rText()),
-			},
-			{
-				Config: customPoliciesForAzurePlatformlogs(rText()),
-			},
-			{
-				Config: customPoliciesWithDisabledRules(rText()),
-			},
-		},
+		Steps: steps,
 	})
 }
 
@@ -79,11 +82,11 @@ resource "sysdig_secure_custom_policy" "sample" {
   runbook = "https://sysdig.com"
 
   rules {
-    name = "Write below etc"
+    name = sysdig_secure_rule_falco.terminal_shell.name
     enabled = true
   }
   rules {
-    name = sysdig_secure_rule_falco.terminal_shell.name
+    name = "Write below etc"
     enabled = true
   }
 


### PR DESCRIPTION
* Do not run cloud policy types tests with `tf_acc_onprem_secure` tag

* Use TypeSet instead of TypeList for rules