### PR TITLE
feat(onboarding): Datasource for OCI Trusted app group

### DIFF
--- a/sysdig/data_source_sysdig_secure_onboarding.go
+++ b/sysdig/data_source_sysdig_secure_onboarding.go
@@ -400,6 +400,58 @@ func dataSourceSysdigSecureCloudIngestionAssetsRead(ctx context.Context, d *sche
 	return nil
 }
 
+func dataSourceSysdigSecureTrustedOracleApp() *schema.Resource {
+	timeout := 5 * time.Minute
+
+	return &schema.Resource{
+		ReadContext: dataSourceSysdigSecureTrustedOracleAppRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(timeout),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"config_posture", "onboarding"}, false),
+			},
+			"tenancy_ocid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_ocid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// Retrieves the information of a resource from the file and loads it in Terraform
+func dataSourceSysdigSecureTrustedOracleAppRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getSecureOnboardingClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	app := d.Get("name").(string)
+	trustedIdentityGroup, err := client.GetTrustedOracleAppSecure(ctx, app)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(app)
+	for k, v := range trustedIdentityGroup {
+		fmt.Printf("%s, %s\n", k, snakeCase(k))
+		err = d.Set(snakeCase(k), v)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return nil
+}
+
 var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
 

--- a/sysdig/data_source_sysdig_secure_onboarding.go
+++ b/sysdig/data_source_sysdig_secure_onboarding.go
@@ -424,6 +424,10 @@ func dataSourceSysdigSecureTrustedOracleApp() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"user_ocid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -215,6 +215,7 @@ func TestAccTrustedOracleAppDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_oracle_app.config_posture", "name", "config_posture"),
 					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "tenancy_ocid"), // uncomment to assert a non empty value
 					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "group_ocid"),   // uncomment to assert a non empty value
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "user_ocid"),   // uncomment to assert a non empty value
 				),
 			},
 			{
@@ -223,6 +224,7 @@ func TestAccTrustedOracleAppDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_oracle_app.onboarding", "name", "onboarding"),
 					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "tenancy_ocid"), // uncomment to assert a non empty value
 					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "group_ocid"),   // uncomment to assert a non empty value
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "user_ocid"),   // uncomment to assert a non empty value
 				),
 			},
 		},

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -213,18 +213,20 @@ func TestAccTrustedOracleAppDataSource(t *testing.T) {
 				Config: `data "sysdig_secure_trusted_oracle_app" "config_posture" {	name = "config_posture" }`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_oracle_app.config_posture", "name", "config_posture"),
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "tenancy_ocid"), // uncomment to assert a non empty value
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "group_ocid"),   // uncomment to assert a non empty value
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "user_ocid"),    // uncomment to assert a non empty value
+					// not asserting the oci exported fields because not every backend environment is oci supported yet and thus will have empty values
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "tenancy_ocid"), // uncomment to assert a non empty value
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "group_ocid"),   // uncomment to assert a non empty value
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "user_ocid"),    // uncomment to assert a non empty value
 				),
 			},
 			{
 				Config: `data "sysdig_secure_trusted_oracle_app" "onboarding" {	name = "onboarding" }`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_oracle_app.onboarding", "name", "onboarding"),
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "tenancy_ocid"), // uncomment to assert a non empty value
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "group_ocid"),   // uncomment to assert a non empty value
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "user_ocid"),    // uncomment to assert a non empty value
+					// not asserting the oci exported fields because not every backend environment is oci supported yet and thus will have empty values
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "tenancy_ocid"), // uncomment to assert a non empty value
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "group_ocid"),   // uncomment to assert a non empty value
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "user_ocid"),    // uncomment to assert a non empty value
 				),
 			},
 		},

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -191,3 +191,40 @@ func TestAccCloudIngestionAssetsDataSource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccTrustedOracleAppDataSource(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+			}
+		},
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      `data "sysdig_secure_trusted_oracle_app" "invalid" {	name = "invalid" }`,
+				ExpectError: regexp.MustCompile(`.*expected name to be one of.*`),
+			},
+			{
+				Config: `data "sysdig_secure_trusted_oracle_app" "config_posture" {	name = "config_posture" }`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_oracle_app.config_posture", "name", "config_posture"),
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "tenancy_ocid"), // uncomment to assert a non empty value
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "group_ocid"),   // uncomment to assert a non empty value
+				),
+			},
+			{
+				Config: `data "sysdig_secure_trusted_oracle_app" "onboarding" {	name = "onboarding" }`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_oracle_app.onboarding", "name", "onboarding"),
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "tenancy_ocid"), // uncomment to assert a non empty value
+					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "group_ocid"),   // uncomment to assert a non empty value
+				),
+			},
+		},
+	})
+}

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -213,18 +213,18 @@ func TestAccTrustedOracleAppDataSource(t *testing.T) {
 				Config: `data "sysdig_secure_trusted_oracle_app" "config_posture" {	name = "config_posture" }`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_oracle_app.config_posture", "name", "config_posture"),
-					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "tenancy_ocid"), // uncomment to assert a non empty value
-					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "group_ocid"),   // uncomment to assert a non empty value
-					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "user_ocid"),   // uncomment to assert a non empty value
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "tenancy_ocid"), // uncomment to assert a non empty value
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "group_ocid"),   // uncomment to assert a non empty value
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.config_posture", "user_ocid"),    // uncomment to assert a non empty value
 				),
 			},
 			{
 				Config: `data "sysdig_secure_trusted_oracle_app" "onboarding" {	name = "onboarding" }`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_oracle_app.onboarding", "name", "onboarding"),
-					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "tenancy_ocid"), // uncomment to assert a non empty value
-					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "group_ocid"),   // uncomment to assert a non empty value
-					// resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "user_ocid"),   // uncomment to assert a non empty value
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "tenancy_ocid"), // uncomment to assert a non empty value
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "group_ocid"),   // uncomment to assert a non empty value
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_oracle_app.onboarding", "user_ocid"),    // uncomment to assert a non empty value
 				),
 			},
 		},

