### PR TITLE
fix(cloudauth-monitor): ADD format logic to get role name param

### DIFF
--- a/sysdig/resource_sysdig_monitor_cloud_account.go
+++ b/sysdig/resource_sysdig_monitor_cloud_account.go
@@ -3,6 +3,7 @@ package sysdig
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
@@ -185,7 +186,7 @@ func monitorCloudAccountToResourceData(data *schema.ResourceData, cloudAccount *
 		return err
 	}
 
-	err = data.Set("role_name", cloudAccount.Credentials.RoleName)
+	err = data.Set("role_name", strings.Split(cloudAccount.Credentials.RoleName, ":role/")[1])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Monitor Cloud account config has an issue with the role name delegation parameter.
Once the resource is created and it's run again, the unchanged parameter rolename has conflicts with the name that we request with the provider. The one of the provider has the full ARN name as suffix of the role name parameter. So, we fix that with this PR.