### PR TITLE
fix(policies) switch out rule in managed secure policy tests

### DIFF
--- a/sysdig/resource_sysdig_secure_managed_policy_test.go
+++ b/sysdig/resource_sysdig_secure_managed_policy_test.go
@@ -56,7 +56,7 @@ resource "sysdig_secure_managed_policy" "sample" {
 	name = "Sysdig Runtime Threat Detection"
 	enabled = true
 	scope = "container.id != \"\""
-	disabled_rules = ["Dump memory for credentials"]
+	disabled_rules = ["Hexadecimal string detected"]
 	runbook = "https://sysdig.com"
 
 	actions {
@@ -80,7 +80,7 @@ resource "sysdig_secure_managed_policy" "sample" {
 	name = "Sysdig Runtime Threat Detection"
 	enabled = true
 	scope = "container.id != \"\""
-	disabled_rules = ["Dump memory for credentials"]
+	disabled_rules = ["Hexadecimal string detected"]
 	runbook = "https://sysdig.com"
 
 	actions {}
@@ -96,7 +96,7 @@ resource "sysdig_secure_managed_policy" "sample" {
 	name = "Sysdig Runtime Threat Detection"
 	enabled = true
 	scope = "container.id != \"\""
-	disabled_rules = ["Dump memory for credentials"]
+	disabled_rules = ["Hexadecimal string detected"]
 	runbook = "https://sysdig.com"
 
 	actions {
@@ -123,7 +123,7 @@ func managedPolicyWithKillAction() string {
 	name = "Sysdig Runtime Threat Detection"
 	enabled = true
 	scope = "container.id != \"\""
-	disabled_rules = ["Dump memory for credentials"]
+	disabled_rules = ["Hexadecimal string detected"]
 	runbook = "https://sysdig.com"
 
 	actions {

--- a/sysdig/resource_sysdig_secure_managed_ruleset_test.go
+++ b/sysdig/resource_sysdig_secure_managed_ruleset_test.go
@@ -66,7 +66,7 @@ resource "sysdig_secure_managed_ruleset" "sample" {
 	}
 	enabled = true
 	scope = "container.id != \"\""
-	disabled_rules = ["Dump memory for credentials"]
+	disabled_rules = ["Hexadecimal string detected"]
 	runbook = "https://sysdig.com"
 
 	actions {
@@ -95,7 +95,7 @@ resource "sysdig_secure_managed_ruleset" "sample" {
 	}
 	enabled = true
 	scope = "container.id != \"\""
-	disabled_rules = ["Dump memory for credentials"]
+	disabled_rules = ["Hexadecimal string detected"]
 	runbook = "https://sysdig.com"
 
 	actions {}
@@ -116,7 +116,7 @@ resource "sysdig_secure_managed_ruleset" "sample" {
 	}
 	enabled = true
 	scope = "container.id != \"\""
-	disabled_rules = ["Dump memory for credentials"]
+	disabled_rules = ["Hexadecimal string detected"]
 	runbook = "https://sysdig.com"
 
 	actions {
@@ -154,7 +154,7 @@ resource "sysdig_secure_managed_ruleset" "sample" {
 	}
 	enabled = true
 	scope = "container.id != \"\""
-	disabled_rules = ["Dump memory for credentials"]
+	disabled_rules = ["Hexadecimal string detected"]
 	runbook = "https://sysdig.com"
 
 	actions {

--- a/website/docs/r/secure_managed_policy.md
+++ b/website/docs/r/secure_managed_policy.md
@@ -32,7 +32,7 @@ resource "sysdig_secure_managed_policy" "sysdig_runtime_threat_detection" {
   scope = "container.id != \"\""
 
   // Disabling rules
-  disabled_rules = ["Dump memory for credentials"]
+  disabled_rules = ["Hexadecimal string detected"]
 
   actions {
     container = "stop"

--- a/website/docs/r/secure_managed_ruleset.md
+++ b/website/docs/r/secure_managed_ruleset.md
@@ -34,7 +34,7 @@ resource "sysdig_secure_managed_ruleset" "sysdig_runtime_threat_detection_manage
     scope = "container.id != \"\""
 
     // Disabling rules
-    disabled_rules = ["Dump memory for credentials"]
+    disabled_rules = ["Hexadecimal string detected"]
 
     actions {
         container = "stop"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->

The old rule was removed from this managed policy 