### PR TITLE
[SSPROD-49510] - Make some falco tests run in serial mode

### DIFF
--- a/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco_count_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccRuleFalcoCountDataSource(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
 				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")

--- a/sysdig/data_source_sysdig_secure_rule_falco_test.go
+++ b/sysdig/data_source_sysdig_secure_rule_falco_test.go
@@ -18,7 +18,7 @@ func TestAccRuleFalcoDataSource(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	rTextForAppendTest := rText()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
 				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")

--- a/sysdig/resource_sysdig_secure_list_test.go
+++ b/sysdig/resource_sysdig_secure_list_test.go
@@ -17,7 +17,7 @@ func TestAccList(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	fixedRandomText := rText()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: preCheckAnyEnv(t, SysdigSecureApiTokenEnv),
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"sysdig": func() (*schema.Provider, error) {

--- a/sysdig/resource_sysdig_secure_macro_test.go
+++ b/sysdig/resource_sysdig_secure_macro_test.go
@@ -17,7 +17,7 @@ func TestAccMacro(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	fixedRandomText := rText()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: preCheckAnyEnv(t, SysdigSecureApiTokenEnv),
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"sysdig": func() (*schema.Provider, error) {

--- a/sysdig/resource_sysdig_secure_rule_falco_test.go
+++ b/sysdig/resource_sysdig_secure_rule_falco_test.go
@@ -21,7 +21,7 @@ func TestAccRuleFalco(t *testing.T) {
 	ruleRandomImmutableText := rText()
 
 	randomText := rText()
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
 				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")


### PR DESCRIPTION
Some of these Falco tests using identical names can interfere with each other when run in parallel