### PR TITLE
[SSPROD-51182] Skip TestAccList due to multiple variants error

### DIFF
--- a/sysdig/resource_sysdig_secure_list_test.go
+++ b/sysdig/resource_sysdig_secure_list_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccList(t *testing.T) {
+	t.Skip("Skipping this test temporarily due to https://sysdig.atlassian.net/browse/SSPROD-51182")
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	fixedRandomText := rText()
 


### PR DESCRIPTION
Test is [failing](https://jenkins.internal.sysdig.tools/job/qa/job/QA-cicd/job/policies-aws-integration-01/844/testReport/github/com_draios_terraform-provider-sysdig_sysdig/TestAccList/) due to the same issue reported in [SSPROD-51182](https://sysdig.atlassian.net/browse/SSPROD-51182):

```
2025-01-09T04:32:06.342Z [WARN]  sdk.helper_resource: Error running Terraform CLI command: test_name=TestAccList test_step_number=6 test_terraform_path=/usr/bin/terraform test_working_directory=/tmp/plugintest3903349811
  error=
  | exit status 1
  | 
  | Error: File falco_rules_local.yaml contains multiple variants with the same required engine version 22
  | 
  |   with sysdig_secure_list.sample3,
  |   on terraform_plugin_test.tf line 2, in resource "sysdig_secure_list" "sample3":
  |    2: resource "sysdig_secure_list" "sample3" {
```

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->