### PR TITLE
fix(vuln-rule-bundle): replace TypeList with TypeSet to ignore ordering

### DIFF
--- a/sysdig/resource_sysdig_secure_vulnerability_rule_bundle.go
+++ b/sysdig/resource_sysdig_secure_vulnerability_rule_bundle.go
@@ -98,7 +98,7 @@ func resourceSysdigSecureVulnerabilityRuleBundle() *schema.Resource {
 			},
 
 			"rule": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				MinItems:    1,
 				Description: "Rules for this bundle",
@@ -606,7 +606,7 @@ func vulnerabilityRuleBundleFromResourceData(d *schema.ResourceData) (v2.Vulnera
 		return &idAsInt
 	}
 
-	rules, err := vulnerabilityRulesFromList(d.Get("rule").([]any))
+	rules, err := vulnerabilityRulesFromList(d.Get("rule").(*schema.Set).List())
 	if err != nil {
 		return v2.VulnerabilityRuleBundle{}, err
 	}
@@ -621,7 +621,10 @@ func vulnerabilityRuleBundleFromResourceData(d *schema.ResourceData) (v2.Vulnera
 }
 
 func vulnerabilityRulesFromList(list []any) ([]v2.VulnerabilityRule, error) {
-	var out []v2.VulnerabilityRule
+	if len(list) == 0 {
+		return nil, fmt.Errorf("empty rule detected, you need to specify one")
+	}
+	out := []v2.VulnerabilityRule{}
 
 	for _, ruleRaw := range list {
 		if ruleRaw == nil {

--- a/sysdig/resource_sysdig_secure_vulnerability_rule_bundle_test.go
+++ b/sysdig/resource_sysdig_secure_vulnerability_rule_bundle_test.go
@@ -76,12 +76,22 @@ func TestAccVulnerabilityRuleBundle(t *testing.T) {
 				),
 			},
 			{
-				Config: fullVulnerabilityRuleBundleConfig_ImageLabel(random()),
+				Config: singleRuleConfig_label_must_not_exist(random()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.0.image_label.0.label_must_not_exist", "forbidden-label"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.1.image_label.0.label_must_exist", "another-required-label"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.2.image_label.0.label_must_exist_and_contain_value.0.required_label", "required-label"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.2.image_label.0.label_must_exist_and_contain_value.0.required_value", "required-value"),
+				),
+			},
+			{
+				Config: singleRuleConfig_label_must_exist(random()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.0.image_label.0.label_must_exist", "another-required-label"),
+				),
+			},
+			{
+				Config: singleRuleConfig_label_must_exist_and_contain_value(random()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.0.image_label.0.label_must_exist_and_contain_value.0.required_label", "required-label"),
+					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.0.image_label.0.label_must_exist_and_contain_value.0.required_value", "required-value"),
 				),
 			},
 			{
@@ -101,29 +111,6 @@ func TestAccVulnerabilityRuleBundle(t *testing.T) {
 					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.0.severities_and_threats.0.cisa_kev_due_date_in_days", "21"),
 					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.0.severities_and_threats.0.epss_score_at_least_percentage", "80"),
 					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.0.severities_and_threats.0.epss_percentile_at_least_percentage", "90"),
-				),
-			},
-			{
-				Config: fullVulnerabilityRuleBundleConfig_AllTypes(random()),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.0.image_label.0.label_must_not_exist", "forbidden-label"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.1.image_label.0.label_must_exist", "another-required-label"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.2.image_label.0.label_must_exist_and_contain_value.0.required_label", "required-label"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.2.image_label.0.label_must_exist_and_contain_value.0.required_value", "required-value"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.severity_at_least", "high"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.disclosure_older_than_days", "90"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.package_type", "os"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.in_use", "true"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.fix_available_since_days", "30"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.public_exploit_available_since_days", "15"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.exploit_no_admin_privileges", "true"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.exploit_no_user_interaction", "true"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.exploit_network_attack_vector", "true"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.cisa_kev_in_ransomware_campaign", "true"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.cisa_kev_available_since_days", "10"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.cisa_kev_due_date_in_days", "21"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.epss_score_at_least_percentage", "80"),
-					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.3.severities_and_threats.0.epss_percentile_at_least_percentage", "90"),
 				),
 			},
 			{
@@ -156,6 +143,9 @@ func TestAccVulnerabilityRuleBundle(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sysdig_secure_vulnerability_rule_bundle.sample", "rule.0.severities_and_threats.0.fix_available", "true"),
 				),
+			},
+			{
+				Config: fullVulnerabilityRuleBundleConfig_AllTypes(random()),
 			},
 			{
 				ResourceName:      "sysdig_secure_vulnerability_rule_bundle.sample",
@@ -224,24 +214,39 @@ resource "sysdig_secure_vulnerability_rule_bundle" "sample" {
 `, suffix)
 }
 
-func fullVulnerabilityRuleBundleConfig_ImageLabel(suffix string) string {
+func singleRuleConfig_label_must_not_exist(suffix string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_vulnerability_rule_bundle" "sample" {
   name        = "TERRAFORM TEST %s"
-  description = "Full bundle with image_label rules"
-
+  description = "rule with label_must_not_exist"
   rule {
     image_label {
       label_must_not_exist = "forbidden-label"
     }
   }
+}
+`, suffix)
+}
 
