### PR TITLE
fix(notificationchannel): fix flaky tests

### DIFF
--- a/sysdig/resource_sysdig_monitor_notification_channel_team_email_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_team_email_test.go
@@ -46,7 +46,7 @@ func TestAccMonitorNotificationChannelTeamEmail(t *testing.T) {
 
 func monitorNotificationChannelTeamEmailWithName(name string) string {
 	return fmt.Sprintf(`
-resource "sysdig_monitor_team" "sample" {
+resource "sysdig_monitor_team" "sample1" {
 	name = "monitor-sample-%s"
 	entrypoint {
 	type = "Explore"
@@ -55,7 +55,7 @@ resource "sysdig_monitor_team" "sample" {
 resource "sysdig_monitor_notification_channel_team_email" "sample_team_email1" {
 	name = "Example Channel %s - team email"
 	enabled = true
-	team_id = sysdig_monitor_team.sample.id
+	team_id = sysdig_monitor_team.sample1.id
 	notify_when_ok = true
 	notify_when_resolved = true
 }`, name, name)
@@ -63,7 +63,7 @@ resource "sysdig_monitor_notification_channel_team_email" "sample_team_email1" {
 
 func monitorNotificationChannelTeamEmailSharedWithCurrentTeam(name string) string {
 	return fmt.Sprintf(`
-resource "sysdig_monitor_team" "sample" {
+resource "sysdig_monitor_team" "sample2" {
 	name = "monitor-sample-%s"
 	entrypoint {
 	type = "Explore"
@@ -72,7 +72,7 @@ resource "sysdig_monitor_team" "sample" {
 resource "sysdig_monitor_notification_channel_team_email" "sample_team_email2" {
 	name = "Example Channel %s - team email"
 	enabled = true
-	team_id = sysdig_monitor_team.sample.id
+	team_id = sysdig_monitor_team.sample2.id
 	notify_when_ok = true
 	notify_when_resolved = true
 	share_with_current_team = true

--- a/sysdig/resource_sysdig_secure_notification_channel_team_email_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_team_email_test.go
@@ -46,14 +46,14 @@ func TestAccSecureNotificationChannelTeamEmail(t *testing.T) {
 
 func secureNotificationChannelTeamEmailWithName(name string) string {
 	return fmt.Sprintf(`
-resource "sysdig_secure_team" "sample" {
+resource "sysdig_secure_team" "sample1" {
 	name = "secure-sample-%s"
 	all_zones = "true"
 }
 resource "sysdig_secure_notification_channel_team_email" "sample_team_email1" {
 	name = "Example Channel %s - team email"
 	enabled = true
-	team_id = sysdig_secure_team.sample.id
+	team_id = sysdig_secure_team.sample1.id
 	notify_when_ok = true
 	notify_when_resolved = true
 }`, name, name)
@@ -61,14 +61,14 @@ resource "sysdig_secure_notification_channel_team_email" "sample_team_email1" {
 
 func secureNotificationChannelTeamEmailSharedWithCurrentTeam(name string) string {
 	return fmt.Sprintf(`
-resource "sysdig_secure_team" "sample" {
+resource "sysdig_secure_team" "sample2" {
 	name = "secure-sample-%s"
 	all_zones = "true"
 }
 resource "sysdig_secure_notification_channel_team_email" "sample_team_email2" {
 	name = "Example Channel %s - team email"
 	enabled = true
-	team_id = sysdig_secure_team.sample.id
+	team_id = sysdig_secure_team.sample2.id
 	notify_when_ok = true
 	notify_when_resolved = true
 	share_with_current_team = true


### PR DESCRIPTION
the team resources seem to suffer of slight caching problems on our tests envs, fix unit tests on notification channels resources by not updating teams but always creating new ones.