### PR TITLE
 feat(cloudtrail): add support for SNS ingestion

### DIFF
--- a/sysdig/data_source_sysdig_secure_onboarding.go
+++ b/sysdig/data_source_sysdig_secure_onboarding.go
@@ -387,7 +387,7 @@ func dataSourceSysdigSecureCloudIngestionAssetsRead(ctx context.Context, d *sche
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	
+
 	assets, err := client.GetCloudIngestionAssetsSecure(ctx, d.Get("cloud_provider").(string), d.Get("cloud_provider_id").(string))
 	if err != nil {
 		return diag.FromErr(err)
@@ -476,8 +476,10 @@ func dataSourceSysdigSecureTrustedOracleAppRead(ctx context.Context, d *schema.R
 	return nil
 }
 
-var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
-var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+var (
+	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
+)
 
 func snakeCase(str string) string {
 	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")

--- a/sysdig/data_source_sysdig_secure_onboarding.go
+++ b/sysdig/data_source_sysdig_secure_onboarding.go
@@ -347,12 +347,12 @@ func dataSourceSysdigSecureCloudIngestionAssets() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"cloud_provider": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"aws", "gcp", "azure"}, false),
 			},
 			"cloud_provider_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"aws": {
 				Type:     schema.TypeMap,
@@ -387,7 +387,7 @@ func dataSourceSysdigSecureCloudIngestionAssetsRead(ctx context.Context, d *sche
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
+	
 	assets, err := client.GetCloudIngestionAssetsSecure(ctx, d.Get("cloud_provider").(string), d.Get("cloud_provider_id").(string))
 	if err != nil {
 		return diag.FromErr(err)

--- a/sysdig/data_source_sysdig_secure_onboarding.go
+++ b/sysdig/data_source_sysdig_secure_onboarding.go
@@ -369,14 +369,6 @@ func dataSourceSysdigSecureCloudIngestionAssets() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
-			"sns_routing_key": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"sns_metadata": {
-				Type:     schema.TypeMap,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -396,12 +388,17 @@ func dataSourceSysdigSecureCloudIngestionAssetsRead(ctx context.Context, d *sche
 	assetsAws, _ := assets["aws"].(map[string]interface{})
 	assetsGcp, _ := assets["gcp"].(map[string]interface{})
 
+	var ingestionURL string
+	if assetsAws["snsMetadata"] != nil {
+		ingestionURL = assetsAws["snsMetadata"].(map[string]interface{})["ingestionURL"].(string)
+	}
+
 	d.SetId("cloudIngestionAssets")
 	err = d.Set("aws", map[string]interface{}{
 		"eventBusARN":     assetsAws["eventBusARN"],
 		"eventBusARNGov":  assetsAws["eventBusARNGov"],
 		"sns_routing_key": assetsAws["snsRoutingKey"],
-		"sns_metadata":    assetsAws["snsMetadata"],
+		"sns_routing_url": ingestionURL,
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -18,7 +18,6 @@ func TestAccTrustedCloudIdentityDataSource(t *testing.T) {
 		PreCheck: func() {
 			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
 				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
-				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
 			}
 		},
 		ProviderFactories: map[string]func() (*schema.Provider, error){
@@ -187,10 +186,10 @@ func TestAccCloudIngestionAssetsDataSource(t *testing.T) {
 				Config: `data "sysdig_secure_cloud_ingestion_assets" "assets" {}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "aws.%", "4"),
-					// not asserting the gov exported fields because not every backend environme nt is gov supported and thus will have empty values
+					// not asserting the gov exported fields because not every backend environment is gov supported and thus will have empty values
 
 					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_routing_key"),
-					// metadata fields are opaque to api backend; cloudingestion controls what f ields are passed
+					// metadata fields are opaque to api backend; cloudingestion controls what fields are passed
 					// asserts ingestionType and ingestionURL in metadata since it is required
 					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_metadata.ingestionType", "gcp"),
 					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_metadata.ingestionURL"),

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -176,28 +176,32 @@ func TestAccCloudIngestionAssetsDataSource(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:      `data "sysdig_secure_cloud_ingestion_assets" "assets" {	cloud_provider = "invalid" }`,
+				Config: `data "sysdig_secure_cloud_ingestion_assets" "assets" { 
+			cloud_provider = "invalid" 
+			cloud_provider_id = "123"
+			}`,
 				ExpectError: regexp.MustCompile(`.*expected cloud_provider to be one of.*`),
 			},
 			{
 				Config: `data "sysdig_secure_cloud_ingestion_assets" "assets" {}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "aws.%", "2"),
-					// not asserting the gov exported fields because not every backend environment is gov supported and thus will have empty values
+					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "aws.%", "4"),
+					// not asserting the gov exported fields because not every backend environme nt is gov supported and thus will have empty values
 
 					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_routing_key"),
-					// metadata fields are opaque to api backend; cloudingestion controls what fields are passed
+					// metadata fields are opaque to api backend; cloudingestion controls what f ields are passed
 					// asserts ingestionType and ingestionURL in metadata since it is required
 					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_metadata.ingestionType", "gcp"),
 					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_metadata.ingestionURL"),
 				),
 			},
 			{
-				Config: `data "sysdig_secure_trusted_cloud_identity" "trusted_identity" {	cloud_provider = "aws" }`,
+				Config: `data "sysdig_secure_cloud_ingestion_assets" "assets" {
+						cloud_provider = "aws" 
+						cloud_provider_id = "012345678901"
+				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_cloud_identity.trusted_identity", "cloud_provider", "aws"),
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_cloud_identity.trusted_identity", "aws_account_id"),
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_cloud_identity.trusted_identity", "aws_role_name"),
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "sns_routing_key"),
 					// not asserting the gov exported fields because not every backend environment is gov supported and thus will have empty values
 				),
 			},

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -176,10 +176,10 @@ func TestAccCloudIngestionAssetsDataSource(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: `data "sysdig_secure_cloud_ingestion_assets" "assets" { 
-			cloud_provider = "invalid" 
-			cloud_provider_id = "123"
-			}`,
+				Config: `data "sysdig_secure_cloud_ingestion_assets" "assets" {
+						cloud_provider = "invalid"
+						cloud_provider_id = "123"
+						}`,
 				ExpectError: regexp.MustCompile(`.*expected cloud_provider to be one of.*`),
 			},
 			{
@@ -201,8 +201,8 @@ func TestAccCloudIngestionAssetsDataSource(t *testing.T) {
 						cloud_provider_id = "012345678901"
 				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "sns_routing_key"),
-					// not asserting the gov exported fields because not every backend environment is gov supported and thus will have empty values
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "aws.sns_routing_key"),
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "aws.sns_routing_url"),
 				),
 			},
 		},

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -18,6 +18,7 @@ func TestAccTrustedCloudIdentityDataSource(t *testing.T) {
 		PreCheck: func() {
 			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
 				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
+				t.Fatal("SYSDIG_SECURE_API_TOKEN must be set for acceptance tests")
 			}
 		},
 		ProviderFactories: map[string]func() (*schema.Provider, error){

--- a/sysdig/data_source_sysdig_secure_onboarding_test.go
+++ b/sysdig/data_source_sysdig_secure_onboarding_test.go
@@ -176,6 +176,10 @@ func TestAccCloudIngestionAssetsDataSource(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
+				Config:      `data "sysdig_secure_cloud_ingestion_assets" "assets" {	cloud_provider = "invalid" }`,
+				ExpectError: regexp.MustCompile(`.*expected cloud_provider to be one of.*`),
+			},
+			{
 				Config: `data "sysdig_secure_cloud_ingestion_assets" "assets" {}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "aws.%", "2"),
@@ -186,6 +190,15 @@ func TestAccCloudIngestionAssetsDataSource(t *testing.T) {
 					// asserts ingestionType and ingestionURL in metadata since it is required
 					resource.TestCheckResourceAttr("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_metadata.ingestionType", "gcp"),
 					resource.TestCheckResourceAttrSet("data.sysdig_secure_cloud_ingestion_assets.assets", "gcp_metadata.ingestionURL"),
+				),
+			},
+			{
+				Config: `data "sysdig_secure_trusted_cloud_identity" "trusted_identity" {	cloud_provider = "aws" }`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sysdig_secure_trusted_cloud_identity.trusted_identity", "cloud_provider", "aws"),
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_cloud_identity.trusted_identity", "aws_account_id"),
+					resource.TestCheckResourceAttrSet("data.sysdig_secure_trusted_cloud_identity.trusted_identity", "aws_role_name"),
+					// not asserting the gov exported fields because not every backend environment is gov supported and thus will have empty values
 				),
 			},
 		},

--- a/sysdig/internal/client/v2/onboarding.go
+++ b/sysdig/internal/client/v2/onboarding.go
@@ -11,7 +11,7 @@ const (
 	onboardingTrustedAzureAppPath         = "%s/api/secure/onboarding/v2/trustedAzureApp?app=%s"
 	onboardingTenantExternaIDPath         = "%s/api/secure/onboarding/v2/externalID"
 	onboardingAgentlessScanningAssetsPath = "%s/api/secure/onboarding/v2/agentlessScanningAssets"
-	onboardingCloudIngestionAssetsPath    = "%s/api/secure/onboarding/v2/cloudIngestionAssets"
+	onboardingCloudIngestionAssetsPath    = "%s/api/secure/onboarding/v2/cloudIngestionAssets?provider=%s&providerID=%s"
 	onboardingTrustedRegulationAssetsPath = "%s/api/secure/onboarding/v2/trustedRegulationAssets?provider=%s"
 	onboardingTrustedOracleAppPath        = "%s/api/secure/onboarding/v2/trustedOracleApp?app=%s"
 )
@@ -22,7 +22,7 @@ type OnboardingSecureInterface interface {
 	GetTrustedAzureAppSecure(ctx context.Context, app string) (map[string]string, error)
 	GetTenantExternalIDSecure(ctx context.Context) (string, error)
 	GetAgentlessScanningAssetsSecure(ctx context.Context) (map[string]any, error)
-	GetCloudIngestionAssetsSecure(ctx context.Context) (map[string]any, error)
+	GetCloudIngestionAssetsSecure(ctx context.Context, provider, providerID string) (map[string]any, error)
 	GetTrustedCloudRegulationAssetsSecure(ctx context.Context, provider string) (map[string]string, error)
 	GetTrustedOracleAppSecure(ctx context.Context, app string) (map[string]string, error)
 }
@@ -83,8 +83,8 @@ func (client *Client) GetAgentlessScanningAssetsSecure(ctx context.Context) (map
 	return Unmarshal[map[string]interface{}](response.Body)
 }
 
-func (client *Client) GetCloudIngestionAssetsSecure(ctx context.Context) (map[string]interface{}, error) {
-	response, err := client.requester.Request(ctx, http.MethodGet, fmt.Sprintf(onboardingCloudIngestionAssetsPath, client.config.url), nil)
+func (client *Client) GetCloudIngestionAssetsSecure(ctx context.Context, provider, providerID string) (map[string]interface{}, error) {
+	response, err := client.requester.Request(ctx, http.MethodGet, fmt.Sprintf(onboardingCloudIngestionAssetsPath, client.config.url, provider, providerID), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/website/docs/d/secure_cloud_ingestion_assets.md
+++ b/website/docs/d/secure_cloud_ingestion_assets.md
@@ -30,7 +30,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `aws.sns_routing_key` - AWS CloudTrail SNS ingestion routing key
 
-* `aws.sns_metadata` - AWS CloudTrail SNS ingestion metadata
+* `aws.sns_routing_url` - AWS CloudTrail SNS ingestion URL
 
 * `gcp_routing_key` - GCP ingestion routing key
 

--- a/website/docs/d/secure_cloud_ingestion_assets.md
+++ b/website/docs/d/secure_cloud_ingestion_assets.md
@@ -32,3 +32,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `gcp_metadata` - GCP ingestion metadata
 
+* `sns_routing_key` - CloudTrail SNS ingestion routing key
+
+* `sns_metadata` - CloudTrail SNS ingestion metadata

--- a/website/docs/d/secure_cloud_ingestion_assets.md
+++ b/website/docs/d/secure_cloud_ingestion_assets.md
@@ -28,10 +28,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `aws.eventBusARNGov` - AWS Gov event bus (if supported) from which Sysdig Cloud Ingestion operates
 
+* `aws.sns_routing_key` - AWS CloudTrail SNS ingestion routing key
+
+* `aws.sns_metadata` - AWS CloudTrail SNS ingestion metadata
+
 * `gcp_routing_key` - GCP ingestion routing key
 
 * `gcp_metadata` - GCP ingestion metadata
-
-* `sns_routing_key` - CloudTrail SNS ingestion routing key
-
-* `sns_metadata` - CloudTrail SNS ingestion metadata


### PR DESCRIPTION
- data_source_sysdig_secure_onboarding.go: Added parameters and updated the API request for cloud provider and provider ID.
- data_source_sysdig_secure_onboarding_test.go: Added tests for the new cloud provider parameter and error handling.
- onboarding.go: Modified the API request to include cloud provider and provider ID.
- secure_cloud_ingestion_assets.md: Updated documentation to reflect new fields for cloud ingestion assets.