### PR TITLE
fix(client): correctly handle nonstandard json errors

### DIFF
--- a/sysdig/data_source_sysdig_secure_notification_channel_team_email_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_team_email_test.go
@@ -39,7 +39,7 @@ func TestAccSecureNotificationChannelTeamEmailDataSource(t *testing.T) {
 func secureNotificationChannelTeamEmail(name string) string {
 	return fmt.Sprintf(`
 	resource "sysdig_secure_team" "sample_data" {
-		name = "secure-sample-data"
+		name = "secure-sample-data-%s"
 		all_zones = "true"
 	}
 resource "sysdig_secure_notification_channel_team_email" "nc_team_email" {
@@ -50,5 +50,5 @@ resource "sysdig_secure_notification_channel_team_email" "nc_team_email" {
 data "sysdig_secure_notification_channel_team_email" "nc_team_email" {
 	name = sysdig_secure_notification_channel_team_email.nc_team_email.name
 }
-`, name)
+`, name, name)
 }

--- a/sysdig/internal/client/v2/client.go
+++ b/sysdig/internal/client/v2/client.go
@@ -75,7 +75,7 @@ func (client *Client) ErrorFromResponse(response *http.Response) error {
 		return errors.New(response.Status)
 	}
 
-	search, err := jmespath.Search("[message, errors[].[reason, message]][][] | join(', ', @)", data)
+	search, err := jmespath.Search("[message, error, errors[].[reason, message]][][] | join(', ', @)", data)
 	if err != nil {
 		return errors.New(response.Status)
 	}
@@ -84,7 +84,12 @@ func (client *Client) ErrorFromResponse(response *http.Response) error {
 		return errors.New(strings.Join(cast.ToStringSlice(searchArray), ", "))
 	}
 
-	return errors.New(cast.ToString(search))
+	searchString := cast.ToString(search)
+	if searchString != "" {
+		return errors.New(searchString)
+	}
+
+	return errors.New(response.Status)
 }
 
 func Unmarshal[T any](data io.ReadCloser) (T, error) {

--- a/sysdig/internal/client/v2/client_test.go
+++ b/sysdig/internal/client/v2/client_test.go
@@ -56,7 +56,24 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
-func TestClient_ErrorFromResponse(t *testing.T) {
+func TestClient_ErrorFromResponse_non_json(t *testing.T) {
+
+	given := "non json body"
+	expected := "401 Unauthorized"
+	c := Client{}
+	payload := given
+
+	resp := &http.Response{
+		Status: "401 Unauthorized",
+		Body:   io.NopCloser(strings.NewReader(payload)),
+	}
+	err := c.ErrorFromResponse(resp)
+	if err.Error() != expected {
+		t.Errorf("expected err %v, got %v", expected, err)
+	}
+}
+
+func TestClient_ErrorFromResponse_standard_error_format(t *testing.T) {
 	type Error struct {
 		Reason  string `json:"reason"`
 		Message string `json:"message"`
@@ -87,6 +104,69 @@ func TestClient_ErrorFromResponse(t *testing.T) {
 
 	resp := &http.Response{
 		Body: io.NopCloser(strings.NewReader(string(payload))),
+	}
+	err = c.ErrorFromResponse(resp)
+	if err.Error() != expected {
+		t.Errorf("expected err %v, got %v", expected, err)
+	}
+}
+
+func TestClient_ErrorFromResponse_standard_error_format_2(t *testing.T) {
+
+	given := `
+	{
+		"timestamp" : 1715255725613,
+		"status" : 401,
+		"error" : "Unauthorized",
+		"path" : "/api/v2/alerts/46667521"
+	}
+	`
+	expected := "Unauthorized"
+	c := Client{}
+	payload := given
+
+	resp := &http.Response{
+		Status: "401 Unauthorized",
+		Body:   io.NopCloser(strings.NewReader(payload)),
+	}
+	err := c.ErrorFromResponse(resp)
+	if err.Error() != expected {
+		t.Errorf("expected err %v, got %v", expected, err)
+	}
+}
+
+func TestClient_ErrorFromResponse_json_nonStandard_error_format(t *testing.T) {
+	type Error struct {
+		Reason  string `json:"nonStandardFieldNameReason"`
+		Message string `json:"nonStandardFieldNameMessage"`
+	}
+
+	type Errors struct {
+		Errors []Error `json:"errors"`
+	}
+
+	given := Errors{
+		Errors: []Error{
+			{
+				Reason:  "error1",
+				Message: "message1",
+			},
+			{
+				Reason:  "error2",
+				Message: "message2",
+			},
+		},
+	}
+	expected := "401 Unauthorized"
+	c := Client{}
+	payload, err := json.Marshal(given)
+	if err != nil {
+		t.Errorf("failed to marshal errors, %v", err)
+	}
+
+	resp := &http.Response{
+		Status: "401 Unauthorized",
+		Body:   io.NopCloser(strings.NewReader(string(payload))),
 	}
 	err = c.ErrorFromResponse(resp)
 	if err.Error() != expected {

--- a/sysdig/internal/client/v2/client_test.go
+++ b/sysdig/internal/client/v2/client_test.go
@@ -58,14 +58,13 @@ func TestUnmarshal(t *testing.T) {
 
 func TestClient_ErrorFromResponse_non_json(t *testing.T) {
 
-	given := "non json body"
+	givenPayload := "non json body"
 	expected := "401 Unauthorized"
 	c := Client{}
-	payload := given
 
 	resp := &http.Response{
 		Status: "401 Unauthorized",
-		Body:   io.NopCloser(strings.NewReader(payload)),
+		Body:   io.NopCloser(strings.NewReader(givenPayload)),
 	}
 	err := c.ErrorFromResponse(resp)
 	if err.Error() != expected {
@@ -113,7 +112,7 @@ func TestClient_ErrorFromResponse_standard_error_format(t *testing.T) {
 
 func TestClient_ErrorFromResponse_standard_error_format_2(t *testing.T) {
 
-	given := `
+	givenPayload := `
 	{
 		"timestamp" : 1715255725613,
 		"status" : 401,
@@ -123,11 +122,10 @@ func TestClient_ErrorFromResponse_standard_error_format_2(t *testing.T) {
 	`
 	expected := "Unauthorized"
 	c := Client{}
-	payload := given
 
 	resp := &http.Response{
 		Status: "401 Unauthorized",
-		Body:   io.NopCloser(strings.NewReader(payload)),
+		Body:   io.NopCloser(strings.NewReader(givenPayload)),
 	}
 	err := c.ErrorFromResponse(resp)
 	if err.Error() != expected {


### PR DESCRIPTION
Sysdig APIs are not perfectly standardised, so several errors at the moment are not well handled: in such cases, if the body is still json, the `ErrorFromResponse` function returns an empty error that is not handled properly by the terraform sdk leading to a misleading message:
```
X-Content-Type-Options: nosniff

{
  "timestamp" : 1715251965029,
  "status" : 401,
  "error" : "Unauthorized",
  "path" : "/api/v2/alerts/46667521"
}: timestamp=2024-05-09T12:52:45.008+0200
2024-05-09T12:52:45.009+0200 [ERROR] provider.terraform-provider-sysdig: Response contains error diagnostic: diagnostic_severity=ERROR tf_proto_version=5.3 tf_req_id=e2629c9f-bc17-9008-98b7-40215d63dfc0 tf_resource_type=sysdig_monitor_alert_v2_downtime diagnostic_detail= diagnostic_summary="Empty Summary: This is always a bug in the provider and should be reported to the provider developers." tf_provider_addr=provider @caller=/Users/diego.bonfigli/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/diag/diagnostics.go:55 @module=sdk.proto tf_rpc=ReadResource timestamp=2024-05-09T12:52:45.009+0200
2024-05-09T12:52:45.010+0200 [ERROR] vertex "sysdig_monitor_alert_v2_downtime.sample" error: Empty Summary: This is always a bug in the provider and should be reported to the provider developers.
2024-05-09T12:52:45.010+0200 [ERROR] vertex "sysdig_monitor_alert_v2_downtime.sample (expand)" error: Empty Summary: This is always a bug in the provider and should be reported to the provider developers.
╷
│ Error: Empty Summary: This is always a bug in the provider and should be reported to the provider developers.
│
│   with sysdig_monitor_alert_v2_downtime.sample,
│   on main.tf line 713, in resource "sysdig_monitor_alert_v2_downtime" "sample":
│  713: resource "sysdig_monitor_alert_v2_downtime" "sample" {
│
╵
2024-05-09T12:52:45.022+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2024-05-09T12:52:45.025+0200 [DEBUG] provider: plugin process exited: path=.terraform/providers/local/sysdiglabs/sysdig/1.0.0/darwin_amd64/terraform-provider-sysdig pid=98303
2024-05-09T12:52:45.025+0200 [DEBUG] provider: plugin exited
```

With this PR:
* we add the missing format to the possible standards, a json body with `error` as root field
* we handle cases where the standard format is not recognised, avoiding the `Empty Summary: This is always a bug in the provider` message