### PR TITLE
fix(notification-channels) Update the terraform tests to account for the notification channel url validation

### DIFF
--- a/sysdig/data_source_sysdig_monitor_notification_channel_msteams_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_msteams_test.go
@@ -40,7 +40,7 @@ func monitorNotificationChannelMSTeams(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_msteams" "nc_msteams" {
 	name = "%s"
-	url = "https://hooks.msteams.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://sysdig.webhook.office.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 }
 
 data "sysdig_monitor_notification_channel_msteams" "nc_msteams" {

--- a/sysdig/data_source_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_slack_test.go
@@ -47,7 +47,7 @@ func monitorNotificationChannelSlack(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_slack" "nc_slack" {
 	name = "%s"
-	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"
 	show_section_runbook_links = false
 	show_section_event_details = false

--- a/sysdig/data_source_sysdig_secure_notification_channel_msteams_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_msteams_test.go
@@ -41,7 +41,7 @@ func secureNotificationChannelMSTeams(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_notification_channel_msteams" "nc_msteams" {
 	name = "%s"
-	url = "https://hooks.msteams.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://sysdig.webhook.office.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	template_version = "v2"
 }
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_slack_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_slack_test.go
@@ -42,7 +42,7 @@ func secureNotificationChannelSlack(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_notification_channel_slack" "nc_slack" {
 	name = "%s"
-	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"
 	template_version = "v2"
 }

--- a/sysdig/resource_sysdig_monitor_notification_channel_msteams_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_msteams_test.go
@@ -49,7 +49,7 @@ func monitorNotificationChannelMSTeamsWithName(name string) string {
 resource "sysdig_monitor_notification_channel_msteams" "sample-msteams1" {
 	name = "Example Channel %s - MS Teams"
 	enabled = true
-	url = "https://hooks.msteams.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://sysdig.webhook.office.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	notify_when_ok = true
 	notify_when_resolved = true
 }`, name)
@@ -61,7 +61,7 @@ resource "sysdig_monitor_notification_channel_msteams" "sample-msteams2" {
 	name = "Example Channel %s - MS Teams"
 	share_with_current_team = true
 	enabled = true
-	url = "https://hooks.msteams.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://sysdig.webhook.office.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	notify_when_ok = true
 	notify_when_resolved = true
 }`, name)

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack_test.go
@@ -52,7 +52,7 @@ func monitorNotificationChannelSlackWithName(name string) string {
 resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
 	name = "Example Channel %s - Slack"
 	enabled = true
-	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"
 	notify_when_ok = true
 	notify_when_resolved = true
@@ -65,7 +65,7 @@ resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
 	name = "Example Channel %s - Slack"
 	share_with_current_team = true
 	enabled = true
-	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"
 	notify_when_ok = true
 	notify_when_resolved = true
@@ -77,7 +77,7 @@ func monitorNotificationChannelSlackSharedWithShowSection(name string) string {
 resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
 	name = "Example Channel %s - Slack"
 	enabled = true
-	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"
 	notify_when_ok = true
 	notify_when_resolved = true

--- a/sysdig/resource_sysdig_secure_notification_channel_msteams_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_msteams_test.go
@@ -57,7 +57,7 @@ func secureNotificationChannelMSTeamsWithName(name string) string {
 resource "sysdig_secure_notification_channel_msteams" "sample-msteams" {
 	name = "Example Channel %s - MS Teams"
 	enabled = true
-	url = "https://hooks.msteams.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://sysdig.webhook.office.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	notify_when_ok = true
 	notify_when_resolved = true
 }`, name)
@@ -69,7 +69,7 @@ resource "sysdig_secure_notification_channel_msteams" "sample-msteams" {
 	name = "Example Channel %s - MS Teams"
 	share_with_current_team = true
 	enabled = true
-	url = "https://hooks.msteams.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://sysdig.webhook.office.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	notify_when_ok = true
 	notify_when_resolved = true
 }`, name)
@@ -80,7 +80,7 @@ func secureNotificationChannelMSTeamsWithNameAndTemplateVersion(name, version st
 resource "sysdig_secure_notification_channel_msteams" "sample-msteams" {
 	name = "Example Channel %s - MS Teams"
 	enabled = true
-	url = "https://hooks.msteams.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://sysdig.webhook.office.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	notify_when_ok = true
 	notify_when_resolved = true
 	template_version = "%s"

--- a/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_slack_test.go
@@ -57,7 +57,7 @@ func secureNotificationChannelSlackWithName(name string) string {
 resource "sysdig_secure_notification_channel_slack" "sample-slack" {
 	name = "Example Channel %s - Slack"
 	enabled = true
-	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"
 	notify_when_ok = true
 	notify_when_resolved = true
@@ -70,7 +70,7 @@ resource "sysdig_secure_notification_channel_slack" "sample-slack" {
 	name = "Example Channel %s - Slack"
 	share_with_current_team = true
 	enabled = true
-	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"
 	notify_when_ok = true
 	notify_when_resolved = true
@@ -82,7 +82,7 @@ func secureNotificationChannelSlackWithNameAndTemplateVersion(name, version stri
 resource "sysdig_secure_notification_channel_slack" "sample-slack" {
 	name = "Example Channel %s - Slack"
 	enabled = true
-	url = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel = "#sysdig"
 	notify_when_ok = true
 	notify_when_resolved = true

--- a/website/docs/r/monitor_notification_channel_slack.md
+++ b/website/docs/r/monitor_notification_channel_slack.md
@@ -18,7 +18,7 @@ Creates a Sysdig Monitor Notification Channel of type Slack.
 resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
 	name                    = "Example Channel - Slack"
 	enabled                 = true
-	url                     = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url                     = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel                 = "#sysdig"
 	notify_when_ok          = false
 	notify_when_resolved    = false

--- a/website/docs/r/secure_notification_channel_slack.md
+++ b/website/docs/r/secure_notification_channel_slack.md
@@ -18,7 +18,7 @@ Creates a Sysdig Secure Notification Channel of type Slack.
 resource "sysdig_secure_notification_channel_slack" "sample-slack" {
 	name                    = "Example Channel - Slack"
 	enabled                 = true
-	url                     = "https://hooks.slack.cwom/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+	url                     = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 	channel                 = "#sysdig"
 	notify_when_ok          = false
 	notify_when_resolved    = false


### PR DESCRIPTION
Tests for msteams and slack notification channels are using invalid urls for the channel webhooks. 

Now that we've added validation of urls on the BE, the tests should be updated to use valid urls.