--- a/sysdig/internal/client/v2/onboarding.go
+++ b/sysdig/internal/client/v2/onboarding.go
@@ -13,6 +13,7 @@ const (
 	onboardingAgentlessScanningAssetsPath = "%s/api/secure/onboarding/v2/agentlessScanningAssets"
 	onboardingCloudIngestionAssetsPath    = "%s/api/secure/onboarding/v2/cloudIngestionAssets"
 	onboardingTrustedRegulationAssetsPath = "%s/api/secure/onboarding/v2/trustedRegulationAssets?provider=%s"
+	onboardingTrustedOracleAppPath        = "%s/api/secure/onboarding/v2/trustedOracleApp?app=%s"
 )
 
 type OnboardingSecureInterface interface {
@@ -23,6 +24,7 @@ type OnboardingSecureInterface interface {
 	GetAgentlessScanningAssetsSecure(ctx context.Context) (map[string]any, error)
 	GetCloudIngestionAssetsSecure(ctx context.Context) (map[string]any, error)
 	GetTrustedCloudRegulationAssetsSecure(ctx context.Context, provider string) (map[string]string, error)
+	GetTrustedOracleAppSecure(ctx context.Context, app string) (map[string]string, error)
 }
 
 func (client *Client) GetTrustedCloudIdentitySecure(ctx context.Context, provider string) (string, error) {
@@ -97,6 +99,20 @@ func (client *Client) GetCloudIngestionAssetsSecure(ctx context.Context) (map[st
 
 func (client *Client) GetTrustedCloudRegulationAssetsSecure(ctx context.Context, provider string) (map[string]string, error) {
 	response, err := client.requester.Request(ctx, http.MethodGet, fmt.Sprintf(onboardingTrustedRegulationAssetsPath, client.config.url, provider), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, client.ErrorFromResponse(response)
+	}
+
+	return Unmarshal[map[string]string](response.Body)
+}
+
+func (client *Client) GetTrustedOracleAppSecure(ctx context.Context, app string) (map[string]string, error) {
+	response, err := client.requester.Request(ctx, http.MethodGet, fmt.Sprintf(onboardingTrustedOracleAppPath, client.config.url, app), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/sysdig/provider.go
+++ b/sysdig/provider.go
@@ -203,6 +203,7 @@ func (p *SysdigProvider) Provider() *schema.Provider {
 			"sysdig_secure_cloud_ingestion_assets":                        dataSourceSysdigSecureCloudIngestionAssets(),
 			"sysdig_secure_trusted_azure_app":                             dataSourceSysdigSecureTrustedAzureApp(),
 			"sysdig_secure_trusted_cloud_identity":                        dataSourceSysdigSecureTrustedCloudIdentity(),
+			"sysdig_secure_trusted_oracle_app":                            dataSourceSysdigSecureTrustedOracleApp(),
 			"sysdig_secure_tenant_external_id":                            dataSourceSysdigSecureTenantExternalID(),
 			"sysdig_secure_notification_channel":                          dataSourceSysdigSecureNotificationChannel(),
 			"sysdig_secure_notification_channel_pagerduty":                dataSourceSysdigSecureNotificationChannelPagerduty(),

--- a/website/docs/d/secure_trusted_oracle_app.md
+++ b/website/docs/d/secure_trusted_oracle_app.md
@@ -1,0 +1,35 @@
+---
+subcategory: "Sysdig Secure"
+layout: "sysdig"
+page_title: "Sysdig: sysdig_secure_trusted_oracle_app"
+description: |-
+  Retrieves information about the Sysdig Secure Trusted Oracle App
+---
+
+# Data Source: sysdig_secure_trusted_oracle_app
+
+Retrieves information about the Sysdig Secure Trusted Oracle App
+
+-> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
+
+## Example Usage
+
+```terraform
+data "sysdig_secure_trusted_oracle_app" "onboarding" {
+	name = "onboarding"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Sysdig's Oracle App name. Currently supported applications are `config_posture` and `onboarding`.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `tenancy_ocid` - The application's associated tenancy OCI identifer.
+
+* `group_ocid` - The application's associated usergroup OCI identifier.
+

--- a/website/docs/d/secure_trusted_oracle_app.md
+++ b/website/docs/d/secure_trusted_oracle_app.md
@@ -33,3 +33,5 @@ In addition to all arguments above, the following attributes are exported:
 
 * `group_ocid` - The application's associated usergroup OCI identifier.
 
+* `user_ocid` - The application's associated user OCI identifier.
+


### PR DESCRIPTION
Change summary:
----------------
- Adding new datasource secure_trusted_oracle_app to fetch OCI trusted identity per app group.
- Added acc tests and docs for the new datasource.

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->