### PR TITLE
fix(alerts): properly handle info severity

### DIFF
--- a/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
@@ -43,6 +43,9 @@ func TestAccAlertV2Metric(t *testing.T) {
 				Config: alertV2MetricWithSeverity(rText()),
 			},
 			{
+				Config: alertV2MetricWithSeverityInfo(rText()),
+			},
+			{
 				Config: alertV2MetricWithGroupBy(rText()),
 			},
 			{
@@ -197,6 +200,23 @@ resource "sysdig_monitor_alert_v2_metric" "sample" {
 	threshold = 50
 	trigger_after_minutes = 15
 	severity = "high"
+
+}
+`, name)
+}
+
+func alertV2MetricWithSeverityInfo(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_metric" "sample" {
+
+	name = "TERRAFORM TEST - METRICV2 %s"
+	metric = "sysdig_container_cpu_used_percent"
+	group_aggregation = "avg"
+	time_aggregation = "avg"
+	operator = ">="
+	threshold = 50
+	trigger_after_minutes = 15
+	severity = "info"
 
 }
 `, name)


### PR DESCRIPTION
In the alerts v2 api, [Info](https://docs.sysdig.com/en/docs/sysdig-monitor/alerts/configure-alerts/#settings) severity is actually defined via the value "none", here we fix this case.

The severity value in the terraform resources is also accepted regardless of casing (same as the alerts v2 api), but using non-lowercase characters leads to plan drifts, here we ignore diffs in such situations.