### PR TITLE
fix(tests): Proper check to determine if env is IBM

### DIFF
--- a/sysdig/resource_sysdig_secure_policy_test.go
+++ b/sysdig/resource_sysdig_secure_policy_test.go
@@ -4,6 +4,8 @@ package sysdig_test
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -49,7 +51,7 @@ func TestAccPolicy(t *testing.T) {
 			resource.TestStep{Config: policiesForGCPAuditLog(rText())},
 			resource.TestStep{Config: policiesForAzurePlatformlogs(rText())},
 		)
-		if !buildinfo.IBMSecure {
+		if !strings.HasSuffix(os.Getenv("SYSDIG_SECURE_URL"), "ibm.com") {
 			steps = append(steps,
 				resource.TestStep{Config: policiesForFalcoCloudAWSCloudtrail(rText())},
 				resource.TestStep{Config: policiesForOkta(rText())},


### PR DESCRIPTION
Fixes #549, as `buildinfo` contains the info about the test suite, not the target env.