### PR TITLE
[SSPROD-46998] Adding agentless azure sysdig_secure_trusted_azure_app

### DIFF
--- a/sysdig/data_source_sysdig_secure_onboarding.go
+++ b/sysdig/data_source_sysdig_secure_onboarding.go
@@ -110,7 +110,7 @@ func dataSourceSysdigSecureTrustedAzureApp() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"config_posture", "onboarding", "threat_detection"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"config_posture", "onboarding", "threat_detection", "agentless"}, false),
 			},
 			"tenant_id": {
 				Type:     schema.TypeString,

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -98,6 +98,15 @@ func TestAccTrustedAzureAppDataSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_azure_app.threat_detection", "service_principal_id"), // uncomment to assert a non empty value
 				),
 			},
+			{
+				Config: `data "sysdig_secure_trusted_azure_app" "agentless" { name = "agentless" }`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_azure_app.agentless", "name", "threat_detection"),
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_azure_app.agentless", "application_id"),       // uncomment to assert a non empty value
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_azure_app.agentless", "tenant_id"),            // uncomment to assert a non empty value
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_azure_app.agentless", "service_principal_id"), // uncomment to assert a non empty value
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
The sysdig azure application needs to be added to the terraform provider so that it can be used by the dependent terraform modules.

Se associated PR:
https://github.com/draios/secure-backend/pull/36116