### PR TITLE
feat(alerts): add notify_on_acknwoledge, deprecated opts at notification channel level

### DIFF
--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -138,9 +138,9 @@ type NotificationChannelOptions struct {
 	CustomData               map[string]any                             `json:"customData,omitempty"`               // Type: ibm function, Webhook
 	TemplateConfiguration    []NotificationChannelTemplateConfiguration `json:"templateConfiguration,omitempty"`    // Type: slack, ms teams
 
-	NotifyOnOk           *bool `json:"notifyOnOk,omitempty"`
-	NotifyOnResolve      *bool `json:"notifyOnResolve,omitempty"`
-	SendTestNotification bool  `json:"sendTestNotification"`
+	NotifyOnOk           bool `json:"notifyOnOk"`
+	NotifyOnResolve      bool `json:"notifyOnResolve"`
+	SendTestNotification bool `json:"sendTestNotification"`
 }
 
 type NotificationChannel struct {

--- a/sysdig/resource_sysdig_monitor_notification_channel_common.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_common.go
@@ -3,7 +3,6 @@ package sysdig
 import (
 	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func createMonitorNotificationChannelSchema(original map[string]*schema.Schema) map[string]*schema.Schema {
@@ -23,16 +22,16 @@ func createMonitorNotificationChannelSchema(original map[string]*schema.Schema) 
 			Default:  false,
 		},
 		"notify_when_ok": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
-			Deprecated:   "The notify_when_ok field is deprecated and will be removed in a future version. This flag has been replaced by the `notify_on_resolve` field inside `notification_channels` when defining an alert resource.",
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Default:    false,
+			Deprecated: "The notify_when_ok field is deprecated and will be removed in a future version. This flag has been replaced by the `notify_on_resolve` field inside `notification_channels` when defining an alert resource.",
 		},
 		"notify_when_resolved": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
-			Deprecated:   "The notify_when_resolved field is deprecated and will be removed in a future version. This flag has been replaced by the `notify_on_acknowledge` field inside `notification_channels` when defining an alert resource.",
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Default:    false,
+			Deprecated: "The notify_when_resolved field is deprecated and will be removed in a future version. This flag has been replaced by the `notify_on_acknowledge` field inside `notification_channels` when defining an alert resource.",
 		},
 		"version": {
 			Type:     schema.TypeInt,
@@ -59,35 +58,13 @@ func monitorNotificationChannelFromResourceData(d *schema.ResourceData, teamID i
 		tID = &teamID
 	}
 
-	var notifyOnOk *bool = nil
-	if onOk, ok := d.GetOk("notify_when_ok"); ok && onOk.(string) != "" {
-		if onOk.(string) == "true" {
-			trueValue := true
-			notifyOnOk = &trueValue
-		} else {
-			falseValue := false
-			notifyOnOk = &falseValue
-		}
-	}
-
-	var notifyOnResolve *bool = nil
-	if onResolve, ok := d.GetOk("notify_when_resolved"); ok && onResolve.(string) != "" {
-		if onResolve.(string) == "true" {
-			trueValue := true
-			notifyOnResolve = &trueValue
-		} else {
-			falseValue := false
-			notifyOnResolve = &falseValue
-		}
-	}
-
 	nc = v2.NotificationChannel{
 		Name:    d.Get("name").(string),
 		Enabled: d.Get("enabled").(bool),
 		TeamID:  tID,
 		Options: v2.NotificationChannelOptions{
-			NotifyOnOk:           notifyOnOk,
-			NotifyOnResolve:      notifyOnResolve,
+			NotifyOnOk:           d.Get("notify_when_ok").(bool),
+			NotifyOnResolve:      d.Get("notify_when_resolved").(bool),
 			SendTestNotification: d.Get("send_test_notification").(bool),
 		},
 	}
@@ -107,23 +84,8 @@ func monitorNotificationChannelToResourceData(nc *v2.NotificationChannel, data *
 	if err != nil {
 		return err
 	}
-
-	if nc.Options.NotifyOnOk != nil {
-		if *nc.Options.NotifyOnOk {
-			_ = data.Set("notify_when_ok", "true")
-		} else {
-			_ = data.Set("notify_when_ok", "false")
-		}
-	}
-
-	if nc.Options.NotifyOnResolve != nil {
-		if *nc.Options.NotifyOnResolve {
-			_ = data.Set("notify_when_resolved", "true")
-		} else {
-			_ = data.Set("notify_when_resolved", "false")
-		}
-	}
-
+	_ = data.Set("notify_when_ok", nc.Options.NotifyOnOk)
+	_ = data.Set("notify_when_resolved", nc.Options.NotifyOnResolve)
 	// do not update "send_test_notification" from the api response as it will always be "false" on subsequent reads because the fields is not persisted
 
 	return err

--- a/sysdig/resource_sysdig_monitor_notification_channel_custom_webhook_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_custom_webhook_test.go
@@ -69,15 +69,6 @@ func TestAccMonitorNotificationChannelCustomWebhook(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"send_test_notification"},
 			},
-			{
-				Config: monitorNotificationChannelCustomWebhookWithoutNotifyFields(rText()),
-			},
-			{
-				ResourceName:            "sysdig_monitor_notification_channel_custom_webhook.sample-custom-webhook6",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"send_test_notification"},
-			},
 		},
 	})
 }
