### PR TITLE
feat(onboarding): Adding regulatory EB ARN to cloud ingestion datasource

### DIFF
--- a/sysdig/data_source_sysdig_secure_onboarding.go
+++ b/sysdig/data_source_sysdig_secure_onboarding.go
@@ -380,7 +380,8 @@ func dataSourceSysdigSecureCloudIngestionAssetsRead(ctx context.Context, d *sche
 
 	d.SetId("cloudIngestionAssets")
 	err = d.Set("aws", map[string]interface{}{
-		"eventBusARN": assetsAws["eventBusARN"],
+		"eventBusARN":    assetsAws["eventBusARN"],
+		"eventBusARNGov": assetsAws["eventBusARNGov"],
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -36,7 +36,7 @@ func TestAccTrustedCloudIdentityDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_cloud_identity.trusted_identity", "cloud_provider", "aws"),
 					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_cloud_identity.trusted_identity", "aws_account_id"),
 					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_cloud_identity.trusted_identity", "aws_role_name"),
-					// not asserting the gov exported fields because not every backend environment is gov supported and will have non-empty values returned
+					// not asserting the gov exported fields because not every backend environment is gov supported and thus will have empty values
 				),
 			},
 			{
@@ -178,9 +178,10 @@ func TestAccCloudIngestionAssetsDataSource(t *testing.T) {
 			{
 				Config: `data "sysdig_secure_cloud_ingestion_assets" "assets" {}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "aws.%", "1"),
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_routing_key"),
+					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "aws.%", "2"),
+					// not asserting the gov exported fields because not every backend environment is gov supported and thus will have empty values
 
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_routing_key"),
 					// metadata fields are opaque to api backend; cloudingestion controls what fields are passed
 					// asserts ingestionType and ingestionURL in metadata since it is required
 					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_metadata.ingestionType", "gcp"),

--- a/website/docs/d/secure_cloud_ingestion_assets.md
+++ b/website/docs/d/secure_cloud_ingestion_assets.md
@@ -26,6 +26,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `aws.eventBusARN` - AWS event bus from which Sysdig Cloud Ingestion operates
 
+* `aws.eventBusARNGov` - AWS Gov event bus (if supported) from which Sysdig Cloud Ingestion operates
+
 * `gcp_routing_key` - GCP ingestion routing key
 
 * `gcp_metadata` - GCP ingestion metadata


### PR DESCRIPTION
Change summary:
----------------
1. Reading and returning new field EB ARN Gov for regulatory workloads such as aws gov workloads.
2. Updated the acc test and docs.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->