### PR TITLE
fix(security): update Go from 1.24.4 to 1.25.7 to address multiple CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/draios/terraform-provider-sysdig
 
-go 1.24.4
+go 1.25.7
 
 require (
 	github.com/Jeffail/gabs/v2 v2.7.0


### PR DESCRIPTION
## Summary

Update Go version from 1.24.4 to 1.25.7 to fix **17+ security vulnerabilities** in the standard library, including **3 critical RCE/code injection** vulnerabilities.

## Vulnerabilities Fixed

### Go 1.24.5 (July 2025)
| CVE | Component | Severity | Description |
|-----|-----------|----------|-------------|
| CVE-2025-4674 | `cmd/go` | High | Unexpected command execution in untrusted VCS repositories |

### Go 1.24.6 (August 2025)
| CVE | Component | Severity | Description |
|-----|-----------|----------|-------------|
| CVE-2025-47906 | `os/exec` | Medium | `LookPath` returns unexpected paths when PATH contains executables |
| CVE-2025-47907 | `database/sql` | Medium | Race condition in `Rows.Scan()` can overwrite parallel query results |

### Go 1.24.8 / 1.25.2 (October 2025)
| CVE | Component | Severity | Description |
|-----|-----------|----------|-------------|
| CVE-2025-58186 | `net/http` | High | Memory exhaustion: no limit on number of cookies parsed |
| CVE-2025-58187 | `crypto/x509` | High | DoS: name constraint checking scales non-linearly with cert size |
| CVE-2025-61724 | `net/textproto` | Medium | CPU exhaustion in `Reader.ReadResponse` with many short lines |

### Go 1.24.11 / 1.25.5 (December 2025)
| CVE | Component | Severity | Description |
|-----|-----------|----------|-------------|
| CVE-2025-61727 | `crypto/x509` | High | Excluded subdomain constraints don't restrict wildcard SANs |
| CVE-2025-61729 | `crypto/x509` | Medium | DoS: `HostnameError.Error()` O(n²) string concatenation |

### Go 1.24.12 / 1.25.6 (January 2026)
| CVE | Component | Severity | Description |
|-----|-----------|----------|-------------|
| CVE-2025-61726 | `net/url` | High | Memory exhaustion: no limit on query parameters |
| CVE-2025-61728 | `archive/zip` | Medium | DoS: super-linear filename indexing with malicious ZIPs |
| CVE-2025-61730 | `crypto/tls` | Medium | TLS 1.3 messages processed at incorrect encryption level |
| CVE-2025-61731 | `cmd/go` | **Critical** | Arbitrary file write via `#cgo pkg-config:` directive |
| CVE-2025-68119 | `cmd/go` | **Critical** | RCE via malicious version strings in Mercurial/Git |
| CVE-2025-68121 | `crypto/tls` | High | Session hijacking: ticket keys copied in `Config.Clone()` |

### Go 1.24.13 / 1.25.7 (February 2026)
| CVE | Component | Severity | Description |
|-----|-----------|----------|-------------|
| CVE-2025-61732 | `cmd/cgo` | **Critical** | Code smuggling via Go/C++ comment parsing discrepancy |

## Verification

```
$ govulncheck ./...
=== Symbol Results ===
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```

## Test plan

- [x] `govulncheck ./...` reports 0 vulnerabilities
- [ ] CI build passes
- [ ] Unit tests pass
- [ ] Acceptance tests pass