### PR TITLE
feat(monitor-alert): support dashboardTemplate link type in alert v2 resources

### DIFF
--- a/sysdig/internal/client/v2/alerts_v2.go
+++ b/sysdig/internal/client/v2/alerts_v2.go
@@ -43,8 +43,9 @@ const (
 )
 
 const (
-	AlertLinkV2TypeDashboard AlertLinkV2Type = "dashboard"
-	AlertLinkV2TypeRunbook   AlertLinkV2Type = "runbook"
+	AlertLinkV2TypeDashboard         AlertLinkV2Type = "dashboard"
+	AlertLinkV2TypeDashboardTemplate AlertLinkV2Type = "dashboardTemplate"
+	AlertLinkV2TypeRunbook           AlertLinkV2Type = "runbook"
 )
 
 var labelCache struct {

--- a/sysdig/resource_sysdig_monitor_alert_v2_common.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_common.go
@@ -216,6 +216,7 @@ func AlertV2SeverityValues() []string {
 func AlertLinkV2TypeValues() []string {
 	return []string{
 		string(v2.AlertLinkV2TypeDashboard),
+		string(v2.AlertLinkV2TypeDashboardTemplate),
 		string(v2.AlertLinkV2TypeRunbook),
 	}
 }

--- a/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
+++ b/sysdig/resource_sysdig_monitor_alert_v2_metric_test.go
@@ -469,6 +469,10 @@ resource "sysdig_monitor_alert_v2_metric" "sample" {
 		type = "dashboard"
 		id = sysdig_monitor_dashboard.dashboard.id
 	}
+	link {
+		type = "dashboardTemplate"
+		id   = "view.promcat.mysql"
+	}
 }
 `, name, name, name)
 }

--- a/website/docs/r/monitor_alert_v2_change.md
+++ b/website/docs/r/monitor_alert_v2_change.md
@@ -97,9 +97,9 @@ By defining this field, the user can modify the title and the body of the messag
 
 By defining this field, the user can add link to notifications.
 
-* `type` - (Required) Type of link. Must be `runbook`, for generic links, or `dashboard`, for internal links to existing dashboards.
+* `type` - (Required) Type of link. Must be `runbook` for generic links, `dashboard` for internal links to existing dashboards, or `dashboardTemplate` for links to dashboard templates.
 * `href` - (Optional) When using `runbook` type, url of the external resource.
-* `id` - (Optional) When using `dashboard` type, dashboard id.
+* `id` - (Optional) When using `dashboard` type, dashboard id. When using `dashboardTemplate` type, the dashboard template id (e.g. `view.promcat.mysql`).
 
 ### Percentage of Change alert arguments
 

--- a/website/docs/r/monitor_alert_v2_downtime.md
+++ b/website/docs/r/monitor_alert_v2_downtime.md
@@ -83,9 +83,9 @@ By defining this field, the user can modify the title and the body of the messag
 
 By defining this field, the user can add link to notifications.
 
-* `type` - (Required) Type of link. Must be `runbook`, for generic links, or `dashboard`, for internal links to existing dashboards.
+* `type` - (Required) Type of link. Must be `runbook` for generic links, `dashboard` for internal links to existing dashboards, or `dashboardTemplate` for links to dashboard templates.
 * `href` - (Optional) When using `runbook` type, url of the external resource.
-* `id` - (Optional) When using `dashboard` type, dashboard id.
+* `id` - (Optional) When using `dashboard` type, dashboard id. When using `dashboardTemplate` type, the dashboard template id (e.g. `view.promcat.mysql`).
 
 ### `capture`
 

--- a/website/docs/r/monitor_alert_v2_event.md
+++ b/website/docs/r/monitor_alert_v2_event.md
@@ -95,9 +95,9 @@ By defining this field, the user can modify the title and the body of the messag
 
 By defining this field, the user can add link to notifications.
 
-* `type` - (Required) Type of link. Must be `runbook`, for generic links, or `dashboard`, for internal links to existing dashboards.
+* `type` - (Required) Type of link. Must be `runbook` for generic links, `dashboard` for internal links to existing dashboards, or `dashboardTemplate` for links to dashboard templates.
 * `href` - (Optional) When using `runbook` type, url of the external resource.
-* `id` - (Optional) When using `dashboard` type, dashboard id.
+* `id` - (Optional) When using `dashboard` type, dashboard id. When using `dashboardTemplate` type, the dashboard template id (e.g. `view.promcat.mysql`).
 
 ### `capture`
 

--- a/website/docs/r/monitor_alert_v2_form_based_prometheus.md
+++ b/website/docs/r/monitor_alert_v2_form_based_prometheus.md
@@ -76,9 +76,9 @@ By defining this field, the user can modify the title and the body of the messag
 
 By defining this field, the user can add link to notifications.
 
-* `type` - (Required) Type of link. Must be `runbook`, for generic links, or `dashboard`, for internal links to existing dashboards.
+* `type` - (Required) Type of link. Must be `runbook` for generic links, `dashboard` for internal links to existing dashboards, or `dashboardTemplate` for links to dashboard templates.
 * `href` - (Optional) When using `runbook` type, url of the external resource.
-* `id` - (Optional) When using `dashboard` type, dashboard id.
+* `id` - (Optional) When using `dashboard` type, dashboard id. When using `dashboardTemplate` type, the dashboard template id (e.g. `view.promcat.mysql`).
 
 ### Threshold Prometheus alert arguments
 

--- a/website/docs/r/monitor_alert_v2_group_outlier.md
+++ b/website/docs/r/monitor_alert_v2_group_outlier.md
@@ -97,9 +97,9 @@ By defining this field, the user can modify the title and the body of the messag
 
 By defining this field, the user can add link to notifications.
 
-* `type` - (Required) Type of link. Must be `runbook`, for generic links, or `dashboard`, for internal links to existing dashboards.
+* `type` - (Required) Type of link. Must be `runbook` for generic links, `dashboard` for internal links to existing dashboards, or `dashboardTemplate` for links to dashboard templates.
 * `href` - (Optional) When using `runbook` type, url of the external resource.
-* `id` - (Optional) When using `dashboard` type, dashboard id.
+* `id` - (Optional) When using `dashboard` type, dashboard id. When using `dashboardTemplate` type, the dashboard template id (e.g. `view.promcat.mysql`).
 
 ### `capture`
 

--- a/website/docs/r/monitor_alert_v2_metric.md
+++ b/website/docs/r/monitor_alert_v2_metric.md
@@ -112,9 +112,9 @@ By defining this field, the user can modify the title and the body of the messag
 
 By defining this field, the user can add link to notifications.
 
-* `type` - (Required) Type of link. Must be `runbook`, for generic links, or `dashboard`, for internal links to existing dashboards.
+* `type` - (Required) Type of link. Must be `runbook` for generic links, `dashboard` for internal links to existing dashboards, or `dashboardTemplate` for links to dashboard templates.
 * `href` - (Optional) When using `runbook` type, url of the external resource.
-* `id` - (Optional) When using `dashboard` type, dashboard id.
+* `id` - (Optional) When using `dashboard` type, dashboard id. When using `dashboardTemplate` type, the dashboard template id (e.g. `view.promcat.mysql`).
 
 ### `capture`
 

--- a/website/docs/r/monitor_alert_v2_prometheus.md
+++ b/website/docs/r/monitor_alert_v2_prometheus.md
@@ -76,9 +76,9 @@ By defining this field, the user can modify the title and the body of the messag
 
 By defining this field, the user can add link to notifications.
 
-* `type` - (Required) Type of link. Must be `runbook`, for generic links, or `dashboard`, for internal links to existing dashboards.
+* `type` - (Required) Type of link. Must be `runbook` for generic links, `dashboard` for internal links to existing dashboards, or `dashboardTemplate` for links to dashboard templates.
 * `href` - (Optional) When using `runbook` type, url of the external resource.
-* `id` - (Optional) When using `dashboard` type, dashboard id.
+* `id` - (Optional) When using `dashboard` type, dashboard id. When using `dashboardTemplate` type, the dashboard template id (e.g. `view.promcat.mysql`).
 
 ### Prometheus alert arguments
 


### PR DESCRIPTION
The Sysdig Monitor API returns `type = "dashboardTemplate"` for alert links referencing dashboard templates, but the provider only validates `dashboard` and `runbook` as accepted values. This causes permanent drift on every `terraform plan` for any alert with dashboard template links, forcing users to add `lifecycle { ignore_changes }` workarounds.

This PR adds `dashboardTemplate` as an accepted link type alongside the existing `dashboard` and `runbook` types, eliminating the state drift.

Closes #700