### PR TITLE
chore(notification-channels): Make Slack webhook URL fields sensitive

### DIFF
--- a/sysdig/data_source_sysdig_monitor_notification_channel_slack.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_slack.go
@@ -21,8 +21,9 @@ func dataSourceSysdigMonitorNotificationChannelSlack() *schema.Resource {
 
 		Schema: createMonitorNotificationChannelSchema(map[string]*schema.Schema{
 			"url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"channel": {
 				Type:     schema.TypeString,

--- a/sysdig/data_source_sysdig_secure_notification_channel_slack.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_slack.go
@@ -21,8 +21,9 @@ func dataSourceSysdigSecureNotificationChannelSlack() *schema.Resource {
 
 		Schema: createSecureNotificationChannelSchema(map[string]*schema.Schema{
 			"url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"channel": {
 				Type:     schema.TypeString,

--- a/sysdig/resource_sysdig_monitor_notification_channel_slack.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_slack.go
@@ -32,8 +32,9 @@ func resourceSysdigMonitorNotificationChannelSlack() *schema.Resource {
 
 		Schema: createMonitorNotificationChannelSchema(map[string]*schema.Schema{
 			"url": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 			"channel": {
 				Type:     schema.TypeString,

--- a/sysdig/resource_sysdig_secure_notification_channel_slack.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_slack.go
@@ -33,8 +33,9 @@ func resourceSysdigSecureNotificationChannelSlack() *schema.Resource {
 
 		Schema: createSecureNotificationChannelSchema(map[string]*schema.Schema{
 			"url": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 			"channel": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->

Slack webhook URLs are sensitive according to Slack documentation (https://api.slack.com/messaging/webhooks):

> Keep it secret, keep it safe. Your webhook URL contains a secret. Don't share it online, including via public version control repositories. Slack actively searches out and revokes leaked secrets.

This PR makes them sensitive in Terraform as well so they don't get sent to logs and unexpectedly exposed.