@@ -158,16 +149,4 @@ func monitorNotificationChannelCustomWebhookSharedWithAdditionalHeaders(name str
 		notify_when_resolved = false
 		send_test_notification = false
 	}`, name)
-}
-
-func monitorNotificationChannelCustomWebhookWithoutNotifyFields(name string) string {
-	return fmt.Sprintf(`
-resource "sysdig_monitor_notification_channel_custom_webhook" "sample-custom-webhook6" {
-	name = "Example Channel %s - Custom Webhook"
-	enabled = true
-	url = "https://example.com/"
-	http_method = "POST"
-	template = "{\n  \"code\": \"incident\",\n  \"alert\": \"{{@alert_name}}\"\n}"
-	send_test_notification = false
-}`, name)
 }

--- a/sysdig/resource_sysdig_secure_notification_channel_common.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_common.go
@@ -3,7 +3,6 @@ package sysdig
 import (
 	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func createSecureNotificationChannelSchema(original map[string]*schema.Schema) map[string]*schema.Schema {
@@ -23,16 +22,16 @@ func createSecureNotificationChannelSchema(original map[string]*schema.Schema) m
 			Default:  false,
 		},
 		"notify_when_ok": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
-			Deprecated:   "The notify_when_ok field is deprecated and will be removed in a future version. This flag has been replaced by the `notify_on_resolve` field inside `notification_channels` when defining an alert resource.",
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Default:    false,
+			Deprecated: "The notify_when_ok field is deprecated and will be removed in a future version. This flag has been replaced by the `notify_on_resolve` field inside `notification_channels` when defining an alert resource.",
 		},
 		"notify_when_resolved": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
-			Deprecated:   "The notify_when_resolved field is deprecated and will be removed in a future version. This flag has been replaced by the `notify_on_acknowledge` field inside `notification_channels` when defining an alert resource.",
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Default:    false,
+			Deprecated: "The notify_when_resolved field is deprecated and will be removed in a future version. This flag has been replaced by the `notify_on_acknowledge` field inside `notification_channels` when defining an alert resource.",
 		},
 		"version": {
 			Type:     schema.TypeInt,
@@ -59,35 +58,13 @@ func secureNotificationChannelFromResourceData(d *schema.ResourceData, teamID in
 		tID = &teamID
 	}
 
-	var notifyOnOk *bool = nil
-	if onOk, ok := d.GetOk("notify_when_ok"); ok && onOk.(string) != "" {
-		if onOk.(string) == "true" {
-			trueValue := true
-			notifyOnOk = &trueValue
-		} else {
-			falseValue := false
-			notifyOnOk = &falseValue
-		}
-	}
-
-	var notifyOnResolve *bool = nil
-	if onResolve, ok := d.GetOk("notify_when_resolved"); ok && onResolve.(string) != "" {
-		if onResolve.(string) == "true" {
-			trueValue := true
-			notifyOnResolve = &trueValue
-		} else {
-			falseValue := false
-			notifyOnResolve = &falseValue
-		}
-	}
-
 	nc = v2.NotificationChannel{
 		Name:    d.Get("name").(string),
 		Enabled: d.Get("enabled").(bool),
 		TeamID:  tID,
 		Options: v2.NotificationChannelOptions{
-			NotifyOnOk:           notifyOnOk,
-			NotifyOnResolve:      notifyOnResolve,
+			NotifyOnOk:           d.Get("notify_when_ok").(bool),
+			NotifyOnResolve:      d.Get("notify_when_resolved").(bool),
 			SendTestNotification: d.Get("send_test_notification").(bool),
 		},
 	}
@@ -107,23 +84,8 @@ func secureNotificationChannelToResourceData(nc *v2.NotificationChannel, data *s
 	if err != nil {
 		return err
 	}
-
-	if nc.Options.NotifyOnOk != nil {
-		if *nc.Options.NotifyOnOk {
-			_ = data.Set("notify_when_ok", "true")
-		} else {
-			_ = data.Set("notify_when_ok", "false")
-		}
-	}
-
-	if nc.Options.NotifyOnResolve != nil {
-		if *nc.Options.NotifyOnResolve {
-			_ = data.Set("notify_when_resolved", "true")
-		} else {
-			_ = data.Set("notify_when_resolved", "false")
-		}
-	}
-
+	_ = data.Set("notify_when_ok", nc.Options.NotifyOnOk)
+	_ = data.Set("notify_when_resolved", nc.Options.NotifyOnResolve)
 	// do not update "send_test_notification" from the api response as it will always be "false" on subsequent reads because the fields is not persisted
 
 	return err

--- a/website/docs/r/monitor_alert_v2_change.md
+++ b/website/docs/r/monitor_alert_v2_change.md
@@ -76,7 +76,7 @@ It is a list of objects with the following fields:
 * `id` - (Required) The ID of the notification channel.
 * `renotify_every_minutes` - (Optional) the amount of minutes to wait before re sending the notification to this channel. `0` means no renotification enabled. Default: `0`.
 * `notify_on_resolve` - (Optional) Whether to send a notification when the alert is resolved. Default: `true`.
-* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected. If it is not defined there, the default is to send notification on acknowledgement.
+* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected.
 * `main_threshold` - (Optional) Whether this notification channel is used for the main threshold of the alert. Default: `true`.
 * `warning_threshold` - (Optional) Whether this notification channel is used for the warning threshold of the alert. Default: `false`.
 

--- a/website/docs/r/monitor_alert_v2_downtime.md
+++ b/website/docs/r/monitor_alert_v2_downtime.md
@@ -64,7 +64,7 @@ It is a list of objects with the following fields:
 * `id` - (Required) The ID of the notification channel.
 * `renotify_every_minutes` - (Optional) the amount of minutes to wait before re sending the notification to this channel. `0` means no renotification enabled. Default: `0`.
 * `notify_on_resolve` - (Optional) Whether to send a notification when the alert is resolved. Default: `true`.
-* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected. If it is not defined there, the default is to send notification on acknowledgement.
+* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected.
 
 ### `custom_notification`
 

--- a/website/docs/r/monitor_alert_v2_event.md
+++ b/website/docs/r/monitor_alert_v2_event.md
@@ -74,7 +74,7 @@ It is a list of objects with the following fields:
 * `id` - (Required) The ID of the notification channel.
 * `renotify_every_minutes` - (Optional) the amount of minutes to wait before re sending the notification to this channel. `0` means no renotification enabled. Default: `0`.
 * `notify_on_resolve` - (Optional) Whether to send a notification when the alert is resolved. Default: `true`.
-* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected. If it is not defined there, the default is to send notification on acknowledgement.
+* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected.
 * `main_threshold` - (Optional) Whether this notification channel is used for the main threshold of the alert. Default: `true`.
 * `warning_threshold` - (Optional) Whether this notification channel is used for the warning threshold of the alert. Default: `false`.
 

--- a/website/docs/r/monitor_alert_v2_form_based_prometheus.md
+++ b/website/docs/r/monitor_alert_v2_form_based_prometheus.md
@@ -55,7 +55,7 @@ It is a list of objects with the following fields:
 * `id` - (Required) The ID of the notification channel.
 * `renotify_every_minutes` - (Optional) the amount of minutes to wait before re sending the notification to this channel. `0` means no renotification enabled.
 * `notify_on_resolve` - (Optional) Whether to send a notification when the alert is resolved. Default: `true`.
-* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected. If it is not defined there, the default is to send notification on acknowledgement.
+* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected.
 * `main_threshold` - (Optional) Whether this notification channel is used for the main threshold of the alert. Default: `true`.
 * `warning_threshold` - (Optional) Whether this notification channel is used for the warning threshold of the alert. Default: `false`.
 

--- a/website/docs/r/monitor_alert_v2_group_outlier.md
+++ b/website/docs/r/monitor_alert_v2_group_outlier.md
@@ -76,7 +76,7 @@ It is a list of objects with the following fields:
 * `id` - (Required) The ID of the notification channel.
 * `renotify_every_minutes` - (Optional) the amount of minutes to wait before re sending the notification to this channel. `0` means no renotification enabled. Default: `0`.
 * `notify_on_resolve` - (Optional) Whether to send a notification when the alert is resolved. Default: `true`.
-* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected. If it is not defined there, the default is to send notification on acknowledgement.
+* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected.
 * `main_threshold` - (Optional) Whether this notification channel is used for the main threshold of the alert. Default: `true`.
 * `warning_threshold` - (Optional) Whether this notification channel is used for the warning threshold of the alert. Default: `false`.
 

--- a/website/docs/r/monitor_alert_v2_metric.md
+++ b/website/docs/r/monitor_alert_v2_metric.md
@@ -91,7 +91,7 @@ It is a list of objects with the following fields:
 * `id` - (Required) The ID of the notification channel.
 * `renotify_every_minutes` - (Optional) the amount of minutes to wait before re sending the notification to this channel. `0` means no renotification enabled. Default: `0`.
 * `notify_on_resolve` - (Optional) Whether to send a notification when the alert is resolved. Default: `true`.
-* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected. If it is not defined there, the default is to send notification on acknowledgement.
+* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected.
 * `main_threshold` - (Optional) Whether this notification channel is used for the main threshold of the alert. Default: `true`.
 * `warning_threshold` - (Optional) Whether this notification channel is used for the warning threshold of the alert. Default: `false`.
 

--- a/website/docs/r/monitor_alert_v2_prometheus.md
+++ b/website/docs/r/monitor_alert_v2_prometheus.md
@@ -57,7 +57,7 @@ It is a list of objects with the following fields:
 * `id` - (Required) The ID of the notification channel.
 * `renotify_every_minutes` - (Optional) the amount of minutes to wait before re sending the notification to this channel. `0` means no renotification enabled.
 * `notify_on_resolve` - (Optional) Whether to send a notification when the alert is resolved. Default: `true`.
-* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected. If it is not defined there, the default is to send notification on acknowledgement.
+* `notify_on_acknowledge` - (Optional) Whether to send a notification when the alert is acknowledged. If not defined, this option is inherited from the `notify_when_resolved` option from the specific notification channel selected.
 
 ### `custom_notification`
 

--- a/website/docs/r/monitor_notification_channel_custom_webhook.md
+++ b/website/docs/r/monitor_notification_channel_custom_webhook.md
@@ -46,9 +46,9 @@ resource "sysdig_monitor_notification_channel_custom_webhook" "sample-custom-web
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_email.md
+++ b/website/docs/r/monitor_notification_channel_email.md
@@ -32,9 +32,9 @@ resource "sysdig_monitor_notification_channel_email" "sample_email" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_google_chat.md
+++ b/website/docs/r/monitor_notification_channel_google_chat.md
@@ -31,9 +31,9 @@ resource "sysdig_monitor_notification_channel_google_chat" "sample-gchat" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_ibm_event_notification.md
+++ b/website/docs/r/monitor_notification_channel_ibm_event_notification.md
@@ -42,9 +42,9 @@ resource "sysdig_monitor_notification_channel_ibm_event_notification" "sample" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_msteams.md
+++ b/website/docs/r/monitor_notification_channel_msteams.md
@@ -31,9 +31,9 @@ resource "sysdig_monitor_notification_channel_msteams" "sample-msteams" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_opsgenie.md
+++ b/website/docs/r/monitor_notification_channel_opsgenie.md
@@ -32,9 +32,9 @@ resource "sysdig_monitor_notification_channel_opsgenie" "sample-opsgenie" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_pagerduty.md
+++ b/website/docs/r/monitor_notification_channel_pagerduty.md
@@ -37,9 +37,9 @@ resource "sysdig_monitor_notification_channel_pagerduty" "sample-pagerduty" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_prometheus_alert_manager.md
+++ b/website/docs/r/monitor_notification_channel_prometheus_alert_manager.md
@@ -39,9 +39,9 @@ resource "sysdig_monitor_notification_channel_prometheus_alert_manager" "sample"
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_slack.md
+++ b/website/docs/r/monitor_notification_channel_slack.md
@@ -52,9 +52,9 @@ resource "sysdig_monitor_notification_channel_slack" "sample-slack" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_sns.md
+++ b/website/docs/r/monitor_notification_channel_sns.md
@@ -31,9 +31,9 @@ resource "sysdig_monitor_notification_channel_sns" "sample-amazon-sns" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_team_email.md
+++ b/website/docs/r/monitor_notification_channel_team_email.md
@@ -34,9 +34,9 @@ resource "sysdig_monitor_notification_channel_team_email" "sample-team-email" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_victorops.md
+++ b/website/docs/r/monitor_notification_channel_victorops.md
@@ -34,9 +34,9 @@ resource "sysdig_monitor_notification_channel_victorops" "sample-victorops" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/monitor_notification_channel_webhook.md
+++ b/website/docs/r/monitor_notification_channel_webhook.md
@@ -42,9 +42,9 @@ resource "sysdig_monitor_notification_channel_webhook" "sample-webhook" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_email.md
+++ b/website/docs/r/secure_notification_channel_email.md
@@ -32,9 +32,9 @@ resource "sysdig_secure_notification_channel_email" "sample_email" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_msteams.md
+++ b/website/docs/r/secure_notification_channel_msteams.md
@@ -31,9 +31,9 @@ resource "sysdig_secure_notification_channel_msteams" "sample-msteams" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_opsgenie.md
+++ b/website/docs/r/secure_notification_channel_opsgenie.md
@@ -32,9 +32,9 @@ resource "sysdig_secure_notification_channel_opsgenie" "sample-opsgenie" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_pagerduty.md
+++ b/website/docs/r/secure_notification_channel_pagerduty.md
@@ -37,9 +37,9 @@ resource "sysdig_secure_notification_channel_pagerduty" "sample-pagerduty" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_prometheus_alert_manager.md
+++ b/website/docs/r/secure_notification_channel_prometheus_alert_manager.md
@@ -39,9 +39,9 @@ resource "sysdig_secure_notification_channel_prometheus_alert_manager" "sample" 
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_slack.md
+++ b/website/docs/r/secure_notification_channel_slack.md
@@ -39,9 +39,9 @@ resource "sysdig_secure_notification_channel_slack" "sample-slack" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_sns.md
+++ b/website/docs/r/secure_notification_channel_sns.md
@@ -31,9 +31,9 @@ resource "sysdig_secure_notification_channel_sns" "sample-amazon-sns" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_team_email.md
+++ b/website/docs/r/secure_notification_channel_team_email.md
@@ -34,9 +34,9 @@ resource "sysdig_secure_notification_channel_team_email" "sample-team-email" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_victorops.md
+++ b/website/docs/r/secure_notification_channel_victorops.md
@@ -34,9 +34,9 @@ resource "sysdig_secure_notification_channel_victorops" "sample-victorops" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.

--- a/website/docs/r/secure_notification_channel_webhook.md
+++ b/website/docs/r/secure_notification_channel_webhook.md
@@ -38,9 +38,9 @@ resource "sysdig_secure_notification_channel_webhook" "sample-webhook" {
 
 * `enabled` - (Optional) If false, the channel will not emit notifications. Default is true.
 
-* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `true`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_ok` - (Optional, Deprecated) Send a new notification when the alert condition is no longer triggered. Default is `false`. This option is deprecated; use `notify_on_resolve` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
-* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `true`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
+* `notify_when_resolved` - (Optional, Deprecated) Send a new notification when the alert is manually acknowledged by a user. Default is `false`. This option is deprecated; use `notify_on_acknowledge` within the `notification_channels` options in the `sysdig_monitor_alert_v2_*` resources instead, which takes precedence over this setting. This option only applies to Monitor alerts when the channel is shared across all teams. It has no effect on Secure features.
 
 * `send_test_notification` - (Optional) Send an initial test notification to check
     if the notification channel is working. Default is false.


### PR DESCRIPTION
* add new attribute `notify_on_acknwoledge` on all alert resources, it should be used if one want to send a notification for an alert that has been manually acknowledged by a user;
* deprecate `notify_when_ok` and `notify_when_resolved` on notification channel resources: users should define these behaviors at alert level now.

technical note: to allow for boolean attributes with no default, we use the string type, enforcing "true" and "false" values, instead of boolean values, because with the current terraform sdk there is no way to distinguish "false" from no value defined.