### PR TITLE
fix(secure-zone): ignore value order inside rules `in (...)` lists

### DIFF
--- a/sysdig/resource_sysdig_secure_zone.go
+++ b/sysdig/resource_sysdig_secure_zone.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
@@ -116,65 +120,183 @@ func resourceSysdigSecureZone() *schema.Resource {
 				Type:     schema.TypeSet,
 				MinItems: 1,
 				Required: true,
+				Set:      zoneScopeSetHash,
+				Elem:     zoneScopeResource(),
+			},
+		},
+	}
+}
+
+// zoneScopeResource is the schema of a single "scope" block. It is shared by the
+// resource schema and by zoneScopeSetHash so both always agree on the shape of
+// an element.
+func zoneScopeResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			SchemaIDKey: {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			SchemaTargetTypeKey: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			SchemaRulesKey: {
+				Type:     schema.TypeString,
+				Optional: true,
+				// The order of the values inside an `in (...)` list carries no
+				// meaning, so a mere reordering must not show up as a change.
+				DiffSuppressFunc: suppressZoneRulesValueOrder,
+				ValidateDiagFunc: func(v interface{}, path cty.Path) diag.Diagnostics {
+					rules := v.(string)
+					if rules != "" && legacyAttributePattern.MatchString(rules) {
+						return diag.Diagnostics{
+							diag.Diagnostic{
+								Severity: diag.Warning,
+								Summary:  "Deprecated legacy rules syntax",
+								Detail:   "The 'rules' field with legacy attributes (labels, labelValues, agentTags) is deprecated. Use 'expression' blocks or `rules` with v2 syntax (label.<key>, agent.tag.<key>) instead. See the documentation for migration guidance.",
+							},
+						}
+					}
+					return nil
+				},
+			},
+			SchemaExpressionKey: {
+				Type:     schema.TypeList,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						SchemaIDKey: {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						SchemaTargetTypeKey: {
+						SchemaFieldKey: {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						SchemaRulesKey: {
+						SchemaOperatorKey: {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						SchemaValueKey: {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateDiagFunc: func(v interface{}, path cty.Path) diag.Diagnostics {
-								rules := v.(string)
-								if rules != "" && legacyAttributePattern.MatchString(rules) {
-									return diag.Diagnostics{
-										diag.Diagnostic{
-											Severity: diag.Warning,
-											Summary:  "Deprecated legacy rules syntax",
-											Detail:   "The 'rules' field with legacy attributes (labels, labelValues, agentTags) is deprecated. Use 'expression' blocks or `rules` with v2 syntax (label.<key>, agent.tag.<key>) instead. See the documentation for migration guidance.",
-										},
-									}
-								}
-								return nil
-							},
+							Computed: true,
 						},
-						SchemaExpressionKey: {
+						SchemaValuesKey: {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									SchemaFieldKey: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									SchemaOperatorKey: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									SchemaValueKey: {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-									},
-									SchemaValuesKey: {
-										Type:     schema.TypeList,
-										Optional: true,
-										Computed: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-								},
-							},
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
 			},
 		},
 	}
+}
+
+// zoneRuleInListPattern matches an `in (...)` / `not in (...)` value list.
+var zoneRuleInListPattern = regexp.MustCompile(`(?i)\b(not\s+in|in)\s*\(([^()]*)\)`)
+
+// canonicalizeZoneRules rewrites every `in (...)` / `not in (...)` value list of
+// a rules expression into a canonical, sorted form. It is only used to compare
+// two rules strings: it is never written to state nor sent to the API, so the
+// user's own ordering is always preserved.
+//
+// Operators that do not take a value list (contains, starts with, exists, ...)
+// are left untouched.
+func canonicalizeZoneRules(rules string) string {
+	return zoneRuleInListPattern.ReplaceAllStringFunc(rules, func(match string) string {
+		groups := zoneRuleInListPattern.FindStringSubmatch(match)
+		operator, body := groups[1], groups[2]
+
+		values := splitZoneRuleValues(body)
+		sort.Strings(values)
+
+		return operator + " (" + strings.Join(values, ", ") + ")"
+	})
+}
+
+// splitZoneRuleValues splits the body of a value list on the commas that are not
+// inside a quoted value. Zone values legitimately contain commas, for instance
+// `agentTags in ("project: foo, bar")`, so a plain strings.Split would treat one
+// value as two and could make two different rules compare equal.
+func splitZoneRuleValues(body string) []string {
+	var (
+		values  []string
+		current strings.Builder
+		quoted  bool
+		escaped bool
+	)
+
+	for _, r := range body {
+		switch {
+		case escaped:
+			current.WriteRune(r)
+			escaped = false
+		case r == '\\':
+			current.WriteRune(r)
+			escaped = true
+		case r == '"':
+			quoted = !quoted
+			current.WriteRune(r)
+		case r == ',' && !quoted:
+			values = append(values, strings.TrimSpace(current.String()))
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if last := strings.TrimSpace(current.String()); last != "" {
+		values = append(values, last)
+	}
+
+	return values
+}
+
+// suppressZoneRulesValueOrder reports whether two rules strings differ only in
+// the order of the values inside their `in (...)` lists.
+//
+// An empty side is never suppressed: expression-based scopes carry an empty
+// rules string, and suppressing empty-vs-empty drops the attribute from the
+// planned scope block, which then fails the "rules or expression is required"
+// validation in CustomizeDiff.
+func suppressZoneRulesValueOrder(_, old, new string, _ *schema.ResourceData) bool {
+	if old == "" || new == "" {
+		return false
+	}
+	return canonicalizeZoneRules(old) == canonicalizeZoneRules(new)
+}
+
+// zoneScopeDefaultHash is the stock hash of a scope block. Building it is not
+// free, and the hash function is called for every element of every set, so it is
+// computed once.
+var zoneScopeDefaultHash = sync.OnceValue(func() schema.SchemaSetFunc {
+	return schema.HashResource(zoneScopeResource())
+})
+
+// zoneScopeSetHash hashes a scope block so that reordering the values inside a
+// rules expression does not change the identity of the block. Without this, a
+// reordering changes the set element hash and Terraform renders the scope as
+// removed and re-added even though nothing changed.
+//
+// Expression-based scopes deliberately keep the stock hash: their identity
+// depends on the nested `values`, and folding those into the hash would make two
+// distinct scope blocks that share a field and operator collide into one.
+func zoneScopeSetHash(v any) int {
+	hash := zoneScopeDefaultHash()
+
+	scope, ok := v.(map[string]any)
+	if !ok {
+		return hash(v)
+	}
+	rules, ok := scope[SchemaRulesKey].(string)
+	if !ok || rules == "" {
+		return hash(v)
+	}
+
+	canonical := make(map[string]any, len(scope))
+	maps.Copy(canonical, scope)
+	canonical[SchemaRulesKey] = canonicalizeZoneRules(rules)
+
+	return hash(canonical)
 }
 
 func resourceSysdigSecureZoneCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {

--- a/sysdig/resource_sysdig_secure_zone_rules_ordering_plan_test.go
+++ b/sysdig/resource_sysdig_secure_zone_rules_ordering_plan_test.go
@@ -1,0 +1,441 @@
+//go:build tf_acc_sysdig_secure
+
+package sysdig_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/draios/terraform-provider-sysdig/sysdig"
+	v2 "github.com/draios/terraform-provider-sysdig/sysdig/internal/client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests drive real plan/apply cycles against an in-process zones backend,
+// so they assert on what a user actually sees rather than on the shape of a diff.
+// They need no credentials: the provider is pointed at the fake server.
+
+// orderingBackend is a zones backend for the ordering tests.
+//
+//   - exposeV2 == false reproduces a deployment where only /platform/v1/zones is
+//     routed, so the provider goes through its v1 fallback.
+//   - sortValuesOnRead makes every read return the values of an `in (...)` list in
+//     a different order than they were written, reproducing a backend that does
+//     not preserve the order.
+type orderingBackend struct {
+	mu               sync.Mutex
+	exposeV2         bool
+	sortValuesOnRead bool
+	zones            map[int]*v2.ZoneV2
+	nextZoneID       int
+	nextScopeID      int
+}
+
+func newOrderingBackend(t *testing.T, exposeV2, sortValuesOnRead bool) *httptest.Server {
+	t.Helper()
+
+	b := &orderingBackend{
+		exposeV2:         exposeV2,
+		sortValuesOnRead: sortValuesOnRead,
+		zones:            map[int]*v2.ZoneV2{},
+		nextZoneID:       1,
+		nextScopeID:      1000,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/v1/zones", b.handleV1Collection(t))
+	mux.HandleFunc("/platform/v1/zones/", b.handleV1Item(t))
+	if exposeV2 {
+		mux.HandleFunc("/platform/v2/zones", b.handleV2Collection(t))
+		mux.HandleFunc("/platform/v2/zones/", b.handleV2Item(t))
+	}
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+var orderingValueListPattern = regexp.MustCompile(`\(([^()]*)\)`)
+
+// reorderValues returns the same rules expression with the values of every list
+// in a different order, so that a test can tell a semantic change apart from a
+// cosmetic one.
+func reorderValues(rules string) string {
+	return orderingValueListPattern.ReplaceAllStringFunc(rules, func(match string) string {
+		body := strings.TrimSuffix(strings.TrimPrefix(match, "("), ")")
+		values := strings.Split(body, ",")
+		for i := range values {
+			values[i] = strings.TrimSpace(values[i])
+		}
+		sort.Sort(sort.Reverse(sort.StringSlice(values)))
+		return "(" + strings.Join(values, ", ") + ")"
+	})
+}
+
+func (b *orderingBackend) store(zone *v2.ZoneV2) {
+	for i := range zone.Scopes {
+		for j := range zone.Scopes[i].Filters {
+			zone.Scopes[i].Filters[j].ID = b.nextScopeID
+			b.nextScopeID++
+		}
+	}
+	b.zones[zone.ID] = zone
+}
+
+// read returns the stored zone as the API would serialize it.
+func (b *orderingBackend) read(id int) (*v2.ZoneV2, bool) {
+	stored, ok := b.zones[id]
+	if !ok {
+		return nil, false
+	}
+
+	out := *stored
+	out.Scopes = make([]v2.ScopeV2, len(stored.Scopes))
+	for i, scope := range stored.Scopes {
+		filters := make([]v2.FilterV2, len(scope.Filters))
+		for j, filter := range scope.Filters {
+			if b.sortValuesOnRead && filter.Rules != "" {
+				filter.Rules = reorderValues(filter.Rules)
+			}
+			filters[j] = filter
+		}
+		out.Scopes[i] = v2.ScopeV2{Filters: filters}
+	}
+	return &out, true
+}
+
+func (b *orderingBackend) handleV2Collection(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var zone v2.ZoneV2
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&zone))
+		zone.ID = b.nextZoneID
+		b.nextZoneID++
+		b.store(&zone)
+
+		stored, _ := b.read(zone.ID)
+		writeOrderingJSON(t, w, stored)
+	}
+}
+
+func (b *orderingBackend) handleV2Item(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/platform/v2/zones/"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			stored, ok := b.read(id)
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			writeOrderingJSON(t, w, stored)
+		case http.MethodPut:
+			var zone v2.ZoneV2
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&zone))
+			zone.ID = id
+			b.store(&zone)
+			stored, _ := b.read(id)
+			writeOrderingJSON(t, w, stored)
+		case http.MethodDelete:
+			delete(b.zones, id)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func (b *orderingBackend) handleV1Collection(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var req v2.ZoneRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		zone := &v2.ZoneV2{ID: b.nextZoneID, Name: req.Name, Description: req.Description}
+		b.nextZoneID++
+		zone.Scopes = []v2.ScopeV2{{Filters: filtersFromV1(req.Scopes)}}
+		b.store(zone)
+
+		stored, _ := b.read(zone.ID)
+		writeOrderingJSON(t, w, zoneV1From(stored))
+	}
+}
+
+func (b *orderingBackend) handleV1Item(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/platform/v1/zones/"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			stored, ok := b.read(id)
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			writeOrderingJSON(t, w, zoneV1From(stored))
+		case http.MethodPut:
+			if _, ok := b.zones[id]; !ok {
+				http.NotFound(w, r)
+				return
+			}
+			var req v2.ZoneRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			zone := &v2.ZoneV2{ID: id, Name: req.Name, Description: req.Description}
+			zone.Scopes = []v2.ScopeV2{{Filters: filtersFromV1(req.Scopes)}}
+			b.store(zone)
+			stored, _ := b.read(id)
+			writeOrderingJSON(t, w, zoneV1From(stored))
+		case http.MethodDelete:
+			if _, ok := b.zones[id]; !ok {
+				http.NotFound(w, r)
+				return
+			}
+			delete(b.zones, id)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func filtersFromV1(scopes []v2.ZoneScope) []v2.FilterV2 {
+	filters := make([]v2.FilterV2, 0, len(scopes))
+	for _, scope := range scopes {
+		filters = append(filters, v2.FilterV2{ResourceType: scope.TargetType, Rules: scope.Rules})
+	}
+	return filters
+}
+
+func zoneV1From(zone *v2.ZoneV2) *v2.Zone {
+	out := &v2.Zone{ID: zone.ID, Name: zone.Name, Description: zone.Description}
+	for _, scope := range zone.Scopes {
+		for _, filter := range scope.Filters {
+			out.Scopes = append(out.Scopes, v2.ZoneScope{
+				ID:         filter.ID,
+				TargetType: filter.ResourceType,
+				Rules:      filter.Rules,
+			})
+		}
+	}
+	return out
+}
+
+func writeOrderingJSON(t *testing.T, w http.ResponseWriter, body any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(body))
+}
+
+func orderingProviderFactories() map[string]func() (*schema.Provider, error) {
+	return map[string]func() (*schema.Provider, error){
+		"sysdig": func() (*schema.Provider, error) {
+			return sysdig.Provider(), nil
+		},
+	}
+}
+
+func zoneRulesConfig(url, name, rules string) string {
+	return fmt.Sprintf(`
+provider "sysdig" {
+  sysdig_secure_url       = %q
+  sysdig_secure_api_token = "fake-token"
+}
+
+resource "sysdig_secure_zone" "test" {
+  name        = %q
+  description = "value ordering"
+
+  scope {
+    target_type = "kubernetes"
+    rules       = %q
+  }
+}
+`, url, name, rules)
+}
+
+const (
+	zoneRulesOriginalOrder = `clusterId in ("c2", "c1", "c4", "c3")`
+	zoneRulesSameValues    = `clusterId in ("c1", "c3", "c2", "c4")`
+	zoneRulesRealChange    = `clusterId in ("c1", "c3", "c2", "brand-new")`
+)
+
+// Reordering the values in the configuration must not plan any change. A
+// configuration that builds the list from a variable whose order is not stable
+// across runs would otherwise be dirty on every plan.
+func TestAccZoneRulesOrderingConfigReorderIsANoOp(t *testing.T) {
+	srv := newOrderingBackend(t, true, false)
+	name := randomText(10)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: orderingProviderFactories(),
+		Steps: []resource.TestStep{
+			{Config: zoneRulesConfig(srv.URL, name, zoneRulesOriginalOrder)},
+			{
+				Config:             zoneRulesConfig(srv.URL, name, zoneRulesSameValues),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// The same must hold when it is the backend that returns the values in another
+// order: a refresh alone used to be enough to make the plan permanently dirty.
+func TestAccZoneRulesOrderingBackendReorderIsANoOp(t *testing.T) {
+	srv := newOrderingBackend(t, true, true)
+	name := randomText(10)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: orderingProviderFactories(),
+		Steps: []resource.TestStep{
+			{Config: zoneRulesConfig(srv.URL, name, zoneRulesOriginalOrder)},
+			{
+				Config:             zoneRulesConfig(srv.URL, name, zoneRulesOriginalOrder),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Same as above on a deployment that only routes /platform/v1/zones, where the
+// provider falls back to the v1 API.
+func TestAccZoneRulesOrderingV1OnlyBackend(t *testing.T) {
+	srv := newOrderingBackend(t, false, false)
+	name := randomText(10)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: orderingProviderFactories(),
+		Steps: []resource.TestStep{
+			{Config: zoneRulesConfig(srv.URL, name, zoneRulesOriginalOrder)},
+			{
+				Config:             zoneRulesConfig(srv.URL, name, zoneRulesSameValues),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Ignoring the order must not turn into ignoring the values.
+func TestAccZoneRulesOrderingRealChangeIsApplied(t *testing.T) {
+	srv := newOrderingBackend(t, true, false)
+	name := randomText(10)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: orderingProviderFactories(),
+		Steps: []resource.TestStep{
+			{Config: zoneRulesConfig(srv.URL, name, zoneRulesOriginalOrder)},
+			{
+				Config: zoneRulesConfig(srv.URL, name, zoneRulesRealChange),
+				Check: resource.TestCheckTypeSetElemNestedAttrs(
+					"sysdig_secure_zone.test", "scope.*",
+					map[string]string{"rules": zoneRulesRealChange},
+				),
+			},
+			{
+				Config:             zoneRulesConfig(srv.URL, name, zoneRulesRealChange),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func zoneExpressionConfig(url, name string, values ...string) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = fmt.Sprintf("%q", v)
+	}
+
+	return fmt.Sprintf(`
+provider "sysdig" {
+  sysdig_secure_url       = %q
+  sysdig_secure_api_token = "fake-token"
+}
+
+resource "sysdig_secure_zone" "test" {
+  name        = %q
+  description = "value ordering"
+
+  scope {
+    target_type = "kubernetes"
+    expression {
+      field    = "kubernetes.cluster.name"
+      operator = "in"
+      values   = [%s]
+    }
+  }
+
+  scope {
+    target_type = "host"
+    expression {
+      field    = "host.hostName"
+      operator = "in"
+      values   = ["h1", "h2"]
+    }
+  }
+}
+`, url, name, strings.Join(quoted, ", "))
+}
+
+// Expression-based scopes keep the stock set hash. Two scope blocks must stay
+// distinct, and updating the values of one must still work.
+func TestAccZoneRulesOrderingExpressionScopesAreUnaffected(t *testing.T) {
+	srv := newOrderingBackend(t, true, false)
+	name := randomText(10)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: orderingProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: zoneExpressionConfig(srv.URL, name, "c1", "c2"),
+				Check:  resource.TestCheckResourceAttr("sysdig_secure_zone.test", "scope.#", "2"),
+			},
+			{
+				Config: zoneExpressionConfig(srv.URL, name, "c1", "brand-new"),
+				Check:  resource.TestCheckResourceAttr("sysdig_secure_zone.test", "scope.#", "2"),
+			},
+			{
+				Config:             zoneExpressionConfig(srv.URL, name, "c1", "brand-new"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}

--- a/sysdig/resource_sysdig_secure_zone_rules_ordering_test.go
+++ b/sysdig/resource_sysdig_secure_zone_rules_ordering_test.go
@@ -1,0 +1,359 @@
+//go:build unit
+
+package sysdig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+// The value order inside an `in (...)` list carries no meaning. These tests pin
+// down that the provider treats it that way without ever equating two rules that
+// actually differ.
+
+func TestCanonicalizeZoneRules(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "sorts values",
+			in:   `clusterId in ("c", "a", "b")`,
+			want: `clusterId in ("a", "b", "c")`,
+		},
+		{
+			name: "already sorted is unchanged",
+			in:   `clusterId in ("a", "b", "c")`,
+			want: `clusterId in ("a", "b", "c")`,
+		},
+		{
+			name: "normalizes missing spaces after commas",
+			in:   `clusterId in ("b","a")`,
+			want: `clusterId in ("a", "b")`,
+		},
+		{
+			name: "handles every list of a compound expression",
+			in:   `clusterId in ("b", "a") and label.team in ("z", "y")`,
+			want: `clusterId in ("a", "b") and label.team in ("y", "z")`,
+		},
+		{
+			name: "handles not in",
+			in:   `clusterId not in ("b", "a")`,
+			want: `clusterId not in ("a", "b")`,
+		},
+		{
+			name: "operator casing is preserved",
+			in:   `clusterId IN ("b", "a")`,
+			want: `clusterId IN ("a", "b")`,
+		},
+		{
+			name: "keeps a comma that belongs to a value",
+			in:   `agentTags in ("project: x", "project: foo, bar")`,
+			want: `agentTags in ("project: foo, bar", "project: x")`,
+		},
+		{
+			name: "handles escaped quotes inside a value",
+			in:   `name in ("h\"2", "h1")`,
+			want: `name in ("h1", "h\"2")`,
+		},
+		{
+			name: "single value",
+			in:   `clusterId in ("a")`,
+			want: `clusterId in ("a")`,
+		},
+		{
+			name: "empty list",
+			in:   `clusterId in ()`,
+			want: `clusterId in ()`,
+		},
+		{
+			name: "leaves contains untouched, even with a comma",
+			in:   `name contains "foo, bar"`,
+			want: `name contains "foo, bar"`,
+		},
+		{
+			name: "leaves exists untouched",
+			in:   `label.env exists`,
+			want: `label.env exists`,
+		},
+		{
+			name: "empty rules",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := canonicalizeZoneRules(tt.in)
+			require.Equal(t, tt.want, got)
+			require.Equal(t, got, canonicalizeZoneRules(got), "canonicalization must be idempotent")
+		})
+	}
+}
+
+func TestCanonicalizeZoneRulesNeverEquatesDifferentRules(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{
+			name: "different value",
+			a:    `clusterId in ("a", "b")`,
+			b:    `clusterId in ("a", "c")`,
+		},
+		{
+			name: "extra value",
+			a:    `clusterId in ("a", "b")`,
+			b:    `clusterId in ("a", "b", "c")`,
+		},
+		{
+			name: "duplicate instead of distinct values",
+			a:    `clusterId in ("a", "b")`,
+			b:    `clusterId in ("a", "a")`,
+		},
+		{
+			name: "one value with a comma vs two values",
+			a:    `agentTags in ("project: foo, bar")`,
+			b:    `agentTags in ("project: foo", "bar")`,
+		},
+		{
+			name: "different field",
+			a:    `clusterId in ("a", "b")`,
+			b:    `name in ("a", "b")`,
+		},
+		{
+			name: "different operator",
+			a:    `clusterId in ("a", "b")`,
+			b:    `clusterId not in ("a", "b")`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotEqual(t, canonicalizeZoneRules(tt.a), canonicalizeZoneRules(tt.b))
+		})
+	}
+}
+
+func TestSuppressZoneRulesValueOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want bool
+	}{
+		{
+			name: "reordering is suppressed",
+			old:  `clusterId in ("b", "a")`,
+			new:  `clusterId in ("a", "b")`,
+			want: true,
+		},
+		{
+			name: "a real change is not suppressed",
+			old:  `clusterId in ("a", "b")`,
+			new:  `clusterId in ("a", "c")`,
+			want: false,
+		},
+		{
+			// An expression-based scope carries an empty rules string. Suppressing
+			// it would drop the attribute from the planned scope block.
+			name: "empty on both sides is not suppressed",
+			old:  "",
+			new:  "",
+			want: false,
+		},
+		{
+			name: "rules being set is not suppressed",
+			old:  "",
+			new:  `clusterId in ("a")`,
+			want: false,
+		},
+		{
+			name: "rules being cleared is not suppressed",
+			old:  `clusterId in ("a")`,
+			new:  "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, suppressZoneRulesValueOrder("scope.0.rules", tt.old, tt.new, nil))
+		})
+	}
+}
+
+func rulesScope(id int, targetType, rules string) map[string]any {
+	return map[string]any{
+		SchemaIDKey:         id,
+		SchemaTargetTypeKey: targetType,
+		SchemaRulesKey:      rules,
+		SchemaExpressionKey: []any{},
+	}
+}
+
+func TestZoneScopeSetHashIgnoresRulesValueOrder(t *testing.T) {
+	base := rulesScope(0, "kubernetes", `clusterId in ("b", "a", "c")`)
+	reordered := rulesScope(0, "kubernetes", `clusterId in ("a", "c", "b")`)
+
+	require.Equal(t, zoneScopeSetHash(base), zoneScopeSetHash(reordered),
+		"reordering the values must not change the identity of a scope block")
+}
+
+func TestZoneScopeSetHashDistinguishesRealDifferences(t *testing.T) {
+	base := rulesScope(0, "kubernetes", `clusterId in ("a", "b")`)
+
+	tests := map[string]map[string]any{
+		"different value":       rulesScope(0, "kubernetes", `clusterId in ("a", "c")`),
+		"extra value":           rulesScope(0, "kubernetes", `clusterId in ("a", "b", "c")`),
+		"different target type": rulesScope(0, "host", `clusterId in ("a", "b")`),
+		"different field":       rulesScope(0, "kubernetes", `name in ("a", "b")`),
+	}
+
+	for name, other := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NotEqual(t, zoneScopeSetHash(base), zoneScopeSetHash(other))
+		})
+	}
+}
+
+func TestZoneScopeSetHashIgnoresComputedID(t *testing.T) {
+	// The state holds a server-assigned id, the configuration does not. If the id
+	// took part in the hash, a configured block could never match its own state.
+	withID := rulesScope(5179, "kubernetes", `clusterId in ("a", "b")`)
+	withoutID := rulesScope(0, "kubernetes", `clusterId in ("a", "b")`)
+
+	require.Equal(t, zoneScopeSetHash(withID), zoneScopeSetHash(withoutID))
+}
+
+func TestZoneScopeSetHashKeepsExpressionScopesDistinct(t *testing.T) {
+	// Expression scopes fall back to the stock hash on purpose: two blocks that
+	// share a field and an operator must not collapse into one.
+	expressionScope := func(values ...string) map[string]any {
+		vals := make([]any, len(values))
+		for i, v := range values {
+			vals[i] = v
+		}
+		return map[string]any{
+			SchemaIDKey:         0,
+			SchemaTargetTypeKey: "kubernetes",
+			SchemaRulesKey:      "",
+			SchemaExpressionKey: []any{
+				map[string]any{
+					SchemaFieldKey:    "kubernetes.cluster.name",
+					SchemaOperatorKey: "in",
+					SchemaValueKey:    "",
+					SchemaValuesKey:   vals,
+				},
+			},
+		}
+	}
+
+	require.NotEqual(t,
+		zoneScopeSetHash(expressionScope("a1", "a2")),
+		zoneScopeSetHash(expressionScope("b1", "b2")),
+		"distinct expression scopes must not collide")
+}
+
+// zoneDiff computes the diff the SDK would produce for a zone whose state holds
+// stateScopes and whose configuration holds configScopes.
+func zoneDiff(t *testing.T, stateScopes, configScopes []any) *terraform.InstanceDiff {
+	t.Helper()
+
+	r := resourceSysdigSecureZone()
+
+	d := r.Data(&terraform.InstanceState{ID: "314"})
+	require.NoError(t, d.Set(SchemaNameKey, "zone"))
+	require.NoError(t, d.Set(SchemaScopeKey, stateScopes))
+	state := d.State()
+	state.ID = "314"
+
+	config := terraform.NewResourceConfigRaw(map[string]any{
+		SchemaNameKey:  "zone",
+		SchemaScopeKey: configScopes,
+	})
+
+	diff, err := r.Diff(context.Background(), state, config, nil)
+	require.NoError(t, err)
+	return diff
+}
+
+func configScope(targetType, rules string) map[string]any {
+	return map[string]any{
+		SchemaTargetTypeKey: targetType,
+		SchemaRulesKey:      rules,
+	}
+}
+
+func TestZoneDiffIgnoresRulesValueReordering(t *testing.T) {
+	diff := zoneDiff(t,
+		[]any{rulesScope(5179, "kubernetes", `clusterId in ("c2", "c1", "c3")`)},
+		[]any{configScope("kubernetes", `clusterId in ("c3", "c2", "c1")`)},
+	)
+
+	require.True(t, diff == nil || diff.Empty(), "reordering the values must not produce a diff, got %#v", diff)
+}
+
+func TestZoneDiffIgnoresReorderingInOneOfSeveralScopes(t *testing.T) {
+	diff := zoneDiff(t,
+		[]any{
+			rulesScope(5179, "kubernetes", `clusterId in ("c2", "c1")`),
+			rulesScope(5180, "host", `name in ("h1", "h2")`),
+		},
+		[]any{
+			configScope("kubernetes", `clusterId in ("c1", "c2")`),
+			configScope("host", `name in ("h1", "h2")`),
+		},
+	)
+
+	require.True(t, diff == nil || diff.Empty(), "got %#v", diff)
+}
+
+func TestZoneDiffStillDetectsRealChanges(t *testing.T) {
+	tests := map[string]string{
+		"replaced value": `clusterId in ("c1", "brand-new")`,
+		"added value":    `clusterId in ("c1", "c2", "c3")`,
+		"removed value":  `clusterId in ("c1")`,
+	}
+
+	for name, configRules := range tests {
+		t.Run(name, func(t *testing.T) {
+			diff := zoneDiff(t,
+				[]any{rulesScope(5179, "kubernetes", `clusterId in ("c1", "c2")`)},
+				[]any{configScope("kubernetes", configRules)},
+			)
+
+			require.NotNil(t, diff)
+			require.False(t, diff.Empty(), "a real change must still be planned")
+		})
+	}
+}
+
+func TestZoneDiffStillDetectsTargetTypeChange(t *testing.T) {
+	diff := zoneDiff(t,
+		[]any{rulesScope(5179, "kubernetes", `clusterId in ("c1", "c2")`)},
+		[]any{configScope("host", `clusterId in ("c1", "c2")`)},
+	)
+
+	require.NotNil(t, diff)
+	require.False(t, diff.Empty())
+}
+
+func TestZoneScopeSchemaUsesTheOrderInsensitiveHash(t *testing.T) {
+	// Guards against the schema being rewritten without the custom hash, which
+	// would silently bring the spurious diffs back.
+	scope := resourceSysdigSecureZone().Schema[SchemaScopeKey]
+	require.NotNil(t, scope.Set, "the scope set must use zoneScopeSetHash")
+
+	elem, ok := scope.Elem.(*schema.Resource)
+	require.True(t, ok)
+	require.NotNil(t, elem.Schema[SchemaRulesKey].DiffSuppressFunc,
+		"rules must keep its DiffSuppressFunc")
+}

--- a/website/docs/r/secure_zone.md
+++ b/website/docs/r/secure_zone.md
@@ -91,6 +91,8 @@ A `scope` defines what resources belong to this zone.
 
   ~> **Note:** The `rules` field supports both v2 and legacy (v1) syntax. When using legacy v1 attributes (`labels`, `labelValues`, `agentTags`), a deprecation warning will be shown — migrate to `expression` blocks with v2 field names (`label.<key>`, `agent.tag.<key>`). Rules using v2-compatible syntax (e.g., `organization`, `account`, `cluster`) are fully supported and produce no warning. `rules` and `expression` cannot be used together within the same `scope`.
 
+  ~> **Note:** The order of the values inside an `in (...)` or `not in (...)` list is not significant, so reordering them does not plan a change. This matters when the list is generated, for example with `join` and `formatlist` over a variable whose order is not stable across runs. The order you write is always preserved in state and sent to the API as-is. Value order inside `expression` blocks is still significant: use `sort()` there if the source list order may vary.
+
 - `expression` - One or more blocks that define the scope as a list of filter expressions.
 
   A scope must specify either `rules` or at least one `expression` block.


### PR DESCRIPTION
The order of the values inside an `in (...)` list carries no meaning, but `rules` is compared as an opaque string and the scope set hash is derived from it. A configuration that builds the list from a variable whose order is not stable across runs therefore plans a change on every run, rendered as the scope block being removed and re-added:

```
  ~ resource "sysdig_secure_zone" "zone_dynamic" {
      - scope {
          - id          = 5179 -> null
          - rules       = "clusterId in (\"c2\", \"c1\", \"c3\")" -> null
          - target_type = "kubernetes" -> null
        }
      + scope {
          + id          = (known after apply)
          + rules       = "clusterId in (\"c1\", \"c3\", \"c2\")"
          + target_type = "kubernetes"
        }
    }
```

The same happens when the backend returns the values in a different order than they were written: a plain refresh is then enough to leave the plan permanently dirty, because the reordering is written back to state on every read.

A rules-based scope is now hashed over a canonical form of `rules`, and a diff that is only a reordering is suppressed. The canonical form is used for comparison only, so the order the user wrote is still what lands in state and what is sent to the API. The splitter that finds the values is quote-aware, since values legitimately contain commas (`agentTags in ("project: foo, bar")`) and a naive split could make two different rules compare equal.

Expression-based scopes deliberately keep the stock hash: their identity depends on the nested `values`, and folding those into the hash makes two distinct scope blocks that share a field and an operator collide into one, silently dropping a scope. Value order inside `expression` blocks therefore remains significant, and the docs say so.

Both alternatives were tried and rejected with evidence: normalizing in `CustomizeDiff` is not possible (`SetNew` only operates on computed keys, and `scope` is required), and switching `expression.values` to `TypeSet` breaks the round trip (state comes back empty because of the `value`/`values` computed pair). Making expression value order insignificant needs that separate change plus a state upgrader, and is left out of this PR.

Three of the new plan-level tests fail without the schema change and pass with it; the other two are regression guards that must pass either way.