### PR TITLE
fix(sysdig_secure_vulnerability_accept_risk): when accept risk is not found, do not continue reading it

### DIFF
--- a/sysdig/resource_sysdig_secure_accept_vulnerability_risk.go
+++ b/sysdig/resource_sysdig_secure_accept_vulnerability_risk.go
@@ -256,6 +256,7 @@ func resourceSysdigSecureVulnerabilityAcceptRiskRead(ctx context.Context, d *sch
 	if err != nil {
 		if statusCode == http.StatusNotFound {
 			d.SetId("")
+			return nil
 		} else {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
If the resource is removed through the UI, and we created it through terraform, terraform should re-create it, if it's still present. There's a nil pointer dereference in the read method when the resource is not found, this fixes it.