### PR TITLE
chore: add nix flake for reproducible dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,7 @@
-export TF_ACC=true
-export TF_LOG=DEBUG
+has nix && use flake
 dotenv_if_exists .env # You can create a .env file with your env vars for this project. You can also use .secrets if you are using act. See the line below.
 dotenv_if_exists .secrets # Used by [act](https://nektosact.com/) to load secrets into the pipelines
 strict_env
 env_vars_required SYSDIG_SECURE_API_TOKEN SYSDIG_MONITOR_API_TOKEN
+export TF_ACC=true
+export TF_LOG=DEBUG

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,4 @@ repos:
         pass_filenames: false
         entry: make test
         language: system
-    -   id: testacc
-        name: testacc
-        pass_filenames: false
-        entry: make testacc
-        language: system
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770169770,
+        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+      in
+      {
+        devShells.default =
+          with pkgs;
+          mkShell {
+            packages = [
+              go
+              terraform
+              goreleaser
+              gnupg
+              golangci-lint
+              gofumpt
+              jq
+              gnumake
+              pre-commit
+            ];
+
+            shellHook = ''
+              pre-commit install
+            '';
+          };
+
+        formatter = pkgs.nixfmt-tree;
+      }
+    );
+}

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_test.go
@@ -574,7 +574,6 @@ func TestAccAWSSecureCloudAuthAccountResponseActions(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func TestAccAWSSecureCloudAccountThreatDetection(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add Nix flake configuration for reproducible development environment
- Include all required tools: go, terraform, goreleaser, golangci-lint, gofumpt, pre-commit, etc.
- Update `.envrc` to automatically use the flake when nix is available
- Remove `testacc` from pre-commit hooks (too slow for local commits)

## Test plan
- [ ] Run `nix develop` and verify all tools are available
- [ ] Run `direnv allow` and verify environment loads correctly
- [ ] Run `git commit` and verify pre-commit hooks pass