### PR TITLE
fix ip_filter acc test - delete resource after creation to avoid conflict

### DIFF
--- a/sysdig/resource_sysdig_ip_filter_test.go
+++ b/sysdig/resource_sysdig_ip_filter_test.go
@@ -4,14 +4,19 @@ package sysdig_test
 
 import (
 	"fmt"
-	"github.com/draios/terraform-provider-sysdig/sysdig"
 	"testing"
 
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestAccSysdigIpFilter_fullLifecycle(t *testing.T) {
+	ipRange1 := generateRandomIPRange()
+	ipRange2 := generateRandomIPRange()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: preCheckAnyEnv(t, SysdigMonitorApiTokenEnv),
 		ProviderFactories: map[string]func() (*schema.Provider, error){
@@ -21,25 +26,29 @@ func TestAccSysdigIpFilter_fullLifecycle(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				// Create resource
-				Config: createIPFilter("192.168.1.0/24", "Initial note", true),
+				// Create resource with the first random IP range
+				Config: createIPFilter(ipRange1, "Initial note", true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("sysdig_ip_filter.test", "ip_range", "192.168.1.0/24"),
+					resource.TestCheckResourceAttr("sysdig_ip_filter.test", "ip_range", ipRange1),
 					resource.TestCheckResourceAttr("sysdig_ip_filter.test", "note", "Initial note"),
 					resource.TestCheckResourceAttr("sysdig_ip_filter.test", "enabled", "true"),
 				),
 			},
 			{
-				// Update resource
-				Config: createIPFilter("192.168.2.0/24", "Updated note", false),
+				// Update resource with the second random IP range
+				Config: createIPFilter(ipRange2, "Updated note", false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("sysdig_ip_filter.test", "ip_range", "192.168.2.0/24"),
+					resource.TestCheckResourceAttr("sysdig_ip_filter.test", "ip_range", ipRange2),
 					resource.TestCheckResourceAttr("sysdig_ip_filter.test", "note", "Updated note"),
 					resource.TestCheckResourceAttr("sysdig_ip_filter.test", "enabled", "false"),
 				),
 			},
 		},
 	})
+}
+
+func generateRandomIPRange() string {
+	return fmt.Sprintf("%d.%d.%d.0/24", acctest.RandIntRange(0, 255), acctest.RandIntRange(0, 255), acctest.RandIntRange(0, 255))
 }
 
 func createIPFilter(ipRange, note string, enabled bool) string {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->