### PR TITLE
fix(ci): reorder elements in test

### DIFF
--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -296,7 +296,7 @@ func TestAccGCPSecureCloudAuthAccountThreatDetection(t *testing.T) {
 		    feature {
 			  secure_threat_detection {
 			    enabled    = true
-			    components = ["COMPONENT_WEBHOOK_DATASOURCE/secure-runtime", "COMPONENT_SERVICE_PRINCIPAL/secure-runtime"]
+			    components = ["COMPONENT_SERVICE_PRINCIPAL/secure-runtime", "COMPONENT_WEBHOOK_DATASOURCE/secure-runtime"]
 			  }
 		    }
 			component {


### PR DESCRIPTION
Latest changes in backend shows the components of the cloud auth resource reordered. This is consistent now, but the test was failing. This may fail for customers as well, complaining that the resources now show differences where there should be none. This comment is also documenting that future issue...

<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->