### PR TITLE
feat(secure): surface Falco static-analyzer warnings as Terraform Diagnostics

### DIFF
--- a/sysdig/falco_warnings.go
+++ b/sysdig/falco_warnings.go
@@ -1,0 +1,144 @@
+package sysdig
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+// falcoSnapshotOnce ensures the account-wide snapshot diagnostic (see
+// snapshotDiagnostic) is emitted at most once per `terraform apply`
+// invocation. Terraform launches a fresh provider process per command
+// invocation, so process-lifetime state here is exactly apply-scoped — no
+// cross-run leakage, no extra backend calls, no explicit reset needed.
+var falcoSnapshotOnce sync.Once
+
+// falcoWarningsToDiagnostics converts Falco static-analyzer warnings returned by
+// the Sysdig backend on rule create/update into Terraform Diagnostics.
+//
+// Today the backend emits LOAD_NO_EVTTYPE (Falco's static analyzer warning
+// that a rule's condition matches too many event types); the helper is
+// code-agnostic and surfaces whatever the backend returns. Each diagnostic is
+// a diag.Warning so `terraform apply` shows them inline without failing the
+// apply.
+//
+// The backend returns the FULL current warning list for the customer's rules
+// on every create/update call, not just warnings caused by this specific
+// save. Two-tier output keeps that from becoming a wall of text that
+// reprints every pre-existing warning on every future apply:
+//
+//   - Headline: warnings attributed to THIS resource's own rule (ruleName) —
+//     one diag.Warning each, always shown. Actionable: this rule needs fixing.
+//   - Snapshot: every OTHER warning elsewhere on the account is bundled into
+//     a single diag.Warning, emitted at most once per apply via
+//     falcoSnapshotOnce. Informational: shows blast radius
+//     (EnabledInPolicies) without implying this save caused it.
+//
+// Wired on sysdig_secure_rule_falco only.
+//
+// Intentionally NOT wired:
+//   - sysdig_secure_rule_container / _filesystem / _network / _process /
+//     _syscall — deprecated and non-functional against current backends
+//     (Create/Update return HTTP 400 before any validation runs; see their
+//     DeprecationMessage). Wiring them would be dead code.
+//   - sysdig_secure_rule_stateful — stateful-detection rules don't go through the
+//     Falco static-analyzer path and the backend doesn't emit warnings for them.
+//   - sysdig_secure_macro / sysdig_secure_list — the backend doesn't surface
+//     warnings on those endpoints today. A macro/list's own noise still
+//     surfaces via the snapshot on whichever rule save happens to trigger
+//     validation next, attributed to the RULE that references it (warnings
+//     are always rule-scoped — LOAD_NO_EVTTYPE never attaches to a macro/list
+//     itself).
+func falcoWarningsToDiagnostics(warnings []v2.FalcoWarning, ruleName string) diag.Diagnostics {
+	if len(warnings) == 0 {
+		return nil
+	}
+
+	var own, other []v2.FalcoWarning
+	for _, w := range warnings {
+		if w.Rule == ruleName {
+			own = append(own, w)
+		} else {
+			other = append(other, w)
+		}
+	}
+
+	diags := make(diag.Diagnostics, 0, len(own)+1)
+	for _, w := range own {
+		diags = append(diags, headlineDiagnostic(w))
+	}
+
+	if len(other) > 0 {
+		falcoSnapshotOnce.Do(func() {
+			diags = append(diags, snapshotDiagnostic(other))
+		})
+	}
+
+	return diags
+}
+
+// headlineDiagnostic renders a single warning attributed to the rule being
+// saved in this resource operation.
+func headlineDiagnostic(w v2.FalcoWarning) diag.Diagnostic {
+	detail := w.Message
+	if len(w.EnabledInPolicies) > 0 {
+		detail = fmt.Sprintf("%s\n\nEnabled in policies: %s", detail, strings.Join(sortedCopy(w.EnabledInPolicies), ", "))
+	}
+	if len(w.AgentVersions) > 0 {
+		detail = fmt.Sprintf("%s\nAgent versions: %s", detail, strings.Join(sortedCopy(w.AgentVersions), ", "))
+	}
+	return diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  fmt.Sprintf("Falco static-analyzer warning (%s) on rule %q", w.Code, w.Rule),
+		Detail:   detail,
+	}
+}
+
+// snapshotDiagnostic bundles every warning NOT attributed to the
+// currently-saved rule into a single diagnostic. Sorted by blast radius
+// (EnabledInPolicies count) descending, then by rule name for determinism —
+// customers see their biggest-impact noisy rule first.
+func snapshotDiagnostic(warnings []v2.FalcoWarning) diag.Diagnostic {
+	sorted := make([]v2.FalcoWarning, len(warnings))
+	copy(sorted, warnings)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if len(sorted[i].EnabledInPolicies) != len(sorted[j].EnabledInPolicies) {
+			return len(sorted[i].EnabledInPolicies) > len(sorted[j].EnabledInPolicies)
+		}
+		return sorted[i].Rule < sorted[j].Rule
+	})
+
+	lines := make([]string, 0, len(sorted))
+	for _, w := range sorted {
+		line := fmt.Sprintf("- %s (%s)", w.Rule, w.Code)
+		if len(w.EnabledInPolicies) > 0 {
+			line = fmt.Sprintf("%s — enabled in policies: %s", line, strings.Join(sortedCopy(w.EnabledInPolicies), ", "))
+		}
+		lines = append(lines, line)
+	}
+
+	noun, verb := "other Falco rules", "emit"
+	if len(sorted) == 1 {
+		noun, verb = "other Falco rule", "emits"
+	}
+	return diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  fmt.Sprintf("%d %s currently %s static-analyzer warnings", len(sorted), noun, verb),
+		Detail:   strings.Join(lines, "\n"),
+	}
+}
+
+// sortedCopy returns a sorted copy of s so diagnostic text built from
+// backend-ordered slices (EnabledInPolicies, AgentVersions) stays stable
+// across applies regardless of the order the backend returns them in.
+func sortedCopy(s []string) []string {
+	out := make([]string, len(s))
+	copy(out, s)
+	sort.Strings(out)
+	return out
+}

