### PR TITLE
ssprod_41907 | add get full policy

### DIFF
--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -926,24 +926,39 @@ type PosturePolicyZoneMeta struct {
 }
 
 type PosturePolicy struct {
-	ID                string                  `json:"id,omitempty"`
-	Name              string                  `json:"name,omitempty"`
-	Type              int                     `json:"type,omitempty"`
-	Kind              int                     `json:"kind,omitempty"`
-	Description       string                  `json:"description,omitempty"`
-	Version           string                  `json:"version,omitempty"`
-	Link              string                  `json:"link,omitempty"`
-	Authors           string                  `json:"authors,omitempty"`
-	PublishedData     string                  `json:"publishedDate,omitempty"`
-	RequirementsGroup []RequirementsGroup     `json:"requirementFolders,omitempty"`
-	MinKubeVersion    float64                 `json:"minKubeVersion,omitempty"`
-	MaxKubeVersion    float64                 `json:"maxKubeVersion,omitempty"`
-	IsCustom          bool                    `json:"isCustom,omitempty"`
-	IsActive          bool                    `json:"isActive,omitempty"`
-	Platform          string                  `json:"platform,omitempty"`
-	Zones             []PosturePolicyZoneMeta `json:"zones,omitempty"`
+	ID             string                  `json:"id,omitempty"`
+	Name           string                  `json:"name,omitempty"`
+	Type           int                     `json:"type,omitempty"`
+	Kind           int                     `json:"kind,omitempty"`
+	Description    string                  `json:"description,omitempty"`
+	Version        string                  `json:"version,omitempty"`
+	Link           string                  `json:"link,omitempty"`
+	Authors        string                  `json:"authors,omitempty"`
+	PublishedData  string                  `json:"publishedDate,omitempty"`
+	MinKubeVersion float64                 `json:"minKubeVersion,omitempty"`
+	MaxKubeVersion float64                 `json:"maxKubeVersion,omitempty"`
+	IsCustom       bool                    `json:"isCustom,omitempty"`
+	IsActive       bool                    `json:"isActive,omitempty"`
+	Platform       string                  `json:"platform,omitempty"`
+	Zones          []PosturePolicyZoneMeta `json:"zones,omitempty"`
 }
 
