### PR TITLE
fix(tests): Skip IBM unsupported policy types

### DIFF
--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -48,10 +48,14 @@ func TestAccPolicy(t *testing.T) {
 			resource.TestStep{Config: policiesForAWSCloudtrail(rText())},
 			resource.TestStep{Config: policiesForGCPAuditLog(rText())},
 			resource.TestStep{Config: policiesForAzurePlatformlogs(rText())},
-			resource.TestStep{Config: policiesForFalcoCloudAWSCloudtrail(rText())},
-			resource.TestStep{Config: policiesForOkta(rText())},
-			resource.TestStep{Config: policiesForGithub(rText())},
 		)
+		if !buildinfo.IBMSecure {
+			steps = append(steps,
+				resource.TestStep{Config: policiesForFalcoCloudAWSCloudtrail(rText())},
+				resource.TestStep{Config: policiesForOkta(rText())},
+				resource.TestStep{Config: policiesForGithub(rText())},
+			)
+		}
 	}
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
Falco Cloud AWS CloudTrail, Okta and GitHub are not enabled on IBM envs, so we should skip them on `TestAccPolicy`.
