### PR TITLE
fix(secure): deprecate dead rule resources (container/filesystem/network/process/syscall)

### DIFF
--- a/sysdig/data_source_sysdig_secure_rule_container.go
+++ b/sysdig/data_source_sysdig_secure_rule_container.go
@@ -13,7 +13,7 @@ func dataSourceSysdigSecureRuleContainer() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "data source sysdig_secure_rule_container is deprecated — the backend no longer returns rules of ruleType CONTAINER (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		DeprecationMessage: "data source sysdig_secure_rule_container is deprecated — the backend no longer returns rules of ruleType CONTAINER. Use the sysdig_secure_rule_falco data source.",
 		ReadContext:        dataSourceSysdigRuleContainerRead,
 
 		Timeouts: &schema.ResourceTimeout{

--- a/sysdig/data_source_sysdig_secure_rule_container.go
+++ b/sysdig/data_source_sysdig_secure_rule_container.go
@@ -13,7 +13,8 @@ func dataSourceSysdigSecureRuleContainer() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		ReadContext: dataSourceSysdigRuleContainerRead,
+		DeprecationMessage: "data source sysdig_secure_rule_container is deprecated — the backend no longer returns rules of ruleType CONTAINER (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		ReadContext:        dataSourceSysdigRuleContainerRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(timeout),

--- a/sysdig/data_source_sysdig_secure_rule_filesystem.go
+++ b/sysdig/data_source_sysdig_secure_rule_filesystem.go
@@ -13,7 +13,7 @@ func dataSourceSysdigSecureRuleFilesystem() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "data source sysdig_secure_rule_filesystem is deprecated — the backend no longer returns rules of ruleType FILESYSTEM (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		DeprecationMessage: "data source sysdig_secure_rule_filesystem is deprecated — the backend no longer returns rules of ruleType FILESYSTEM. Use the sysdig_secure_rule_falco data source.",
 		ReadContext:        dataSourceSysdigRuleFilesystemRead,
 
 		Timeouts: &schema.ResourceTimeout{

--- a/sysdig/data_source_sysdig_secure_rule_filesystem.go
+++ b/sysdig/data_source_sysdig_secure_rule_filesystem.go
@@ -13,7 +13,8 @@ func dataSourceSysdigSecureRuleFilesystem() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		ReadContext: dataSourceSysdigRuleFilesystemRead,
+		DeprecationMessage: "data source sysdig_secure_rule_filesystem is deprecated — the backend no longer returns rules of ruleType FILESYSTEM (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		ReadContext:        dataSourceSysdigRuleFilesystemRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(timeout),

--- a/sysdig/data_source_sysdig_secure_rule_network.go
+++ b/sysdig/data_source_sysdig_secure_rule_network.go
@@ -14,7 +14,8 @@ func dataSourceSysdigSecureRuleNetwork() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		ReadContext: dataSourceSysdigRuleNetworkRead,
+		DeprecationMessage: "data source sysdig_secure_rule_network is deprecated — the backend no longer returns rules of ruleType NETWORK (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		ReadContext:        dataSourceSysdigRuleNetworkRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(timeout),

--- a/sysdig/data_source_sysdig_secure_rule_network.go
+++ b/sysdig/data_source_sysdig_secure_rule_network.go
@@ -14,7 +14,7 @@ func dataSourceSysdigSecureRuleNetwork() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "data source sysdig_secure_rule_network is deprecated — the backend no longer returns rules of ruleType NETWORK (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		DeprecationMessage: "data source sysdig_secure_rule_network is deprecated — the backend no longer returns rules of ruleType NETWORK. Use the sysdig_secure_rule_falco data source.",
 		ReadContext:        dataSourceSysdigRuleNetworkRead,
 
 		Timeouts: &schema.ResourceTimeout{

--- a/sysdig/data_source_sysdig_secure_rule_process.go
+++ b/sysdig/data_source_sysdig_secure_rule_process.go
@@ -13,7 +13,7 @@ func dataSourceSysdigSecureRuleProcess() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "data source sysdig_secure_rule_process is deprecated — the backend no longer returns rules of ruleType PROCESS (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		DeprecationMessage: "data source sysdig_secure_rule_process is deprecated — the backend no longer returns rules of ruleType PROCESS. Use the sysdig_secure_rule_falco data source.",
 		ReadContext:        dataSourceSysdigRuleProcessRead,
 
 		Timeouts: &schema.ResourceTimeout{

--- a/sysdig/data_source_sysdig_secure_rule_process.go
+++ b/sysdig/data_source_sysdig_secure_rule_process.go
@@ -13,7 +13,8 @@ func dataSourceSysdigSecureRuleProcess() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		ReadContext: dataSourceSysdigRuleProcessRead,
+		DeprecationMessage: "data source sysdig_secure_rule_process is deprecated — the backend no longer returns rules of ruleType PROCESS (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		ReadContext:        dataSourceSysdigRuleProcessRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(timeout),

--- a/sysdig/data_source_sysdig_secure_rule_syscall.go
+++ b/sysdig/data_source_sysdig_secure_rule_syscall.go
@@ -13,7 +13,8 @@ func dataSourceSysdigSecureRuleSyscall() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		ReadContext: dataSourceSysdigRuleSyscallRead,
+		DeprecationMessage: "data source sysdig_secure_rule_syscall is deprecated — the backend no longer returns rules of ruleType SYSCALL (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		ReadContext:        dataSourceSysdigRuleSyscallRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(timeout),

--- a/sysdig/data_source_sysdig_secure_rule_syscall.go
+++ b/sysdig/data_source_sysdig_secure_rule_syscall.go
@@ -13,7 +13,7 @@ func dataSourceSysdigSecureRuleSyscall() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "data source sysdig_secure_rule_syscall is deprecated — the backend no longer returns rules of ruleType SYSCALL (removed in SSPROD-66298). Use the sysdig_secure_rule_falco data source. Tracking: SSPROD-68481.",
+		DeprecationMessage: "data source sysdig_secure_rule_syscall is deprecated — the backend no longer returns rules of ruleType SYSCALL. Use the sysdig_secure_rule_falco data source.",
 		ReadContext:        dataSourceSysdigRuleSyscallRead,
 
 		Timeouts: &schema.ResourceTimeout{

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -17,7 +17,7 @@ func resourceSysdigSecureRuleContainer() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "sysdig_secure_rule_container is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType CONTAINER since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		DeprecationMessage: "sysdig_secure_rule_container is deprecated and no longer functional against current Sysdig backends — the backend rejects ruleType CONTAINER. Migrate to sysdig_secure_rule_falco with an equivalent Falco condition.",
 		CreateContext:      resourceSysdigRuleContainerCreate,
 		UpdateContext:      resourceSysdigRuleContainerUpdate,
 		ReadContext:        resourceSysdigRuleContainerRead,

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -17,10 +17,11 @@ func resourceSysdigSecureRuleContainer() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		CreateContext: resourceSysdigRuleContainerCreate,
-		UpdateContext: resourceSysdigRuleContainerUpdate,
-		ReadContext:   resourceSysdigRuleContainerRead,
-		DeleteContext: resourceSysdigRuleContainerDelete,
+		DeprecationMessage: "sysdig_secure_rule_container is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType CONTAINER since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		CreateContext:      resourceSysdigRuleContainerCreate,
+		UpdateContext:      resourceSysdigRuleContainerUpdate,
+		ReadContext:        resourceSysdigRuleContainerRead,
+		DeleteContext:      resourceSysdigRuleContainerDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/sysdig/resource_sysdig_secure_rule_filesystem.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem.go
@@ -17,10 +17,11 @@ func resourceSysdigSecureRuleFilesystem() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		CreateContext: resourceSysdigRuleFilesystemCreate,
-		UpdateContext: resourceSysdigRuleFilesystemUpdate,
-		ReadContext:   resourceSysdigRuleFilesystemRead,
-		DeleteContext: resourceSysdigRuleFilesystemDelete,
+		DeprecationMessage: "sysdig_secure_rule_filesystem is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType FILESYSTEM since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		CreateContext:      resourceSysdigRuleFilesystemCreate,
+		UpdateContext:      resourceSysdigRuleFilesystemUpdate,
+		ReadContext:        resourceSysdigRuleFilesystemRead,
+		DeleteContext:      resourceSysdigRuleFilesystemDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/sysdig/resource_sysdig_secure_rule_filesystem.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem.go
@@ -17,7 +17,7 @@ func resourceSysdigSecureRuleFilesystem() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "sysdig_secure_rule_filesystem is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType FILESYSTEM since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		DeprecationMessage: "sysdig_secure_rule_filesystem is deprecated and no longer functional against current Sysdig backends — the backend rejects ruleType FILESYSTEM. Migrate to sysdig_secure_rule_falco with an equivalent Falco condition.",
 		CreateContext:      resourceSysdigRuleFilesystemCreate,
 		UpdateContext:      resourceSysdigRuleFilesystemUpdate,
 		ReadContext:        resourceSysdigRuleFilesystemRead,

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -17,7 +17,7 @@ func resourceSysdigSecureRuleNetwork() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "sysdig_secure_rule_network is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType NETWORK since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		DeprecationMessage: "sysdig_secure_rule_network is deprecated and no longer functional against current Sysdig backends — the backend rejects ruleType NETWORK. Migrate to sysdig_secure_rule_falco with an equivalent Falco condition.",
 		CreateContext:      resourceSysdigRuleNetworkCreate,
 		UpdateContext:      resourceSysdigRuleNetworkUpdate,
 		ReadContext:        resourceSysdigRuleNetworkRead,

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -17,10 +17,11 @@ func resourceSysdigSecureRuleNetwork() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		CreateContext: resourceSysdigRuleNetworkCreate,
-		UpdateContext: resourceSysdigRuleNetworkUpdate,
-		ReadContext:   resourceSysdigRuleNetworkRead,
-		DeleteContext: resourceSysdigRuleNetworkDelete,
+		DeprecationMessage: "sysdig_secure_rule_network is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType NETWORK since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		CreateContext:      resourceSysdigRuleNetworkCreate,
+		UpdateContext:      resourceSysdigRuleNetworkUpdate,
+		ReadContext:        resourceSysdigRuleNetworkRead,
+		DeleteContext:      resourceSysdigRuleNetworkDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -17,10 +17,11 @@ func resourceSysdigSecureRuleProcess() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		CreateContext: resourceSysdigRuleProcessCreate,
-		UpdateContext: resourceSysdigRuleProcessUpdate,
-		ReadContext:   resourceSysdigRuleProcessRead,
-		DeleteContext: resourceSysdigRuleProcessDelete,
+		DeprecationMessage: "sysdig_secure_rule_process is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType PROCESS since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		CreateContext:      resourceSysdigRuleProcessCreate,
+		UpdateContext:      resourceSysdigRuleProcessUpdate,
+		ReadContext:        resourceSysdigRuleProcessRead,
+		DeleteContext:      resourceSysdigRuleProcessDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -17,7 +17,7 @@ func resourceSysdigSecureRuleProcess() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "sysdig_secure_rule_process is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType PROCESS since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		DeprecationMessage: "sysdig_secure_rule_process is deprecated and no longer functional against current Sysdig backends — the backend rejects ruleType PROCESS. Migrate to sysdig_secure_rule_falco with an equivalent Falco condition.",
 		CreateContext:      resourceSysdigRuleProcessCreate,
 		UpdateContext:      resourceSysdigRuleProcessUpdate,
 		ReadContext:        resourceSysdigRuleProcessRead,

--- a/sysdig/resource_sysdig_secure_rule_syscall.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall.go
@@ -16,10 +16,11 @@ func resourceSysdigSecureRuleSyscall() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		CreateContext: resourceSysdigRuleSyscallCreate,
-		UpdateContext: resourceSysdigRuleSyscallUpdate,
-		ReadContext:   resourceSysdigRuleSyscallRead,
-		DeleteContext: resourceSysdigRuleSyscallDelete,
+		DeprecationMessage: "sysdig_secure_rule_syscall is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType SYSCALL since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		CreateContext:      resourceSysdigRuleSyscallCreate,
+		UpdateContext:      resourceSysdigRuleSyscallUpdate,
+		ReadContext:        resourceSysdigRuleSyscallRead,
+		DeleteContext:      resourceSysdigRuleSyscallDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/sysdig/resource_sysdig_secure_rule_syscall.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall.go
@@ -16,7 +16,7 @@ func resourceSysdigSecureRuleSyscall() *schema.Resource {
 	timeout := 5 * time.Minute
 
 	return &schema.Resource{
-		DeprecationMessage: "sysdig_secure_rule_syscall is deprecated and no longer creates or updates against current Sysdig backends — the backend rejects ruleType SYSCALL since list-matching policy code was removed (SSPROD-66298). Migrate to sysdig_secure_rule_falco with an equivalent Falco condition. Tracking: SSPROD-68481.",
+		DeprecationMessage: "sysdig_secure_rule_syscall is deprecated and no longer functional against current Sysdig backends — the backend rejects ruleType SYSCALL. Migrate to sysdig_secure_rule_falco with an equivalent Falco condition.",
 		CreateContext:      resourceSysdigRuleSyscallCreate,
 		UpdateContext:      resourceSysdigRuleSyscallUpdate,
 		ReadContext:        resourceSysdigRuleSyscallRead,


### PR DESCRIPTION
## Summary
Five sub-type rule resources and their matching data sources — `sysdig_secure_rule_container`, `_filesystem`, `_network`, `_process`, `_syscall` — are **broken end-to-end** against current Sysdig backends. Their `Create`/`Update` calls hit `POST /api/secure/rules` with `ruleType` values (`CONTAINER`, `FILESYSTEM`, `NETWORK`, `PROCESS`, `SYSCALL`) that the backend stopped accepting when list-matching policy code was removed. The endpoint returns HTTP 400 `"unknown ruleType: <type>"`.

This adds `Schema.DeprecationMessage` on the resource and data source definitions so users see a clear `terraform plan`/`apply`-time warning pointing them at `sysdig_secure_rule_falco`.

## Repro

Against a fresh Sysdig stack:

```
$ curl -X POST .../api/secure/rules \
    -d '{"details":{"ruleType":"CONTAINER",...}}'
HTTP 400: "The field details has an unknown ruleType: CONTAINER"
```

Same for `FILESYSTEM` / `NETWORK` / `PROCESS` / `SYSCALL`.

The modern backend rule unmarshaller only accepts: `FALCO`, `DRIFT`, `MACHINE_LEARNING`, `AWS_MACHINE_LEARNING`, `MALWARE`, `OKTA_MACHINE_LEARNING`, `FIM`.

## Changes

| File | Change |
|---|---|
| `sysdig/resource_sysdig_secure_rule_{container,filesystem,network,process,syscall}.go` | Add `DeprecationMessage` on the returned `schema.Resource`. |
| `sysdig/data_source_sysdig_secure_rule_{container,filesystem,network,process,syscall}.go` | Same on the data source. |

Net: +35, -25. Pure metadata change — no behavior change beyond Terraform surfacing the deprecation banner.

## What users see

When `sysdig_secure_rule_container` (etc.) appears in a config:

```
Warning: Argument is deprecated
  with sysdig_secure_rule_container.foo,
  on main.tf line 12, in resource "sysdig_secure_rule_container" "foo":

sysdig_secure_rule_container is deprecated and no longer functional
against current Sysdig backends — the backend rejects ruleType CONTAINER.
Migrate to sysdig_secure_rule_falco with an equivalent Falco condition.
```

## Why not remove

Outright removal would be a breaking change for anyone with these resources in state (`terraform plan` would error out before they can migrate). Deprecation now warns users; a follow-up at a major-version bump can remove them.

## Why not restore backend support

The structured ruleTypes were tied to the (now-removed) list-matching code path. Re-introducing them would resurrect that surface. Out of scope.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./sysdig/...` — clean
- [x] `gofmt -l sysdig/...` — clean
- [x] Confirmed the 400 reproduction against a current Sysdig backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
