### PR TITLE
fix access key by ommiting both limit and reservation when not specified

### DIFF
--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -1090,8 +1090,8 @@ type SilenceRule struct {
 
 type AgentAccessKey struct {
 	ID             int               `json:"id,omitempty"`
-	Reservation    int               `json:"agentReservation"`
-	Limit          int               `json:"agentLimit"`
+	Reservation    int               `json:"agentReservation,omitempty"`
+	Limit          int               `json:"agentLimit,omitempty"`
 	TeamID         int               `json:"teamId,omitempty"`
 	AgentAccessKey string            `json:"accessKey,omitempty"`
 	Metadata       map[string]string `json:"metadata,omitempty"`


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->