### PR TITLE
fix(ci): add setup-terraform to prevent flaky test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Run tests from ${{ matrix.file }}
         run: |
           tests=$(grep -oh "func Test[A-Za-z0-9_]*" sysdig/${{ matrix.file }}.go | sed 's/func //' | tr '\n' '|' | sed 's/|$//')
@@ -127,6 +130,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Run tests from ${{ matrix.file }}
         run: |
           tests=$(grep -oh "func Test[A-Za-z0-9_]*" sysdig/${{ matrix.file }}.go | sed 's/func //' | tr '\n' '|' | sed 's/|$//')
@@ -170,6 +176,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Test
         run: make testacc
         env:
@@ -194,6 +204,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Test
         run: make testacc
         env:


### PR DESCRIPTION
## Summary
- Add `hashicorp/setup-terraform@v3` step to all 4 acceptance test jobs (`test-sysdig-secure`, `test-sysdig-monitor`, `test-ibm-monitor`, `test-ibm-secure`)
- Uses `terraform_wrapper: false` to avoid interference with programmatic CLI usage from Go tests
- Fixes flaky CI failures caused by `terraform-plugin-testing` trying to dynamically download Terraform CLI from `checkpoint-api.hashicorp.com`, which returns timeouts and 502 errors

## Context
All 3 test failures in [this CI run](https://github.com/sysdiglabs/terraform-provider-sysdig/actions/runs/21869038206) share the same root cause:
```
failed to find or install Terraform CLI: Get "https://checkpoint-api.hashicorp.com/v1/check/terraform?...": context deadline exceeded
```

## Test plan
- [ ] CI acceptance tests pass without checkpoint-api.hashicorp.com availability issues