### PR TITLE
fix(cloud-auth-account): use TypeSet for components to fix idempotency

### DIFF
--- a/sysdig/resource_sysdig_secure_cloud_auth_account.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account.go
@@ -101,7 +101,7 @@ func resourceSysdigSecureCloudauthAccount() *schema.Resource {
 				Required: true,
 			},
 			SchemaComponents: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -335,7 +335,7 @@ func setAccountFeature(accountFeatures *cloudauth.AccountFeatures, fieldName str
 		case SchemaEnabled:
 			target.Elem().FieldByName("Enabled").SetBool(value.(bool))
 		case SchemaComponents:
-			for _, componentID := range value.([]any) {
+			for _, componentID := range value.(*schema.Set).List() {
 				target.Elem().FieldByName("Components").Set(reflect.Append(target.Elem().FieldByName("Components"), reflect.ValueOf(componentID.(string))))
 			}
 		}

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_feature.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_feature.go
@@ -51,7 +51,7 @@ func getAccountFeatureSchema() map[string]*schema.Schema {
 			Required: true,
 		},
 		SchemaComponents: {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
@@ -184,7 +184,7 @@ func validateCloudauthAccountFeatureUpdate(existingFeature *v2.CloudauthAccountF
 
 func getFeatureComponentsList(data *schema.ResourceData) []string {
 	componentsList := []string{}
-	componentsResourceList := data.Get(SchemaComponents).([]any)
+	componentsResourceList := data.Get(SchemaComponents).(*schema.Set).List()
 	for _, componentID := range componentsResourceList {
 		componentsList = append(componentsList, componentID.(string))
 	}


### PR DESCRIPTION
## Summary

- Change `components` field from `TypeList` to `TypeSet` in cloud auth account feature schema
- Update code that reads components to handle `*schema.Set` instead of `[]any`

## Problem

The `components` field in `sysdig_secure_cloud_auth_account` features was defined as `TypeList`. However, the API returns components in arbitrary order. This caused Terraform to detect spurious changes on every plan:

```
# sysdig_secure_cloud_auth_account.example will be updated in-place
~ resource "sysdig_secure_cloud_auth_account" "example" {
    - feature {
        - secure_threat_detection {
            - components = [
                - "COMPONENT_WEBHOOK_DATASOURCE/secure-runtime",
                - "COMPONENT_SERVICE_PRINCIPAL/secure-runtime",
              ] -> null
          }
      }
    + feature {
        + secure_threat_detection {
            + components = [
                + "COMPONENT_SERVICE_PRINCIPAL/secure-runtime",
                + "COMPONENT_WEBHOOK_DATASOURCE/secure-runtime",
              ]
          }
      }
  }
```

## Solution

Change the schema type from `TypeList` to `TypeSet`. Sets compare elements regardless of order, which matches the API's behavior.

## Files Changed

- `sysdig/resource_sysdig_secure_cloud_auth_account.go`
- `sysdig/resource_sysdig_secure_cloud_auth_account_feature.go`