### PR TITLE
fix(secure): fall back to v1 zones API when /platform/v2/zones is not exposed

### DIFF
--- a/sysdig/internal/client/v2/zonesV2.go
+++ b/sysdig/internal/client/v2/zonesV2.go
@@ -110,6 +110,10 @@ func (c *Client) UpdateZoneV2(ctx context.Context, zone *ZoneV2) (updatedZone *Z
 	return Unmarshal[*ZoneV2](response.Body)
 }
 
+// DeleteZoneV2 deletes a zone through the v2 API. Unlike DeleteZone, a 404 is
+// returned as an error: callers need it to distinguish an already-deleted zone
+// from a backend that does not expose the v2 zones endpoint, where they fall
+// back to the v1 API.
 func (c *Client) DeleteZoneV2(ctx context.Context, id int) (err error) {
 	response, err := c.requester.Request(ctx, http.MethodDelete, c.getZoneV2URL(id), nil)
 	if err != nil {
@@ -121,7 +125,7 @@ func (c *Client) DeleteZoneV2(ctx context.Context, id int) (err error) {
 		}
 	}()
 
-	if response.StatusCode != http.StatusNoContent && response.StatusCode != http.StatusOK && response.StatusCode != http.StatusNotFound {
+	if response.StatusCode != http.StatusNoContent && response.StatusCode != http.StatusOK {
 		return c.APIErrorFromResponse(response)
 	}
 

--- a/sysdig/resource_sysdig_secure_zone.go
+++ b/sysdig/resource_sysdig_secure_zone.go
@@ -218,10 +218,29 @@ func createZone(ctx context.Context, d *schema.ResourceData, clientV1 v2.ZoneInt
 	zone := expandZoneV2(d)
 	created, err := clientV2.CreateZoneV2(ctx, zone)
 	if err != nil {
+		// Some backends do not expose /platform/v2/zones. A 404 on the
+		// collection endpoint means the endpoint itself is missing, so
+		// fall back to the v1 API when possible.
+		if isNotFound(err) {
+			if stateHasExpressions(d) {
+				return 0, diag.FromErr(errZoneV2EndpointMissing)
+			}
+			createdV1, v1Err := clientV1.CreateZone(ctx, zoneRequestFromResourceData(d))
+			if v1Err != nil {
+				return 0, diag.FromErr(fmt.Errorf("error creating Sysdig Zone: %w", v1Err))
+			}
+			return createdV1.ID, nil
+		}
 		return 0, diag.FromErr(fmt.Errorf("error creating zone: %w", err))
 	}
 	return created.ID, nil
 }
+
+// errZoneV2EndpointMissing is returned when the backend does not expose the
+// v2 zones API but the configuration requires it (expression-based scopes).
+var errZoneV2EndpointMissing = errors.New(
+	"the backend does not expose the /platform/v2/zones API, which is required for expression-based scopes; " +
+		"use rules-based scopes instead, or upgrade the backend to a version that exposes the v2 zones endpoint")
 
 func isNotFound(err error) bool {
 	var apiErr *v2.APIError
@@ -293,6 +312,10 @@ func resourceSysdigSecureZoneRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
+	return readZone(ctx, d, client, clientv2)
+}
+
+func readZone(ctx context.Context, d *schema.ResourceData, clientV1 v2.ZoneInterface, clientV2 v2.ZoneV2Interface) diag.Diagnostics {
 	id, _ := strconv.Atoi(d.Id())
 
 	legacyZone, e := categorizeZone(d)
@@ -300,7 +323,7 @@ func resourceSysdigSecureZoneRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(fmt.Errorf("error analyzing zone scope: %s", e))
 	}
 	if legacyZone {
-		zone, err := client.GetZoneByID(ctx, id)
+		zone, err := clientV1.GetZoneByID(ctx, id)
 		if err != nil {
 			if isNotFound(err) {
 				d.SetId("")
@@ -309,24 +332,25 @@ func resourceSysdigSecureZoneRead(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(fmt.Errorf("error reading zone %d: %w", id, err))
 		}
 
-		_ = d.Set("name", zone.Name)
-		_ = d.Set("description", zone.Description)
-		_ = d.Set("is_system", zone.IsSystem)
-		_ = d.Set("author", zone.Author)
-		_ = d.Set("last_modified_by", zone.LastModifiedBy)
-		_ = d.Set("last_updated", time.UnixMilli(zone.LastUpdated).Format(time.RFC3339))
-		// For legacy zones, we need to set the rules field in the scope
-		if err := d.Set(SchemaScopeKey, fromZoneScopesResponse(zone.Scopes)); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting scope: %s", err))
-		}
-		return nil
+		return zoneV1ToState(d, zone)
 	}
 
-	zone, err := clientv2.GetZoneV2(ctx, id)
+	zone, err := clientV2.GetZoneV2(ctx, id)
 	if err != nil {
 		if isNotFound(err) {
-			d.SetId("")
-			return nil
+			// A 404 here is ambiguous: the zone may be gone, or the
+			// backend may not expose /platform/v2/zones at all. Probe
+			// the v1 endpoint to disambiguate before removing the
+			// zone from state.
+			zoneV1, v1Err := clientV1.GetZoneByID(ctx, id)
+			if v1Err != nil {
+				if isNotFound(v1Err) {
+					d.SetId("")
+					return nil
+				}
+				return diag.FromErr(fmt.Errorf("error reading zone %d: %w", id, v1Err))
+			}
+			return zoneV1ToState(d, zoneV1)
 		}
 		return diag.FromErr(fmt.Errorf("error reading zone %d: %w", id, err))
 	}
@@ -349,6 +373,21 @@ func resourceSysdigSecureZoneRead(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
+// zoneV1ToState writes a v1 Zone API response into the Terraform state.
+func zoneV1ToState(d *schema.ResourceData, zone *v2.Zone) diag.Diagnostics {
+	_ = d.Set("name", zone.Name)
+	_ = d.Set("description", zone.Description)
+	_ = d.Set("is_system", zone.IsSystem)
+	_ = d.Set("author", zone.Author)
+	_ = d.Set("last_modified_by", zone.LastModifiedBy)
+	_ = d.Set("last_updated", time.UnixMilli(zone.LastUpdated).Format(time.RFC3339))
+	// v1 zones only carry rules, so set the rules field in the scope
+	if err := d.Set(SchemaScopeKey, fromZoneScopesResponse(zone.Scopes)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting scope: %s", err))
+	}
+	return nil
+}
+
 func resourceSysdigSecureZoneUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client, err := getZoneClient(m.(SysdigClients))
 	if err != nil {
@@ -360,6 +399,14 @@ func resourceSysdigSecureZoneUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	if diags := updateZone(ctx, d, client, clientV2); diags.HasError() {
+		return diags
+	}
+
+	return resourceSysdigSecureZoneRead(ctx, d, m)
+}
+
+func updateZone(ctx context.Context, d *schema.ResourceData, clientV1 v2.ZoneInterface, clientV2 v2.ZoneV2Interface) diag.Diagnostics {
 	legacyZone, e := categorizeZone(d)
 	if e != nil {
 		return diag.FromErr(fmt.Errorf("error analyzing zone scope: %s", e))
@@ -378,19 +425,30 @@ func resourceSysdigSecureZoneUpdate(ctx context.Context, d *schema.ResourceData,
 		zone.ID = id
 
 		if _, err := clientV2.UpdateZoneV2(ctx, zone); err != nil {
+			// Fall back to the v1 API when the backend does not
+			// expose /platform/v2/zones.
+			if isNotFound(err) {
+				if stateHasExpressions(d) {
+					return diag.FromErr(errZoneV2EndpointMissing)
+				}
+				if _, v1Err := clientV1.UpdateZone(ctx, zoneRequestFromResourceData(d)); v1Err != nil {
+					return diag.FromErr(fmt.Errorf("error updating Sysdig Zone: %w", v1Err))
+				}
+				return nil
+			}
 			return diag.FromErr(fmt.Errorf("error updating zone: %w", err))
 		}
 
-		return resourceSysdigSecureZoneRead(ctx, d, m)
+		return nil
 	}
 
 	zoneRequest := zoneRequestFromResourceData(d)
 
-	if _, err := client.UpdateZone(ctx, zoneRequest); err != nil {
+	if _, err := clientV1.UpdateZone(ctx, zoneRequest); err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Sysdig Zone: %w", err))
 	}
 
-	return resourceSysdigSecureZoneRead(ctx, d, m)
+	return nil
 }
 
 func resourceSysdigSecureZoneDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
@@ -404,13 +462,17 @@ func resourceSysdigSecureZoneDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	return deleteZone(ctx, d, client, clientV2)
+}
+
+func deleteZone(ctx context.Context, d *schema.ResourceData, clientV1 v2.ZoneInterface, clientV2 v2.ZoneV2Interface) diag.Diagnostics {
 	id, _ := strconv.Atoi(d.Id())
 	legacyZone, e := categorizeZone(d)
 	if e != nil {
 		return diag.FromErr(fmt.Errorf("error analyzing zone scope: %s", e))
 	}
 	if legacyZone {
-		if err := client.DeleteZone(ctx, id); err != nil {
+		if err := clientV1.DeleteZone(ctx, id); err != nil {
 			return diag.FromErr(fmt.Errorf("error deleting Sysdig Zone: %w", err))
 		}
 
@@ -419,6 +481,17 @@ func resourceSysdigSecureZoneDelete(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err := clientV2.DeleteZoneV2(ctx, id); err != nil {
+		// A 404 here means either the zone is already gone or the backend
+		// does not expose /platform/v2/zones at all. The v1 delete covers
+		// both cases: it deletes the zone on v1-only backends and
+		// tolerates 404 when the zone no longer exists.
+		if isNotFound(err) {
+			if v1Err := clientV1.DeleteZone(ctx, id); v1Err != nil {
+				return diag.FromErr(fmt.Errorf("error deleting Sysdig Zone: %w", v1Err))
+			}
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(fmt.Errorf("error deleting Sysdig Zone: %w", err))
 	}
 	d.SetId("")

--- a/sysdig/resource_sysdig_secure_zone_v1_fallback_test.go
+++ b/sysdig/resource_sysdig_secure_zone_v1_fallback_test.go
@@ -1,0 +1,370 @@
+package sysdig
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeZoneBackend simulates the zones API of a backend. When exposeV2 is
+// false it behaves like a deployment where only /platform/v1/zones is
+// exposed and any /platform/v2/* request returns a plain 404.
+type fakeZoneBackend struct {
+	mu       sync.Mutex
+	exposeV2 bool
+	zones    map[int]*v2.Zone
+	nextID   int
+
+	v1Hits []string // "METHOD path" of every /platform/v1/zones request
+	v2Hits []string // "METHOD path" of every /platform/v2/zones request
+}
+
+func newFakeZoneBackend(exposeV2 bool) *fakeZoneBackend {
+	return &fakeZoneBackend{
+		exposeV2: exposeV2,
+		zones:    map[int]*v2.Zone{},
+		nextID:   1,
+	}
+}
+
+func (f *fakeZoneBackend) seed(zone *v2.Zone) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.zones[zone.ID] = zone
+	if zone.ID >= f.nextID {
+		f.nextID = zone.ID + 1
+	}
+}
+
+func (f *fakeZoneBackend) has(id int) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.zones[id]
+	return ok
+}
+
+func (f *fakeZoneBackend) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/platform/v1/zones", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.v1Hits = append(f.v1Hits, r.Method+" "+r.URL.Path)
+
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var req v2.ZoneRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		zone := &v2.Zone{
+			ID:          f.nextID,
+			Name:        req.Name,
+			Description: req.Description,
+			Scopes:      req.Scopes,
+		}
+		f.nextID++
+		f.zones[zone.ID] = zone
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(zone))
+	})
+
+	mux.HandleFunc("/platform/v1/zones/", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.v1Hits = append(f.v1Hits, r.Method+" "+r.URL.Path)
+
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/platform/v1/zones/"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		zone, ok := f.zones[id]
+
+		switch r.Method {
+		case http.MethodGet:
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(zone))
+		case http.MethodPut:
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			var req v2.ZoneRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			zone.Name = req.Name
+			zone.Description = req.Description
+			zone.Scopes = req.Scopes
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(zone))
+		case http.MethodDelete:
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			delete(f.zones, id)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	if f.exposeV2 {
+		toV2 := func(zone *v2.Zone) *v2.ZoneV2 {
+			out := &v2.ZoneV2{
+				ID:          zone.ID,
+				Name:        zone.Name,
+				Description: zone.Description,
+			}
+			scope := v2.ScopeV2{}
+			for _, s := range zone.Scopes {
+				scope.Filters = append(scope.Filters, v2.FilterV2{
+					ID:           s.ID,
+					ResourceType: s.TargetType,
+					Rules:        s.Rules,
+				})
+			}
+			if len(scope.Filters) > 0 {
+				out.Scopes = []v2.ScopeV2{scope}
+			}
+			return out
+		}
+
+		mux.HandleFunc("/platform/v2/zones/", func(w http.ResponseWriter, r *http.Request) {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			f.v2Hits = append(f.v2Hits, r.Method+" "+r.URL.Path)
+
+			id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/platform/v2/zones/"))
+			if err != nil {
+				http.NotFound(w, r)
+				return
+			}
+			zone, ok := f.zones[id]
+
+			switch r.Method {
+			case http.MethodGet:
+				if !ok {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				require.NoError(t, json.NewEncoder(w).Encode(toV2(zone)))
+			case http.MethodDelete:
+				if !ok {
+					http.NotFound(w, r)
+					return
+				}
+				delete(f.zones, id)
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.NotFound(w, r)
+			}
+		})
+	}
+
+	// Anything else (including /platform/v2/* when exposeV2 is false)
+	// falls through to the mux default 404.
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func zoneTestClients(t *testing.T, url string) (v2.ZoneInterface, v2.ZoneV2Interface) {
+	t.Helper()
+	client := v2.NewSysdigSecure(v2.WithURL(url), v2.WithToken("test-token"))
+	return client, client
+}
+
+// v2-syntax rules (no labels/labelValues/agentTags): categorizeZone treats
+// this as v2 even though the backend may only expose the v1 API.
+func zoneRulesResourceData(t *testing.T) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, resourceSysdigSecureZone().Schema, map[string]interface{}{
+		"name":        "Empty zone",
+		"description": "Exclude all cluster and host runtime scan results",
+		"scope": []interface{}{
+			map[string]interface{}{
+				"target_type": "kubernetes",
+				"rules":       `clusterId in ("non-existent")`,
+			},
+		},
+	})
+}
+
+func zoneExpressionResourceData(t *testing.T) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, resourceSysdigSecureZone().Schema, map[string]interface{}{
+		"name": "Expression zone",
+		"scope": []interface{}{
+			map[string]interface{}{
+				"target_type": "kubernetes",
+				"expression": []interface{}{
+					map[string]interface{}{
+						"field":    "clusterId",
+						"operator": "in",
+						"values":   []interface{}{"prod"},
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestZoneV1Fallback_CreateUsesV1WhenV2NotExposed(t *testing.T) {
+	backend := newFakeZoneBackend(false)
+	srv := backend.server(t)
+	clientV1, clientV2 := zoneTestClients(t, srv.URL)
+
+	d := zoneRulesResourceData(t)
+
+	id, diags := createZone(context.Background(), d, clientV1, clientV2)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+	require.True(t, backend.has(id), "zone should have been created through the v1 endpoint")
+}
+
+func TestZoneV1Fallback_CreateWithExpressionsFailsClearly(t *testing.T) {
+	backend := newFakeZoneBackend(false)
+	srv := backend.server(t)
+	clientV1, clientV2 := zoneTestClients(t, srv.URL)
+
+	d := zoneExpressionResourceData(t)
+
+	_, diags := createZone(context.Background(), d, clientV1, clientV2)
+	require.True(t, diags.HasError())
+	require.Contains(t, diags[0].Summary, "/platform/v2/zones")
+}
+
+func TestZoneV1Fallback_ReadFallsBackToV1(t *testing.T) {
+	backend := newFakeZoneBackend(false)
+	backend.seed(&v2.Zone{
+		ID:   22,
+		Name: "Empty zone",
+		Scopes: []v2.ZoneScope{
+			{ID: 1, TargetType: "kubernetes", Rules: `clusterId in ("non-existent")`},
+		},
+	})
+	srv := backend.server(t)
+	clientV1, clientV2 := zoneTestClients(t, srv.URL)
+
+	d := zoneRulesResourceData(t)
+	d.SetId("22")
+
+	diags := readZone(context.Background(), d, clientV1, clientV2)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+	require.Equal(t, "22", d.Id(), "zone must not be removed from state when only the v2 endpoint is missing")
+	require.Equal(t, "Empty zone", d.Get("name"))
+}
+
+func TestZoneV1Fallback_ReadRemovesFromStateWhenGoneEverywhere(t *testing.T) {
+	backend := newFakeZoneBackend(false)
+	srv := backend.server(t)
+	clientV1, clientV2 := zoneTestClients(t, srv.URL)
+
+	d := zoneRulesResourceData(t)
+	d.SetId("22")
+
+	diags := readZone(context.Background(), d, clientV1, clientV2)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+	require.Empty(t, d.Id(), "zone missing on both endpoints must be removed from state")
+}
+
+func TestZoneV1Fallback_UpdateFallsBackToV1(t *testing.T) {
+	backend := newFakeZoneBackend(false)
+	backend.seed(&v2.Zone{
+		ID:   22,
+		Name: "Old name",
+		Scopes: []v2.ZoneScope{
+			{ID: 1, TargetType: "kubernetes", Rules: `clusterId in ("non-existent")`},
+		},
+	})
+	srv := backend.server(t)
+	clientV1, clientV2 := zoneTestClients(t, srv.URL)
+
+	d := zoneRulesResourceData(t)
+	d.SetId("22")
+
+	diags := updateZone(context.Background(), d, clientV1, clientV2)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+
+	backend.mu.Lock()
+	name := backend.zones[22].Name
+	backend.mu.Unlock()
+	require.Equal(t, "Empty zone", name, "update should have gone through the v1 endpoint")
+}
+
+func TestZoneV1Fallback_DeleteFallsBackToV1(t *testing.T) {
+	backend := newFakeZoneBackend(false)
+	backend.seed(&v2.Zone{
+		ID:   22,
+		Name: "Empty zone",
+		Scopes: []v2.ZoneScope{
+			{ID: 1, TargetType: "kubernetes", Rules: `clusterId in ("non-existent")`},
+		},
+	})
+	srv := backend.server(t)
+	clientV1, clientV2 := zoneTestClients(t, srv.URL)
+
+	d := zoneRulesResourceData(t)
+	d.SetId("22")
+
+	diags := deleteZone(context.Background(), d, clientV1, clientV2)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+	require.False(t, backend.has(22), "zone should have been deleted through the v1 endpoint")
+}
+
+// Regression guard for SaaS: when the v2 endpoint is available, the provider
+// must keep using it and never touch v1 for non-legacy zones.
+func TestZoneV2Available_ReadDoesNotTouchV1(t *testing.T) {
+	backend := newFakeZoneBackend(true)
+	backend.seed(&v2.Zone{
+		ID:   22,
+		Name: "Empty zone",
+		Scopes: []v2.ZoneScope{
+			{ID: 1, TargetType: "kubernetes", Rules: `clusterId in ("non-existent")`},
+		},
+	})
+	srv := backend.server(t)
+	clientV1, clientV2 := zoneTestClients(t, srv.URL)
+
+	d := zoneRulesResourceData(t)
+	d.SetId("22")
+
+	diags := readZone(context.Background(), d, clientV1, clientV2)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+	require.Equal(t, "22", d.Id())
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Empty(t, backend.v1Hits, "v1 endpoint must not be called when v2 is available")
+	require.NotEmpty(t, backend.v2Hits)
+}
+
+// Regression guard for SaaS: deleting a zone that is already gone must still
+// succeed (DeleteZoneV2 returns 404, the v1 fallback tolerates it).
+func TestZoneV2Available_DeleteAlreadyGoneSucceeds(t *testing.T) {
+	backend := newFakeZoneBackend(true)
+	srv := backend.server(t)
+	clientV1, clientV2 := zoneTestClients(t, srv.URL)
+
+	d := zoneRulesResourceData(t)
+	d.SetId("22")
+
+	diags := deleteZone(context.Background(), d, clientV1, clientV2)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+	require.Empty(t, d.Id())
+}

--- a/website/docs/r/secure_zone.md
+++ b/website/docs/r/secure_zone.md
@@ -95,6 +95,8 @@ A `scope` defines what resources belong to this zone.
 
   A scope must specify either `rules` or at least one `expression` block.
 
+  ~> **Note:** Expression-based scopes require the v2 zones API. If the backend only exposes the v1 zones API, the provider automatically falls back to it for rules-based scopes, while expression-based scopes will fail with an explicit error. Use `rules` in that case.
+
 #### Expression block
 
 Each `expression` block represents a single condition.


### PR DESCRIPTION
Some backends only expose `/platform/v1/zones` and answer 404 on any `/platform/v2/zones` request. The provider classifies any zone whose `rules` don't contain legacy attribute names (`labels`, `labelValues`, `agentTags`) as v2-compatible — e.g. `clusterId in (...)` — and calls `/platform/v2/zones/{id}`. The 404 makes the provider treat the zone as deleted: it removes it from state and plans a duplicate create, forcing affected users to stay pinned on provider 3.5.0 and blocking every newer feature.

Since Zone v1 and v2 share the same data model server-side (only the serialization layer differs), CRUD on rules-based zones now falls back to v1 when v2 returns 404:

- **Read**: probe v1 before removing the zone from state, so a missing v2 route is no longer mistaken for a deleted zone. Also fixes `terraform import` on v1-only backends.
- **Create/Update**: retry through v1 for rules-based scopes; expression-based scopes fail with an explicit error (v2 zones API required) since they can't be represented in the v1 API.
- **Delete**: `DeleteZoneV2` no longer swallows 404 so the resource can fall back to v1, which still tolerates already-deleted zones — destroy of an already-gone zone keeps succeeding.

Behavior against backends with v2 available is unchanged: v1 is only contacted after a v2 404, which there only happens when the zone is really gone (one extra request in that path, same final behavior). Covered by unit tests with an httptest backend simulating both a v1-only and a v1+v2 deployment, including regression guards asserting v1 is never touched while v2 is available.