+func singleRuleConfig_label_must_exist(suffix string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_vulnerability_rule_bundle" "sample" {
+  name        = "TERRAFORM TEST %s"
+  description = "rule with label_must_exist"
   rule {
     image_label {
       label_must_exist = "another-required-label"
     }
   }
+}
+`, suffix)
+}
 
+func singleRuleConfig_label_must_exist_and_contain_value(suffix string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_vulnerability_rule_bundle" "sample" {
+  name        = "TERRAFORM TEST %s"
+  description = "rule with label_must_exist_and_contain_value"
   rule {
     image_label {
       label_must_exist_and_contain_value {
@@ -259,55 +264,6 @@ func fullVulnerabilityRuleBundleConfig_Severities(suffix string) string {
 resource "sysdig_secure_vulnerability_rule_bundle" "sample" {
   name        = "TERRAFORM TEST %s"
   description = "Full bundle with severities_and_threats rules"
-
-  rule {
-    severities_and_threats {
-      severity_at_least                   = "high"
-      disclosure_older_than_days          = 90
-      package_type                        = "os"
-      in_use                              = true
-      fix_available_since_days            = 30
-      public_exploit_available_since_days = 15
-      exploit_no_admin_privileges         = true
-      exploit_no_user_interaction         = true
-      exploit_network_attack_vector       = true
-      cisa_kev_in_ransomware_campaign     = true
-      cisa_kev_available_since_days       = 10
-      cisa_kev_due_date_in_days           = 21
-      epss_score_at_least_percentage      = 80
-      epss_percentile_at_least_percentage = 90
-    }
-  }
-}
-`, suffix)
-}
-
-func fullVulnerabilityRuleBundleConfig_AllTypes(suffix string) string {
-	return fmt.Sprintf(`
-resource "sysdig_secure_vulnerability_rule_bundle" "sample" {
-  name        = "TERRAFORM TEST %s"
-  description = "Full bundle with all rule types"
-
-  rule {
-    image_label {
-      label_must_not_exist = "forbidden-label"
-    }
-  }
-
-  rule {
-    image_label {
-      label_must_exist = "another-required-label"
-    }
-  }
-
-  rule {
-    image_label {
-      label_must_exist_and_contain_value {
-        required_label = "required-label"
-        required_value = "required-value"
-      }
-    }
-  }
 
   rule {
     severities_and_threats {
@@ -480,6 +436,55 @@ resource "sysdig_secure_vulnerability_rule_bundle" "sample" {
   rule {
     severities_and_threats {
       fix_available = true
+    }
+  }
+}
+`, suffix)
+}
+
+func fullVulnerabilityRuleBundleConfig_AllTypes(suffix string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_vulnerability_rule_bundle" "sample" {
+  name        = "TERRAFORM TEST %s"
+  description = "Full bundle with all rule types"
+
+  rule {
+    image_label {
+      label_must_not_exist = "forbidden-label"
+    }
+  }
+
+  rule {
+    image_label {
+      label_must_exist = "another-required-label"
+    }
+  }
+
+  rule {
+    image_label {
+      label_must_exist_and_contain_value {
+        required_label = "required-label"
+        required_value = "required-value"
+      }
+    }
+  }
+
+  rule {
+    severities_and_threats {
+      severity_at_least                   = "high"
+      disclosure_older_than_days          = 90
+      package_type                        = "os"
+      in_use                              = true
+      fix_available_since_days            = 30
+      public_exploit_available_since_days = 15
+      exploit_no_admin_privileges         = true
+      exploit_no_user_interaction         = true
+      exploit_network_attack_vector       = true
+      cisa_kev_in_ransomware_campaign     = true
+      cisa_kev_available_since_days       = 10
+      cisa_kev_due_date_in_days           = 21
+      epss_score_at_least_percentage      = 80
+      epss_percentile_at_least_percentage = 90
     }
   }
 }


### PR DESCRIPTION
The API does not keep the order for rule bundle rules. This change ensures that there won't be undesired updates for resources that should not change, because the API will not return the rules always in the same order.