### PR TITLE
Quickfix - Remove policies build tag from CSPM tests

### DIFF
--- a/sysdig/resource_sysdig_secure_posture_control_test.go
+++ b/sysdig/resource_sysdig_secure_posture_control_test.go
@@ -1,4 +1,4 @@
-//go:build tf_acc_sysdig_secure || tf_acc_policies
+//go:build tf_acc_sysdig_secure
 
 package sysdig_test
 


### PR DESCRIPTION
CSPM test tagged with policies build tag - removed