### PR TITLE
fix(monitor-secure-alerts): replace urls in prometheus alert-manager tests

### DIFF
--- a/sysdig/data_source_sysdig_monitor_notification_channel_prometheus_alert_manager_test.go
+++ b/sysdig/data_source_sysdig_monitor_notification_channel_prometheus_alert_manager_test.go
@@ -40,7 +40,7 @@ func monitorNotificationChannelPrometheusAlertManager(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_monitor_notification_channel_prometheus_alert_manager" "nc_prometheus_alert_manager" {
 	name = "%s"
-	url = "https://testurl.com/xxx"
+	url = "https://example.com/test"
 	allow_insecure_connections = true
 }
 

--- a/sysdig/data_source_sysdig_secure_notification_channel_prometheus_alert_manager_test.go
+++ b/sysdig/data_source_sysdig_secure_notification_channel_prometheus_alert_manager_test.go
@@ -40,7 +40,7 @@ func secureNotificationChannelPrometheusAlertManager(name string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_notification_channel_prometheus_alert_manager" "nc_prometheus_alert_manager" {
 	name = "%s"
-	url = "https://testurl.com/xxx"
+	url = "https://example.com/test"
 	allow_insecure_connections = true
 }
 

--- a/sysdig/resource_sysdig_monitor_notification_channel_prometheus_alert_manager_test.go
+++ b/sysdig/resource_sysdig_monitor_notification_channel_prometheus_alert_manager_test.go
@@ -69,7 +69,7 @@ func monitorNotificationChannelPrometheusAlertManagerWithName(name string) strin
 resource "sysdig_monitor_notification_channel_prometheus_alert_manager" "sample-channel1" {
 	name = "Example Channel %s - prometheus alert manager"
 	enabled = true
-	url = "https://testurl.com/xxx"
+	url = "https://example.com/test"
 	notify_when_ok = false
 	notify_when_resolved = false
 	send_test_notification = false
@@ -81,7 +81,7 @@ func monitorNotificationChannelPrometheusAlertManagerWithNameWithAdditionalheade
 	resource "sysdig_monitor_notification_channel_prometheus_alert_manager" "sample-channel2" {
 		name = "Example Channel %s - prometheus alert manager With Additional Headers"
 		enabled = true
-		url = "https://testurl.com/xxx"
+		url = "https://example.com/test"
 		notify_when_ok = false
 		notify_when_resolved = false
 		send_test_notification = false
@@ -96,7 +96,7 @@ func monitorNotificationChannelPrometheusAlertManagerWithNameWithAllowInsecureCo
 	resource "sysdig_monitor_notification_channel_prometheus_alert_manager" "sample-channel3" {
 		name = "Example Channel %s - prometheus alert manager with insecure connections"
 		enabled = true
-		url = "https://testurl.com/xxx"
+		url = "https://example.com/test"
 		notify_when_ok = false
 		notify_when_resolved = false
 		send_test_notification = false
@@ -109,7 +109,7 @@ func monitorNotificationChannelPrometheusAlertManagerSharedWithCurrentTeam(name 
 	resource "sysdig_monitor_notification_channel_prometheus_alert_manager" "sample-channel4" {
 		name = "Example Channel %s - prometheus alert manager with share with current team"
 		enabled = true
-		url = "https://testurl.com/xxx"
+		url = "https://example.com/test"
 		notify_when_ok = false
 		notify_when_resolved = false
 		send_test_notification = false

--- a/sysdig/resource_sysdig_secure_notification_channel_prometheus_alert_manager_test.go
+++ b/sysdig/resource_sysdig_secure_notification_channel_prometheus_alert_manager_test.go
@@ -69,7 +69,7 @@ func secureNotificationChannelPrometheusAlertManagerWithName(name string) string
 resource "sysdig_secure_notification_channel_prometheus_alert_manager" "sample-channel1" {
 	name = "Example Channel %s - prometheus alert manager"
 	enabled = true
-	url = "https://testurl.com/xxx"
+	url = "https://example.com/test"
 	notify_when_ok = false
 	notify_when_resolved = false
 	send_test_notification = false
@@ -81,7 +81,7 @@ func secureNotificationChannelPrometheusAlertManagerWithNameWithAdditionalheader
 	resource "sysdig_secure_notification_channel_prometheus_alert_manager" "sample-channel2" {
 		name = "Example Channel %s - prometheus alert manager With Additional Headers"
 		enabled = true
-		url = "https://testurl.com/xxx"
+		url = "https://example.com/test"
 		notify_when_ok = false
 		notify_when_resolved = false
 		send_test_notification = false
@@ -96,7 +96,7 @@ func secureNotificationChannelPrometheusAlertManagerWithNameWithAllowInsecureCon
 	resource "sysdig_secure_notification_channel_prometheus_alert_manager" "sample-channel3" {
 		name = "Example Channel %s - prometheus alert manager with insecure connections"
 		enabled = true
-		url = "https://testurl.com/xxx"
+		url = "https://example.com/test"
 		notify_when_ok = false
 		notify_when_resolved = false
 		send_test_notification = false
@@ -109,7 +109,7 @@ func secureNotificationChannelPrometheusAlertManagerSharedWithCurrentTeam(name s
 	resource "sysdig_secure_notification_channel_prometheus_alert_manager" "sample-channel4" {
 		name = "Example Channel %s - prometheus alert manager with share with current team"
 		enabled = true
-		url = "https://testurl.com/xxx"
+		url = "https://example.com/test"
 		notify_when_ok = false
 		notify_when_resolved = false
 		send_test_notification = false


### PR DESCRIPTION
Updates Prometheus Alertmanager notification channel acceptance tests to use a stable, DNS-resolving placeholder domain so channel creation no longer fails due to URL validation.

Changes:

- Replaced `https://testurl.com/xxx` with `https://example.com/test` in **Secure** resource acceptance tests.
- Replaced `https://testurl.com/xxx` with `https://example.com/test` in **Monitor** resource acceptance tests.
Updated both **Secure** and **Monitor** data source acceptance tests to use the same stable URL.