### PR TITLE
fix(secure): mark list-matching rule resources deprecated in docs; drop list_matching policy type

### DIFF
--- a/sysdig/resource_sysdig_secure_common_policy.go
+++ b/sysdig/resource_sysdig_secure_common_policy.go
@@ -16,7 +16,9 @@ import (
 
 var validatePolicyType = validation.StringInSlice([]string{
 	"falco",
-	"list_matching",
+	// "list_matching" removed: list-matching policy support was removed from the
+	// Sysdig backend on 2026-02-28 (creation deprecated 2025-12-15). The platform
+	// now rejects this type, so the provider no longer accepts it.
 	"k8s_audit",
 	"aws_cloudtrail",
 	"awscloudtrail",

--- a/website/docs/d/secure_custom_policy.md
+++ b/website/docs/d/secure_custom_policy.md
@@ -25,7 +25,7 @@ data "sysdig_secure_custom_policy" "example" {
 
 * `name` - (Required) The name of the Secure custom policy.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `k8s_audit`,
   `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`, `guardduty`. By default it is `falco`.
 
 ## Attributes Reference

--- a/website/docs/d/secure_managed_policy.md
+++ b/website/docs/d/secure_managed_policy.md
@@ -25,7 +25,7 @@ data "sysdig_secure_managed_policy" "example" {
 
 * `name` - (Required) The name of the Secure managed policy.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `k8s_audit`,
   `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`, `guardduty`. By default it is `falco`.
 
 ## Attributes Reference

--- a/website/docs/d/secure_managed_ruleset.md
+++ b/website/docs/d/secure_managed_ruleset.md
@@ -25,7 +25,7 @@ data "sysdig_secure_managed_ruleset" "example" {
 
 * `name` - (Required) The name of the Secure managed ruleset.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `k8s_audit`,
   `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`, `guardduty`. By default it is `falco`.
 
 ## Attributes Reference

--- a/website/docs/d/secure_rule_container.md
+++ b/website/docs/d/secure_rule_container.md
@@ -10,6 +10,8 @@ description: |-
 
 Retrieves the information of an existing Sysdig Secure Container Rule.
 
+!> **Deprecated:** The `sysdig_secure_rule_container` data source is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28. Use [`sysdig_secure_rule_falco`](secure_rule_falco.md) instead.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/d/secure_rule_filesystem.md
+++ b/website/docs/d/secure_rule_filesystem.md
@@ -10,6 +10,8 @@ description: |-
 
 Retrieves the information of an existing Sysdig Secure Filesystem Rule.
 
+!> **Deprecated:** The `sysdig_secure_rule_filesystem` data source is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28. Use [`sysdig_secure_rule_falco`](secure_rule_falco.md) instead.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/d/secure_rule_network.md
+++ b/website/docs/d/secure_rule_network.md
@@ -10,6 +10,8 @@ description: |-
 
 Retrieves the information of an existing Sysdig Secure Network Rule.
 
+!> **Deprecated:** The `sysdig_secure_rule_network` data source is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28. Use [`sysdig_secure_rule_falco`](secure_rule_falco.md) instead.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/d/secure_rule_process.md
+++ b/website/docs/d/secure_rule_process.md
@@ -10,6 +10,8 @@ description: |-
 
 Retrieves the information of an existing Sysdig Secure Process Rule.
 
+!> **Deprecated:** The `sysdig_secure_rule_process` data source is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28. Use [`sysdig_secure_rule_falco`](secure_rule_falco.md) instead.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/d/secure_rule_syscall.md
+++ b/website/docs/d/secure_rule_syscall.md
@@ -10,6 +10,8 @@ description: |-
 
 Retrieves the information of an existing Sysdig Secure Syscall Rule.
 
+!> **Deprecated:** The `sysdig_secure_rule_syscall` data source is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28. Use [`sysdig_secure_rule_falco`](secure_rule_falco.md) instead.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/r/secure_custom_policy.md
+++ b/website/docs/r/secure_custom_policy.md
@@ -59,7 +59,7 @@ resource "sysdig_secure_custom_policy" "write_apt_database" {
 
 * `enabled` - (Optional) Will secure process with this rule?. By default this is true.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `k8s_audit`,
   `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`, `guardduty`. By default it is `falco`.
 
 * `runbook` - (Optional) Customer provided url that provides a runbook for a given policy. 

--- a/website/docs/r/secure_managed_policy.md
+++ b/website/docs/r/secure_managed_policy.md
@@ -50,7 +50,7 @@ resource "sysdig_secure_managed_policy" "sysdig_runtime_threat_detection" {
 
 * `name` - (Required) The name of the Secure managed policy. It must match the name of an existing managed policy.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`,
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `k8s_audit`,
   `aws_cloudtrail`, `gcp_auditlog`, `azure_platformlogs`, `awscloudtrail`, `okta`, `github`, `guardduty`. By default it is `falco`.
 
 * `enabled` - (Optional) Will secure process with this policy?. By default this is true.

--- a/website/docs/r/secure_managed_ruleset.md
+++ b/website/docs/r/secure_managed_ruleset.md
@@ -59,7 +59,7 @@ resource "sysdig_secure_managed_ruleset" "sysdig_runtime_threat_detection_manage
 
 * `enabled` - (Optional) Will secure process with this rule?. By default this is true.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`, `aws_cloudtrail`, `awscloudtrail`, `okta`, `github`, `guardduty`. By default it is `falco`.
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `k8s_audit`, `aws_cloudtrail`, `awscloudtrail`, `okta`, `github`, `guardduty`. By default it is `falco`.
 
 * `runbook` - (Optional) Customer provided url that provides a runbook for a given policy. 
 - - -
@@ -70,7 +70,7 @@ The `inherited_from` block is required and identifies the managed policy that th
 
 * `name` - (Required) The name of the Secure managed policy. It must match the name of an existing managed policy.
 
-* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `list_matching`, `k8s_audit`, `aws_cloudtrail`, `awscloudtrail`, `okta`, `github`, `guardduty`. By default it is `falco`.
+* `type` - (Optional) Specifies the type of the runtime policy. Must be one of: `falco`, `k8s_audit`, `aws_cloudtrail`, `awscloudtrail`, `okta`, `github`, `guardduty`. By default it is `falco`.
 
 - - -
 

--- a/website/docs/r/secure_rule_container.md
+++ b/website/docs/r/secure_rule_container.md
@@ -10,6 +10,8 @@ description: |-
 
 Creates a Sysdig Secure Container Rule.
 
+!> **Deprecated:** `sysdig_secure_rule_container` is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28; the backend now rejects `ruleType CONTAINER`. Migrate to [`sysdig_secure_rule_falco`](secure_rule_falco.md) with an equivalent Falco condition.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/r/secure_rule_filesystem.md
+++ b/website/docs/r/secure_rule_filesystem.md
@@ -10,6 +10,8 @@ description: |-
 
 Creates a Sysdig Secure Filesystem Rule.
 
+!> **Deprecated:** `sysdig_secure_rule_filesystem` is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28; the backend now rejects `ruleType FILESYSTEM`. Migrate to [`sysdig_secure_rule_falco`](secure_rule_falco.md) with an equivalent Falco condition.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/r/secure_rule_network.md
+++ b/website/docs/r/secure_rule_network.md
@@ -10,6 +10,8 @@ description: |-
 
 Creates a Sysdig Secure Network Rule.
 
+!> **Deprecated:** `sysdig_secure_rule_network` is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28; the backend now rejects `ruleType NETWORK`. Migrate to [`sysdig_secure_rule_falco`](secure_rule_falco.md) with an equivalent Falco condition.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/r/secure_rule_process.md
+++ b/website/docs/r/secure_rule_process.md
@@ -10,6 +10,8 @@ description: |-
 
 Creates a Sysdig Secure Process Rule.
 
+!> **Deprecated:** `sysdig_secure_rule_process` is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28; the backend now rejects `ruleType PROCESS`. Migrate to [`sysdig_secure_rule_falco`](secure_rule_falco.md) with an equivalent Falco condition.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage

--- a/website/docs/r/secure_rule_syscall.md
+++ b/website/docs/r/secure_rule_syscall.md
@@ -10,6 +10,8 @@ description: |-
 
 Creates a Sysdig Secure Syscall Rule.
 
+!> **Deprecated:** `sysdig_secure_rule_syscall` is deprecated and no longer functional against current Sysdig backends. List-matching rule support was deprecated on 2025-12-15 and removed on 2026-02-28; the backend now rejects `ruleType SYSCALL`. Migrate to [`sysdig_secure_rule_falco`](secure_rule_falco.md) with an equivalent Falco condition.
+
 -> **Note:** Sysdig Terraform Provider is under rapid development at this point. If you experience any issue or discrepancy while using it, please make sure you have the latest version. If the issue persists, or you have a Feature Request to support an additional set of resources, please open a [new issue](https://github.com/sysdiglabs/terraform-provider-sysdig/issues/new) in the GitHub repository.
 
 ## Example Usage


### PR DESCRIPTION
## Why

Field feedback (Felipe Nonay): the Terraform provider docs are out of sync with current product behavior.

- Creation of List Matching policies/rules was **deprecated on 2025-12-15**.
- List Matching support was **removed on 2026-02-28** — the backend now rejects `sysdig_secure_rule_network`, `_process`, `_syscall` (and `_container`, `_filesystem`) with HTTP 400 `unknown ruleType: <TYPE>`.

PR #734 already added plan-time `DeprecationMessage` warnings on these resources/data sources, but those **do not render on the Terraform Registry doc pages**, and `list_matching` was still advertised as a valid policy `type`. This closes that docs gap.

## Changes

**Provider**
- Remove `"list_matching"` from `validatePolicyType` (shared by `custom_policy`, `managed_policy`, `managed_ruleset`) so plans referencing it fail early instead of at apply against a rejecting backend.

**Docs — deprecation callouts**
- Added `!> **Deprecated:**` notes to the rule **resource + data-source** pages for all 5 types (`container`, `filesystem`, `network`, `process`, `syscall`), citing the removal dates and pointing to `sysdig_secure_rule_falco`.

**Docs — policy `type`**
- Dropped `list_matching` from the `type` enumeration in `custom_policy`, `managed_policy`, and `managed_ruleset` (both `r/` and `d/`).

## Verification
- `go build ./sysdig/` ✅
- `gofmt` clean ✅
- No `list_matching` references remain anywhere except an explanatory code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)