### PR TITLE
fix(ci): fix govet error

### DIFF
--- a/sysdig/cfn_preprocess_template.go
+++ b/sysdig/cfn_preprocess_template.go
@@ -58,7 +58,7 @@ func updateKeys(inputMap gabs.Container) error {
 
 			err = inputMap.Delete(key)
 			if err != nil {
-				return fmt.Errorf("failed to delete old key %s" + key)
+				return fmt.Errorf("failed to delete old key %s", key)
 			}
 
 			// recurse to update child's keys


### PR DESCRIPTION
This PR fixes govet error showing in regression CI builds.
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->