### PR TITLE
feat(posture_zone): use public api for creating zones

### DIFF
--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -1154,6 +1154,11 @@ type PostureZoneRequest struct {
 	Scopes      []PostureZoneScope `json:"scopes"`
 }
 
+type ZonePoliciesRequest struct {
+	ZoneID    int   `json:"zoneId"`
+	PolicyIDs []int `json:"policyIds"`
+}
+
 type PostureZoneResponse struct {
 	Data PostureZone `json:"data"`
 }

--- a/sysdig/internal/client/v2/posture_zones.go
+++ b/sysdig/internal/client/v2/posture_zones.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	PostureZonesPath = "%s/api/cspm/v1/policy/zones"
-	PostureZonePath  = "%s/api/cspm/v1/policy/zones/%d"
+	PostureZonesPath        = "%s/api/cspm/v1/policy/zones"
+	PostureZonePath         = "%s/api/cspm/v1/policy/zones/%d"
+	PostureZonePoliciesPath = "%s/api/cspm/v1/policy/zone-policies"
 )
 
 type PostureZoneInterface interface {
@@ -16,6 +17,7 @@ type PostureZoneInterface interface {
 	CreateOrUpdatePostureZone(ctx context.Context, z *PostureZoneRequest) (*PostureZone, string, error)
 	GetPostureZone(ctx context.Context, id int) (*PostureZone, error)
 	DeletePostureZone(ctx context.Context, id int) error
+	BindZoneToPolicies(ctx context.Context, r *ZonePoliciesRequest) error
 }
 
 func (client *Client) CreateOrUpdatePostureZone(ctx context.Context, r *PostureZoneRequest) (*PostureZone, string, error) {
@@ -76,10 +78,35 @@ func (client *Client) DeletePostureZone(ctx context.Context, id int) error {
 	return nil
 }
 
+func (client *Client) BindZoneToPolicies(ctx context.Context, r *ZonePoliciesRequest) error {
+
+	payload, err := Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	response, err := client.requester.Request(ctx, http.MethodPost, client.getZonePoliciesURL(), payload)
+	if err != nil {
+		return err
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return client.ErrorFromResponse(response)
+	}
+
+	return nil
+}
+
 func (client *Client) createPostureZoneURL() string {
 	return fmt.Sprintf(PostureZonesPath, client.config.url)
 }
 
 func (client *Client) getPostureZoneURL(id int) string {
 	return fmt.Sprintf(PostureZonePath, client.config.url, id)
+}
+
+func (client *Client) getZonePoliciesURL() string {
+	return fmt.Sprintf(PostureZonePoliciesPath, client.config.url)
 }

--- a/sysdig/resource_sysdig_secure_posture_zone.go
+++ b/sysdig/resource_sysdig_secure_posture_zone.go
@@ -119,6 +119,9 @@ func resourceCreatePostureZone(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	zoneClient, err := getZoneClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	postureZoneClient, err := getPostureZoneClient(meta.(SysdigClients))
 	if err != nil {
 		return diag.FromErr(err)
@@ -171,6 +174,9 @@ func resourceUpdatePostureZone(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	zoneClient, err := getZoneClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	postureZoneClient, err := getPostureZoneClient(meta.(SysdigClients))
 	if err != nil {
 		return diag.FromErr(err)
@@ -293,6 +299,9 @@ func resourceSysdigSecurePostureZoneRead(ctx context.Context, d *schema.Resource
 
 func resourceSysdigSecurePostureZoneDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	postureClient, err := getPostureZoneClient(meta.(SysdigClients))
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	zoneClient, err := getZoneClient(meta.(SysdigClients))
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
This PR updates the sysdig_secure_posture_zone resource to use the public API for creating zones and then make an additional request to the /api/cspm/v1/policy/zone-policies endpoint to attach the created zone to existing policies. If the second request fails, the created zone is deleted.