### PR TITLE
fix(ci): use unique names in macro append test to prevent flakiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,6 +333,14 @@ func TestAccResourceXxx(t *testing.T) {
 - `randomText(len)` - Generate random strings for unique names
 - `sysdigOrIBMMonitorPreCheck(t)` - Check for either credential type
 
+### Avoiding Name Collisions
+
+Multiple CI runs share the same Sysdig environment, so hardcoded resource names cause race conditions. Follow these rules:
+
+- **Never hardcode resource names** in test configs — always use unique random names via `rText()` (`acctest.RandStringFromCharSet`) or `randomText()`
+- **Prefix with `terraform_test_`** for easy identification and cleanup
+- **Never reference built-in Sysdig resources by name** (e.g., the `"container"` macro) — instead, create your own base resource with a unique name and reference that
+
 ## Development Workflow (TDD)
 
 Follow the **Red-Green-Refactor** cycle:

--- a/sysdig/resource_sysdig_secure_macro_test.go
+++ b/sysdig/resource_sysdig_secure_macro_test.go
@@ -40,7 +40,7 @@ func TestAccMacro(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: macroAppendToDefault(),
+				Config: macroAppendToDefault(rText()),
 			},
 			{
 				Config: macroWithMacro(rText(), rText()),
@@ -73,14 +73,20 @@ resource "sysdig_secure_macro" "sample" {
 `, name)
 }
 
-func macroAppendToDefault() string {
-	return `
-resource "sysdig_secure_macro" "sample2" {
-  name = "container"
-  condition = "and always_true"
-  append = true
+func macroAppendToDefault(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_macro" "sample" {
+  name      = "terraform_test_%s"
+  condition = "always_true"
 }
-`
+
+resource "sysdig_secure_macro" "sample2" {
+  name       = "terraform_test_%s"
+  condition  = "and always_true"
+  append     = true
+  depends_on = [sysdig_secure_macro.sample]
+}
+`, name, name)
 }
 
 func macroWithMacro(name1, name2 string) string {


### PR DESCRIPTION
The `TestAccMacro` test Step 5 (`macroAppendToDefault`) hardcodes the macro name `"container"` — a built-in Sysdig macro. When multiple CI runs execute concurrently against the same Sysdig environment, they collide with the error: *"The field 'name' must not be the same as another Secure UI macro"*.

This is the same class of bug fixed in #697 for managed rulesets and custom policies.

The fix replaces the hardcoded built-in macro reference with a self-contained test that creates its own base macro with a unique `terraform_test_` prefixed name, then appends to it. Also documents the "avoid name collisions" pattern in AGENTS.md.