### PR TITLE
fix(alerts): fix operator for form based prometheus alerts

### DIFF
--- a/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus.go
@@ -36,7 +36,7 @@ func resourceSysdigMonitorAlertV2FormBasedPrometheus() *schema.Resource {
 			"operator": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{">", ">=", "<", "<=", "=", "!="}, false),
+				ValidateFunc: validation.StringInSlice([]string{">", ">=", "<", "<=", "==", "!="}, false),
 			},
 			"threshold": {
 				Type:     schema.TypeFloat,

--- a/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_form_based_prometheus_test.go
@@ -28,6 +28,9 @@ func TestAccAlertV2FormBasedPrometheusTest(t *testing.T) {
 				Config: alertV2FormBasedPrometheusTest(rText()),
 			},
 			{
+				Config: alertV2FormBasedPrometheusWithEqualOperatorTest(rText()),
+			},
+			{
 				Config: alertV2FormBasedPrometheusTestWithNoData(rText()),
 			},
 			{
@@ -72,6 +75,17 @@ resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
 	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
 	query = "avg_over_time(sysdig_container_cpu_used_percent{container_name=\"test\"}[59s])"
 	operator = ">="
+	threshold = 50
+}
+`, name)
+}
+
+func alertV2FormBasedPrometheusWithEqualOperatorTest(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_monitor_alert_v2_form_based_prometheus" "sample" {
+	name = "TERRAFORM TEST - FORM BASED PROMETHEUS %s"
+	query = "avg_over_time(sysdig_container_cpu_used_percent{container_name=\"test\"}[59s])"
+	operator = "=="
 	threshold = 50
 }
 `, name)

--- a/website/docs/r/monitor_alert_v2_form_based_prometheus.md
+++ b/website/docs/r/monitor_alert_v2_form_based_prometheus.md
@@ -74,7 +74,7 @@ By defining this field, the user can add link to notifications.
 ### Form Based Prometheus alert arguments
 
 * `query` - (Required) PromQL-based metric expression to alert on. Example: `sysdig_host_memory_available_bytes / sysdig_host_memory_total_bytes * 100` or `avg_over_time(sysdig_container_cpu_used_percent{}[59s])`.
-* `operator` - (Required) Operator for the condition to alert on. It can be `>`, `>=`, `<`, `<=`, `=` or `!=`.
+* `operator` - (Required) Operator for the condition to alert on. It can be `>`, `>=`, `<`, `<=`, `==` or `!=`.
 * `threshold` - (Required) Threshold used together with `op` to trigger the alert if crossed.
 * `warning_threshold` - (Optional) Warning threshold used together with `op` to trigger the alert if crossed. Must be a number that triggers the alert before reaching the main `threshold`.
 * `no_data_behaviour` - (Optional) behaviour in case of missing data. Can be `DO_NOTHING`, i.e. ignore, or `TRIGGER`, i.e. notify on main threshold. Default: `DO_NOTHING`.


### PR DESCRIPTION
For form based prometheus alerts, the operator to check equality is `==`, not `=`. We fix this bug in this PR.

This is slightly inconsistent with the operator in metric alerts, that uses `=` but still we use `==` because the tf resources should be as close as possible to the underlying apis.

Note that this is not really a breaking change because the old `=` never worked.