### PR TITLE
fix(ci): use owned resource in posture zone test to prevent flakiness

### DIFF
--- a/sysdig/resource_sysdig_secure_posture_zone_test.go
+++ b/sysdig/resource_sysdig_secure_posture_zone_test.go
@@ -66,10 +66,15 @@ resource "sysdig_secure_posture_zone" "z1" {
 
 func securePostureZoneWithPolicies(name string) string {
 	return fmt.Sprintf(`
-data "sysdig_secure_posture_policies" "all" {}
+resource "sysdig_secure_posture_policy" "test" {
+  name        = "%s-policy"
+  description = "test policy for posture zone"
+  is_active   = true
+  type        = "Unknown"
+}
 
 resource "sysdig_secure_posture_zone" "z1" {
-  name = "%s"
-  policy_ids = [data.sysdig_secure_posture_policies.all.policies[0].id]
-}`, name)
+  name       = "%s"
+  policy_ids = [sysdig_secure_posture_policy.test.id]
+}`, name, name)
 }


### PR DESCRIPTION
`TestAccSecurePostureZone` fails intermittently in CI (IBM Secure Acceptance Tests) at Step 3/4 with "plan was not empty" on `policy_ids`.

The test used `data.sysdig_secure_posture_policies.all.policies[0].id` to get a policy ID, but the data source returns policies in non-deterministic order from the API. Between apply and refresh, the data source is re-read and `policies[0]` can resolve to a different policy, causing drift.

This replaces the data source lookup with a test-owned `sysdig_secure_posture_policy` resource so the ID is stable across reads.