--- a/sysdig/falco_warnings_test.go
+++ b/sysdig/falco_warnings_test.go
@@ -1,0 +1,124 @@
+package sysdig
+
+import (
+	"sync"
+	"testing"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFalcoWarningsToDiagnostics_HeadlineOnly(t *testing.T) {
+	resetFalcoSnapshotOnce(t)
+
+	warnings := []v2.FalcoWarning{
+		{Code: "LOAD_NO_EVTTYPE", Rule: "my-rule", Message: "too broad"},
+	}
+
+	diags := falcoWarningsToDiagnostics(warnings, "my-rule")
+
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Summary, `on rule "my-rule"`)
+}
+
+func TestHeadlineDiagnostic_SortsEnabledInPoliciesAndAgentVersions(t *testing.T) {
+	w := v2.FalcoWarning{
+		Code:              "LOAD_NO_EVTTYPE",
+		Rule:              "my-rule",
+		Message:           "too broad",
+		EnabledInPolicies: []string{"Zebra Policy", "Alpha Policy"},
+		AgentVersions:     []string{"linux-14.7.0", "linux-13.8.0"},
+	}
+
+	d := headlineDiagnostic(w)
+
+	// Backend order is Zebra, Alpha / 14.7.0, 13.8.0 — Detail must render them
+	// sorted so the diagnostic text is stable across applies regardless of
+	// the order the backend happens to return.
+	assert.Contains(t, d.Detail, "Enabled in policies: Alpha Policy, Zebra Policy")
+	assert.Contains(t, d.Detail, "Agent versions: linux-13.8.0, linux-14.7.0")
+}
+
+func TestFalcoWarningsToDiagnostics_HeadlinePlusSnapshot(t *testing.T) {
+	resetFalcoSnapshotOnce(t)
+
+	warnings := []v2.FalcoWarning{
+		{Code: "LOAD_NO_EVTTYPE", Rule: "my-rule", Message: "too broad"},
+		{Code: "LOAD_NO_EVTTYPE", Rule: "other-rule-1", Message: "also broad", EnabledInPolicies: []string{"Policy A"}},
+		{Code: "LOAD_NO_EVTTYPE", Rule: "other-rule-2", Message: "also broad too"},
+	}
+
+	diags := falcoWarningsToDiagnostics(warnings, "my-rule")
+
+	require.Len(t, diags, 2, "expect exactly 1 headline + 1 bundled snapshot, not 3 separate diagnostics")
+	assert.Contains(t, diags[0].Summary, `on rule "my-rule"`)
+	assert.Contains(t, diags[1].Summary, "2 other Falco rules")
+	assert.Contains(t, diags[1].Detail, "other-rule-1")
+	assert.Contains(t, diags[1].Detail, "other-rule-2")
+}
+
+func TestFalcoWarningsToDiagnostics_SnapshotEmittedOnceAcrossCalls(t *testing.T) {
+	resetFalcoSnapshotOnce(t)
+
+	// Simulates two resources being saved in the same apply: both calls see
+	// the same account-wide "other" warning, but the snapshot must only
+	// render once — on the second call it must be a headline-only result.
+	warningsForFirstRule := []v2.FalcoWarning{
+		{Code: "LOAD_NO_EVTTYPE", Rule: "rule-a", Message: "a is broad"},
+		{Code: "LOAD_NO_EVTTYPE", Rule: "leftover-rule", Message: "pre-existing noise"},
+	}
+	warningsForSecondRule := []v2.FalcoWarning{
+		{Code: "LOAD_NO_EVTTYPE", Rule: "rule-b", Message: "b is broad"},
+		{Code: "LOAD_NO_EVTTYPE", Rule: "leftover-rule", Message: "pre-existing noise"},
+	}
+
+	first := falcoWarningsToDiagnostics(warningsForFirstRule, "rule-a")
+	second := falcoWarningsToDiagnostics(warningsForSecondRule, "rule-b")
+
+	require.Len(t, first, 2, "first call: headline for rule-a + snapshot for leftover-rule")
+	require.Len(t, second, 1, "second call: headline for rule-b only — snapshot already emitted this apply")
+	assert.Contains(t, second[0].Summary, `on rule "rule-b"`)
+}
+
+func TestFalcoWarningsToDiagnostics_NoWarnings(t *testing.T) {
+	resetFalcoSnapshotOnce(t)
+	assert.Nil(t, falcoWarningsToDiagnostics(nil, "my-rule"))
+}
+
+func TestSnapshotDiagnostic_SortedByPolicyCountDesc(t *testing.T) {
+	warnings := []v2.FalcoWarning{
+		{Rule: "z-rule-no-policies", Code: "LOAD_NO_EVTTYPE"},
+		{Rule: "a-rule-many-policies", Code: "LOAD_NO_EVTTYPE", EnabledInPolicies: []string{"P1", "P2", "P3"}},
+		{Rule: "m-rule-one-policy", Code: "LOAD_NO_EVTTYPE", EnabledInPolicies: []string{"P1"}},
+	}
+
+	diag := snapshotDiagnostic(warnings)
+
+	lines := diag.Detail
+	// a-rule-many-policies (3 policies) should appear before m-rule-one-policy (1),
+	// which should appear before z-rule-no-policies (0).
+	idxA := indexOf(lines, "a-rule-many-policies")
+	idxM := indexOf(lines, "m-rule-one-policy")
+	idxZ := indexOf(lines, "z-rule-no-policies")
+	require.True(t, idxA >= 0 && idxM >= 0 && idxZ >= 0)
+	assert.Less(t, idxA, idxM)
+	assert.Less(t, idxM, idxZ)
+}
+
+// resetFalcoSnapshotOnce clears the process-lifetime dedup guard between
+// test cases. In production this state is scoped to one `terraform apply`
+// process; tests need to reset it since they share a process.
+func resetFalcoSnapshotOnce(t *testing.T) {
+	t.Helper()
+	falcoSnapshotOnce = sync.Once{}
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/sysdig/internal/client/v2/model.go
+++ b/sysdig/internal/client/v2/model.go
@@ -518,6 +518,22 @@ type Rule struct {
 	Tags        []string `json:"tags"`
 	Details     Details  `json:"details"`
 	Version     int      `json:"version,omitempty"`
+	// Warnings carries Falco static-analyzer warnings (LOAD_NO_EVTTYPE today)
+	// returned by the backend on rule create/update. The provider's resource
+	// layer surfaces these as TF Diagnostics with severity Warning so
+	// `terraform apply` shows them without failing the apply.
+	Warnings []FalcoWarning `json:"warnings,omitempty"`
+}
+
+// FalcoWarning is a structured warning emitted by the Falco static analyzer at
+// rule-mutation time. EnabledInPolicies attributes the warning to the
+// customer's policies that have the consuming rule enabled.
+type FalcoWarning struct {
+	Code              string   `json:"code"`
+	Rule              string   `json:"rule"`
+	Message           string   `json:"message"`
+	EnabledInPolicies []string `json:"enabled_in_policies"`
+	AgentVersions     []string `json:"agent_versions"`
 }
 
 const (

--- a/sysdig/internal/client/v2/rule_warnings_test.go
+++ b/sysdig/internal/client/v2/rule_warnings_test.go
@@ -1,0 +1,125 @@
+package v2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The payloads below are real HTTP response bodies captured from a live
+// Sysdig Secure backend (POST/PUT /api/secure/rules), not hand-typed to match
+// what we assume the JSON tags produce. This guards against a struct-tag
+// typo silently deserializing a field to its zero value while every
+// hand-built-struct test still passes.
+
+const capturedCreateRuleResponse = `{
+  "id": 10010392,
+  "name": "ROUNDTRIP-capture-fixture-rule",
+  "origin": "Secure UI",
+  "versionId": "0.0.0",
+  "filename": "falco_rules_local.yaml",
+  "description": "captured for PR 733 review round-trip test",
+  "details": {
+    "ruleType": "FALCO",
+    "condition": {
+      "condition": "proc.name=nginx"
+    },
+    "description": "captured for PR 733 review round-trip test",
+    "output": "nginx activity (proc.cmdline=%proc.cmdline)",
+    "priority": "NOTICE",
+    "source": "syscall",
+    "append": false
+  },
+  "tags": [],
+  "version": 1,
+  "createdOn": 1783702635571,
+  "modifiedOn": 1783702635571,
+  "warnings": [
+    {
+      "code": "LOAD_NO_EVTTYPE",
+      "rule": "ROUNDTRIP-capture-fixture-rule",
+      "message": "Rule matches too many evt.type values. This has a significant performance penalty.",
+      "enabled_in_policies": null,
+      "agent_versions": [
+        "linux-14.7.0"
+      ]
+    }
+  ]
+}`
+
+// Same rule, after being attached to a policy and re-saved — captures the
+// enabled_in_policies-populated case.
+const capturedUpdateRuleResponseWithPolicy = `{
+  "id": 10010392,
+  "name": "ROUNDTRIP-capture-fixture-rule",
+  "origin": "Secure UI",
+  "versionId": "0.0.0",
+  "filename": "falco_rules_local.yaml",
+  "description": "captured for PR 733 review round-trip test (updated)",
+  "details": {
+    "ruleType": "FALCO",
+    "condition": {
+      "condition": "proc.name=nginx"
+    },
+    "description": "captured for PR 733 review round-trip test (updated)",
+    "output": "nginx activity (proc.cmdline=%proc.cmdline)",
+    "priority": "NOTICE",
+    "source": "syscall",
+    "append": false
+  },
+  "tags": [],
+  "version": 2,
+  "createdOn": 1783702635571,
+  "modifiedOn": 1783702842138,
+  "warnings": [
+    {
+      "code": "LOAD_NO_EVTTYPE",
+      "rule": "ROUNDTRIP-capture-fixture-rule",
+      "message": "Rule matches too many evt.type values. This has a significant performance penalty.",
+      "enabled_in_policies": [
+        "ROUNDTRIP-capture-policy"
+      ],
+      "agent_versions": [
+        "linux-14.7.0"
+      ]
+    }
+  ]
+}`
+
+func TestRule_UnmarshalWarnings_RealPayload_NoPolicyAttachment(t *testing.T) {
+	var rule Rule
+	if err := json.Unmarshal([]byte(capturedCreateRuleResponse), &rule); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if len(rule.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(rule.Warnings))
+	}
+	w := rule.Warnings[0]
+	if w.Code != "LOAD_NO_EVTTYPE" {
+		t.Errorf("Code = %q, want LOAD_NO_EVTTYPE", w.Code)
+	}
+	if w.Rule != "ROUNDTRIP-capture-fixture-rule" {
+		t.Errorf("Rule = %q, want ROUNDTRIP-capture-fixture-rule", w.Rule)
+	}
+	if w.EnabledInPolicies != nil {
+		t.Errorf("EnabledInPolicies = %v, want nil (rule not yet attached to any policy)", w.EnabledInPolicies)
+	}
+	if len(w.AgentVersions) != 1 || w.AgentVersions[0] != "linux-14.7.0" {
+		t.Errorf("AgentVersions = %v, want [linux-14.7.0]", w.AgentVersions)
+	}
+}
+
+func TestRule_UnmarshalWarnings_RealPayload_WithPolicyAttachment(t *testing.T) {
+	var rule Rule
+	if err := json.Unmarshal([]byte(capturedUpdateRuleResponseWithPolicy), &rule); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if len(rule.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(rule.Warnings))
+	}
+	w := rule.Warnings[0]
+	if len(w.EnabledInPolicies) != 1 || w.EnabledInPolicies[0] != "ROUNDTRIP-capture-policy" {
+		t.Errorf("EnabledInPolicies = %v, want [ROUNDTRIP-capture-policy]", w.EnabledInPolicies)
+	}
+}

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -240,6 +240,8 @@ func resourceSysdigRuleFalcoUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
+	_ = d.Set("version", updatedRule.Version)
+
 	return falcoWarningsToDiagnostics(updatedRule.Warnings, updatedRule.Name)
 }
 

