### PR TITLE
fix: Do not run custom control resource test in onprem

### DIFF
--- a/sysdig/resource_sysdig_secure_posture_control_test.go
+++ b/sysdig/resource_sysdig_secure_posture_control_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies || tf_acc_onprem_secure
+//go:build tf_acc_sysdig_secure || tf_acc_policies
 
 package sysdig_test
 


### PR DESCRIPTION
This test should not be run against an onprem environment