### PR TITLE
fix(event-bridge-api-dest): remove validation on component type param (SSPROD-53947)

### DIFF
--- a/sysdig/data_source_sysdig_secure_onboarding.go
+++ b/sysdig/data_source_sysdig_secure_onboarding.go
@@ -355,9 +355,8 @@ func dataSourceSysdigSecureCloudIngestionAssets() *schema.Resource {
 				Optional: true,
 			},
 			"component_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"COMPONENT_WEBHOOK_DATASOURCE"}, false),
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"aws": {
 				Type:     schema.TypeMap,


### PR DESCRIPTION
This pull request includes a small change to the `sysdig/data_source_sysdig_secure_onboarding.go` file. The change removes the validation function for the `component_type` field, which previously restricted its values to a specific string.

* [`sysdig/data_source_sysdig_secure_onboarding.go`](diffhunk://#diff-9178b032a69f9ba37daf2be14caa309c43f3c77d6d813bf24d310f819396f6e8L360): Removed the `ValidateFunc` that restricted `component_type` to "COMPONENT_WEBHOOK_DATASOURCE".