--- a/sysdig/resource_sysdig_secure_rule_falco.go
+++ b/sysdig/resource_sysdig_secure_rule_falco.go
@@ -121,7 +121,7 @@ func resourceSysdigRuleFalcoCreate(ctx context.Context, d *schema.ResourceData, 
 	d.SetId(strconv.Itoa(rule.ID))
 	_ = d.Set("version", rule.Version)
 
-	return nil
+	return falcoWarningsToDiagnostics(rule.Warnings, rule.Name)
 }
 
 // Retrieves the information of a resource form the file and loads it in Terraform
@@ -234,13 +234,13 @@ func resourceSysdigRuleFalcoUpdate(ctx context.Context, d *schema.ResourceData, 
 	rule.Version = d.Get("version").(int)
 	rule.ID, _ = strconv.Atoi(d.Id())
 
-	_, err = client.UpdateRule(ctx, rule)
+	updatedRule, err := client.UpdateRule(ctx, rule)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
-	return nil
+	return falcoWarningsToDiagnostics(updatedRule.Warnings, updatedRule.Name)
 }
 
 func resourceSysdigRuleFalcoDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {


### PR DESCRIPTION
## Summary

Adds Terraform Diagnostics for Falco static-analyzer warnings (today `LOAD_NO_EVTTYPE`) emitted by the Sysdig backend on `sysdig_secure_rule_falco` create/update.

The backend returns the full current set of warnings for the customer's rules on every create/update call, not just warnings caused by the current save. A naive per-warning diagnostic would reprint every pre-existing warning on every future apply that touches any rule, growing unbounded as more noisy rules accumulate. This PR splits the output into two tiers to avoid that:

- **Headline** — warnings attributed to the rule being saved in *this* resource operation. One diagnostic each, always shown, actionable (this rule needs fixing).
- **Snapshot** — every other warning elsewhere on the account is bundled into a single diagnostic, sorted by policy-attachment count descending (biggest blast radius first), emitted at most once per `terraform apply` (a fresh provider process is launched per apply invocation, so process-lifetime state is exactly apply-scoped — no extra backend calls, no explicit reset needed).

The apply still succeeds — these are advisory (`diag.Warning`), not gates.

## What it looks like

Single rule with a broad condition:

```
│ Warning: Falco static-analyzer warning (LOAD_NO_EVTTYPE) on rule "my_test_rule"
│
│   with sysdig_secure_rule_falco.my_test_rule,
│   on main.tf line 12, in resource "sysdig_secure_rule_falco" "my_test_rule":
│   12: resource "sysdig_secure_rule_falco" "my_test_rule" {
│
│ Rule matches too many evt.type values. This has a significant
│ performance penalty.
│
│ Enabled in policies: my-runtime-policy
│ Agent versions: linux-14.5.2
```

Multiple rules touched in one apply, with an unrelated pre-existing noisy rule elsewhere on the account:

```
│ Warning: Falco static-analyzer warning (LOAD_NO_EVTTYPE) on rule "my_test_rule"
│ ... (headline, as above)

│ Warning: 1 other Falco rule currently emits static-analyzer warnings
│
│   with sysdig_secure_rule_falco.my_test_rule,
│   on main.tf line 12, in resource "sysdig_secure_rule_falco" "my_test_rule":
│   12: resource "sysdig_secure_rule_falco" "my_test_rule" {
│
│ - some_other_noisy_rule (LOAD_NO_EVTTYPE)
```

The snapshot fires once per apply regardless of how many resources are touched — it doesn't grow with the number of new/updated rules.

## Changes

| File | Change |
|---|---|
| `sysdig/internal/client/v2/model.go` | Add `FalcoWarning` type and `Warnings []FalcoWarning` field on `Rule`. JSON shape mirrors the backend response. |
| `sysdig/falco_warnings.go` | New shared helper `falcoWarningsToDiagnostics(warnings, ruleName)`: splits warnings into own-rule (headline) vs. other (bundled snapshot, deduped via a package-level `sync.Once`), sorted by policy-attachment count. |
| `sysdig/falco_warnings_test.go` | Unit tests: headline-only, headline+snapshot split, snapshot-fires-once-across-calls within one apply, no-op on empty input, snapshot sort order. |
| `sysdig/resource_sysdig_secure_rule_falco.go` | Capture `rule.Warnings` / `updatedRule.Warnings` on Create/Update; surface via the helper with the rule's own name. |
| `sysdig/internal/client/v2/rule_warnings_test.go` | JSON round-trip test against two real captured `POST`/`PUT /api/secure/rules` response bodies (with and without a policy attachment) — guards against a struct-tag typo silently deserializing to the zero value. |

## Bug fix found during review

While wiring `Update` to capture `updatedRule` (needed for `.Warnings`/`.Name`), found that `resourceSysdigRuleFalcoUpdate` never called `d.Set("version", ...)` after a successful update — pre-existing on `master`, unrelated to this PR's actual feature, just newly visible/fixable since the return value is now captured (`Create` already did this correctly). Without it, `terraform apply -refresh=false` (or any workflow skipping a post-update `Read`) would leave a stale `version` in state, and the next update would send that stale value and hit an optimistic-lock conflict on the backend.

Fixed by setting `version` from `updatedRule.Version`, mirroring `Create`. Verified live: two consecutive `terraform apply -refresh=false` updates against a real backend now track version `1 -> 2 -> 3` correctly with no conflicts.

## Backwards compatibility

Zero new required fields. Rules whose backend response carries no warnings emit zero diagnostics (helper returns `nil` on empty input). Existing acceptance tests are unaffected since they don't inspect Diagnostics beyond the error count.

## Out of scope (deliberately)

- **`sysdig_secure_rule_container` / `_filesystem` / `_network` / `_process` / `_syscall`**: these are deprecated and non-functional against current backends — `Create`/`Update` return HTTP 400 before any validation runs (see #734). Wiring them here would be dead code; only `sysdig_secure_rule_falco` is touched.
- **`sysdig_secure_macro` / `sysdig_secure_list`**: the backend doesn't surface warnings on those endpoints today. A macro/list's own noise still surfaces via the snapshot on whichever rule save happens to trigger validation next, attributed to the rule that references it (warnings are always rule-scoped — `LOAD_NO_EVTTYPE` never attaches to a macro/list itself).
- **`sysdig_secure_rule_stateful`**: stateful-detection rules don't go through the Falco static-analyzer path; the backend doesn't emit warnings for them.
- **Delete path**: `sysdig_secure_rule_falco`'s Delete function doesn't call the backend's validation, and the underlying delete endpoint doesn't currently return a warnings payload to surface even if it did. Deleting a rule shows zero diagnostics today regardless of the account's remaining warning state. Tracked as a follow-up; needs a backend-side change before the provider side can do anything with it.
- **Performance-warning gate** (opt-in "fail the apply" semantics): the backend supports a query parameter for this; not wired here. The right Terraform UX for a hard gate isn't obvious — happy to discuss if there's interest.

## Test plan
- [x] `go build .` — clean
- [x] `go vet ./sysdig/...` — clean
- [x] Unit tests for the split/dedup helper — passing
- [x] End-to-end against a live backend: single bad rule, multiple rules in one apply, many rules in one apply (confirmed the snapshot stays at one block regardless of count), a macro referenced by a rule (confirmed the macro itself gets no diagnostic, the referencing rule does), a rule attached to policies (confirmed `Enabled in policies: <names>` renders once attached, absent before)


