### PR TITLE
docs(serverless): the workload agent no longer requires the orchestrator

### DIFF
--- a/website/docs/d/fargate_workload_agent.md
+++ b/website/docs/d/fargate_workload_agent.md
@@ -8,11 +8,11 @@ description: |-
 
 # Data Source: fargate_workload_agent
 
-Updates the fargate workload definition to add a [Sysdig Agent](https://docs.sysdig.com/en/docs/installation/serverless-agents/aws-fargate-serverless-agents/)
+Updates the ECS Fargate Container Definitions to add a [Sysdig Workload Agent](https://docs.sysdig.com/en/docs/installation/serverless-agents/aws-fargate-serverless-agents/)
 
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
-You'll need to connect the Sysdig Agent to the Sysdig backend through an orchestrator. For details about how to deploy an orchestrator check the [Sysdig Orchestrator module](https://registry.terraform.io/modules/sysdiglabs/fargate-orchestrator-agent/aws/latest).
+The Sysdig Workload Agent will need to connect to the Sysdig Collector. Find your region's collector endpoint here: https://docs.sysdig.com/en/docs/administration/saas-regions-and-ip-ranges/.
 
 ## Example Usage
 
@@ -20,20 +20,21 @@ You'll need to connect the Sysdig Agent to the Sysdig backend through an orchest
 data "sysdig_fargate_workload_agent" "instrumented_containers" {
   container_definitions = "[]"
 
-  image_auth_secret    = ""
   workload_agent_image = "quay.io/sysdig/workload-agent:latest"
-  
-  orchestrator_host    = module.fargate-orchestrator-agent.orchestrator_host
-  orchestrator_port    = module.fargate-orchestrator-agent.orchestrator_port
+
+  collector_host    = var.collector_host
+  collector_port    = var.collector_port
+  sysdig_access_key = var.sysdig_access_key
 }
 ```
 
 ## Argument Reference
 
 * `container_definitions` - (Required) The input Fargate container definitions to instrument with the Sysdig workload agent.
-* `orchestrator_host` - (Required) The orchestrator host to connect to.
-* `orchestrator_port` - (Required) The orchestrator port to connect to.
 * `workload_agent_image` - (Required) The Sysdig workload agent image.
+* `collector_host` - (Required) The Sysdig Collector host to connect to.
+* `collector_port` - (Required) The Sysdig Collector port.
+* `sysdig_access_key` - (Required) The Sysdig Agent access key, available in the Sysdig Secure UI.
 * `image_auth_secret` - (Optional) The registry authentication secret.
 * `log_configuration` - (Optional) Configuration for the awslogs driver on the instrumentation container. All three values must be specified if instrumentation logging is desired:
   * `group` - The name of the existing log group for instrumentation logs


### PR DESCRIPTION
This PR updates the documentation of the fargate workload agent data source. The orchestrator agent is no longer required.