### PR TITLE
[SSPROD-49510] Use unique names for parallel tests

### DIFF
--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -119,7 +119,7 @@ func TestAccRuleFalco(t *testing.T) {
 func ruleFalcoTerminalShell(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "terminal_shell" {
-  name = "TERRAFORM TEST %s - Terminal Shell"
+  name = "TERRAFORM TEST %s - Terminal Shell Base Rule"
   description = "TERRAFORM TEST %s"
   tags = ["container", "shell", "mitre_execution"]
 
@@ -133,7 +133,7 @@ resource "sysdig_secure_rule_falco" "terminal_shell" {
 func ruleFalcoTerminalShellWithMissingOuput(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "terminal_shell" {
-  name = "TERRAFORM TEST %s - Terminal Shell"
+  name = "TERRAFORM TEST %s - Terminal Shell Missing Output"
   description = "TERRAFORM TEST %s"
   tags = ["container", "shell", "mitre_execution"]
 
@@ -146,7 +146,7 @@ resource "sysdig_secure_rule_falco" "terminal_shell" {
 func ruleFalcoTerminalShellWithMissingSource(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "terminal_shell" {
-  name = "TERRAFORM TEST %s - Terminal Shell"
+  name = "TERRAFORM TEST %s - Terminal Shell Missing Source"
   description = "TERRAFORM TEST %s"
   tags = ["container", "shell", "mitre_execution"]
 
@@ -160,7 +160,7 @@ resource "sysdig_secure_rule_falco" "terminal_shell" {
 func ruleFalcoUpdatedTerminalShell(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "terminal_shell" {
-  name = "TERRAFORM TEST %s - Terminal Shell"
+  name = "TERRAFORM TEST %s - Terminal Shell Updated"
   description = "TERRAFORM TEST %s"
   tags = ["shell", "mitre_execution"]
 
@@ -278,7 +278,7 @@ resource "sysdig_secure_rule_falco" "attach_to_cluster_admin_role_exceptions" {
 func ruleFalcoTerminalShellWithMinimumEngineVersion(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "terminal_shell" {
-  name = "TERRAFORM TEST %s - Terminal Shell"
+  name = "TERRAFORM TEST %s - Terminal Shell Min Engine Version"
   minimum_engine_version = 13
   description = "TERRAFORM TEST %s"
   tags = ["container", "shell", "mitre_execution"]

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -119,7 +119,7 @@ func TestAccRuleFalco(t *testing.T) {
 func ruleFalcoTerminalShell(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_rule_falco" "terminal_shell" {
-  name = "TERRAFORM TEST %s - Terminal Shell Base Rule"
+  name = "TERRAFORM TEST %s - Terminal Shell"
   description = "TERRAFORM TEST %s"
   tags = ["container", "shell", "mitre_execution"]
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->