+type FullPosturePolicy struct {
+	ID                string              `json:"id,omitempty"`
+	Name              string              `json:"name,omitempty"`
+	Type              string              `json:"type,omitempty"`
+	Description       string              `json:"description,omitempty"`
+	Version           string              `json:"version,omitempty"`
+	Link              string              `json:"link,omitempty"`
+	Authors           string              `json:"authors,omitempty"`
+	PublishedData     string              `json:"publishedDate,omitempty"`
+	RequirementsGroup []RequirementsGroup `json:"requirementFolders,omitempty"`
+	MinKubeVersion    float64             `json:"minKubeVersion,omitempty"`
+	MaxKubeVersion    float64             `json:"maxKubeVersion,omitempty"`
+	IsCustom          bool                `json:"isCustom,omitempty"`
+	IsActive          bool                `json:"isActive,omitempty"`
+	Platform          string              `json:"platform,omitempty"`
+}
 type RequirementsGroup struct {
 	ID                        string              `json:"id,omitempty"`
 	Name                      string              `json:"name,omitempty"`
@@ -1005,6 +1020,9 @@ type PosturePolicyResponse struct {
 	Data PosturePolicy `json:"data"`
 }
 
+type FullPosturePolicyResponse struct {
+	Data FullPosturePolicy `json:"data"`
+}
 type PostureZonePolicyListResponse struct {
 	Data []PosturePolicy `json:"data"`
 }

--- a/sysdig/internal/client/v2/posture_policies.go
+++ b/sysdig/internal/client/v2/posture_policies.go
@@ -9,14 +9,14 @@ import (
 const (
 	PosturePolicyListPath   = "%s/api/cspm/v1/policy/policies/list"
 	PosturePolicyCreatePath = "%s/api/cspm/v1/policy"
-	PosturePolicyGetPath    = "%s/api/cspm/v1/policy/policies/view/%d"
+	PosturePolicyGetPath    = "%s/api/cspm/v1/policy/posture/policies/%d?include_controls=true"
 )
 
 type PosturePolicyInterface interface {
 	Base
 	ListPosturePolicies(ctx context.Context) ([]PosturePolicy, error)
-	CreateOrUpdatePosturePolicy(ctx context.Context, p *CreatePosturePolicy) (*PosturePolicy, string, error)
-	GetPosturePolicy(ctx context.Context, id int64) (*PosturePolicy, error)
+	CreateOrUpdatePosturePolicy(ctx context.Context, p *CreatePosturePolicy) (*FullPosturePolicy, string, error)
+	GetPosturePolicy(ctx context.Context, id int64) (*FullPosturePolicy, error)
 }
 
 func (client *Client) ListPosturePolicies(ctx context.Context) ([]PosturePolicy, error) {
@@ -34,7 +34,7 @@ func (client *Client) ListPosturePolicies(ctx context.Context) ([]PosturePolicy,
 	return resp.Data, nil
 }
 
-func (client *Client) CreateOrUpdatePosturePolicy(ctx context.Context, p *CreatePosturePolicy) (*PosturePolicy, string, error) {
+func (client *Client) CreateOrUpdatePosturePolicy(ctx context.Context, p *CreatePosturePolicy) (*FullPosturePolicy, string, error) {
 	payload, err := Marshal(p)
 	if err != nil {
 		return nil, "", err
@@ -48,25 +48,24 @@ func (client *Client) CreateOrUpdatePosturePolicy(ctx context.Context, p *Create
 		errStatus, err := client.ErrorAndStatusFromResponse(response)
 		return nil, errStatus, err
 	}
-	resp, err := Unmarshal[PosturePolicyResponse](response.Body)
+	resp, err := Unmarshal[FullPosturePolicyResponse](response.Body)
 	if err != nil {
 		return nil, "", err
 	}
 	return &resp.Data, "", nil
 }
 
-func (client *Client) GetPosturePolicy(ctx context.Context, id int64) (*PosturePolicy, error) {
+func (client *Client) GetPosturePolicy(ctx context.Context, id int64) (*FullPosturePolicy, error) {
 	response, err := client.requester.Request(ctx, http.MethodGet, client.getPolicyUrl(id), nil)
 	if err != nil {
 		return nil, err
 	}
 	defer response.Body.Close()
 
-	wrapper, err := Unmarshal[PosturePolicyResponse](response.Body)
+	wrapper, err := Unmarshal[FullPosturePolicyResponse](response.Body)
 	if err != nil {
 		return nil, err
 	}
-
 	return &wrapper.Data, nil
 }
 

--- a/sysdig/resource_sysdig_secure_posture_policy.go
+++ b/sysdig/resource_sysdig_secure_posture_policy.go
@@ -201,6 +201,7 @@ func resourceSysdigSecurePosturePolicyCreateOrUpdate(ctx context.Context, d *sch
 	req := &v2.CreatePosturePolicy{
 		ID:                getStringValue(d, SchemaIDKey),
 		Name:              getStringValue(d, SchemaNameKey),
+		Type:              getStringValue(d, SchemaTypeKey),
 		Description:       getStringValue(d, SchemaDescriptionKey),
 		MinKubeVersion:    getFloatValue(d, SchemaMinKubeVersionKey),
 		MaxKubeVersion:    getFloatValue(d, SchemaMaxKubeVersionKey),

--- a/sysdig/resource_sysdig_secure_posture_policy.go
+++ b/sysdig/resource_sysdig_secure_posture_policy.go
@@ -249,9 +249,7 @@ func resourceSysdigSecurePosturePolicyRead(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	strconv.Itoa(policy.Type)
-
-	err = d.Set(SchemaTypeKey, strconv.Itoa(policy.Type))
+	err = d.Set(SchemaTypeKey, policy.Type)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/sysdig/resource_sysdig_secure_posture_policy_test.go
+++ b/sysdig/resource_sysdig_secure_posture_policy_test.go
@@ -34,6 +34,6 @@ func createPolicyResource(name string) string {
 		name = "policy-test-%s"
 		description = "policy description"
 		is_active = true
-		type = "0"
+		type = "Unknown"
 	}`, name)
 }


### PR DESCRIPTION
we change get policy to get full policy. that api will return policy with requirement folders, requirements and controls (that are linked to requirement). to be align with create and update we change the response to be the same to get create and update policy. this task in JIRA: https://sysdig.atlassian.net/browse/SSPROD-41907


<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->