### PR TITLE
fix(posture/zones): correctly handle api errors

### DIFF
--- a/sysdig/internal/client/v2/posture_controls.go
+++ b/sysdig/internal/client/v2/posture_controls.go
@@ -48,6 +48,9 @@ func (c *Client) GetPostureControl(ctx context.Context, id int64) (*PostureContr
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return nil, c.ErrorFromResponse(response)
+	}
 	wrapper, err := Unmarshal[SaveControlResponse](response.Body)
 	if err != nil {
 		return nil, err

--- a/sysdig/internal/client/v2/posture_policies.go
+++ b/sysdig/internal/client/v2/posture_policies.go
@@ -28,6 +28,10 @@ func (client *Client) ListPosturePolicies(ctx context.Context) ([]PosturePolicy,
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return nil, client.ErrorFromResponse(response)
+	}
+
 	resp, err := Unmarshal[PostureZonePolicyListResponse](response.Body)
 	if err != nil {
 		return nil, err

--- a/sysdig/internal/client/v2/posture_zones.go
+++ b/sysdig/internal/client/v2/posture_zones.go
@@ -54,6 +54,9 @@ func (client *Client) GetPostureZone(ctx context.Context, id int) (*PostureZone,
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return nil, client.ErrorFromResponse(response)
+	}
 	wrapper, err := Unmarshal[PostureZoneResponse](response.Body)
 	if err != nil {
 		return nil, err

--- a/sysdig/internal/client/v2/zones.go
+++ b/sysdig/internal/client/v2/zones.go
@@ -31,6 +31,9 @@ func (client *Client) GetZones(ctx context.Context, name string) ([]Zone, error)
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return nil, client.ErrorFromResponse(response)
+	}
 	wrapper, err := Unmarshal[ZonesWrapper](response.Body)
 	if err != nil {
 		return nil, err
@@ -46,6 +49,9 @@ func (client *Client) GetZoneById(ctx context.Context, id int) (*Zone, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return nil, client.ErrorFromResponse(response)
+	}
 	zone, err := Unmarshal[Zone](response.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
correctly handle api errors in several GET calls so that a proper message is shown, rather than a parsing issue. 

Fixes https://github.com/sysdiglabs/terraform-provider-sysdig/issues/617.