### PR TITLE
ci(test): do not run Secure cloud tests in Monitor suite

### DIFF
--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_sysdig_common
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For a cleaner PR make sure you follow these recommendations:
- Add the **scope** of the affected area in the PR name, following [Conventional Commit](https://www.conventionalcommits.
org/en/v1.0.0/) format
ex.: feat(secure-policy): Add runbook to policy resources
- If not there yet, add yourself and/or your team as the **Codeowners** of the affected area
- Make sure to modify the respective **tests**
- Make sure to modify the respective **documentation**
-->

These tests are running as part of the Monitor backend deployments to integration environments, and they should not. They are failing and causing noise, so lets remove them from this suite.