### PR TITLE
fix(secure): persist API-returned version on Falco element updates

### DIFF
--- a/sysdig/resource_sysdig_secure_list.go
+++ b/sysdig/resource_sysdig_secure_list.go
@@ -94,11 +94,13 @@ func resourceSysdigListUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	id, _ := strconv.Atoi(d.Id())
 	list.ID = id
 
-	_, err = client.UpdateList(ctx, list)
+	updatedList, err := client.UpdateList(ctx, list)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
+	_ = d.Set("version", updatedList.Version)
 
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_macro.go
+++ b/sysdig/resource_sysdig_secure_macro.go
@@ -94,11 +94,13 @@ func resourceSysdigMacroUpdate(ctx context.Context, d *schema.ResourceData, meta
 	id, _ := strconv.Atoi(d.Id())
 	macro.ID = id
 
-	_, err = client.UpdateMacro(ctx, macro)
+	updatedMacro, err := client.UpdateMacro(ctx, macro)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
+	_ = d.Set("version", updatedMacro.Version)
 
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_macro_test.go
+++ b/sysdig/resource_sysdig_secure_macro_test.go
@@ -4,6 +4,7 @@ package sysdig_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -120,5 +121,81 @@ resource "sysdig_secure_macro" "sample" {
 	name = "terraform_test_%s"
 	condition = "always_true"
   }
+`, name)
+}
+
+// TestAccMacroVersionIsPersistedOnUpdate guards against the update path dropping
+// the version returned by the API. The resource sends the version it holds in
+// state on update; if the response version is not written back, state keeps the
+// pre-update value while the backend has already moved on.
+func TestAccMacroVersionIsPersistedOnUpdate(t *testing.T) {
+	name := randomText(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: preCheckAnyEnv(t, SysdigSecureApiTokenEnv),
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: macroWithName(name),
+				Check:  resource.TestCheckResourceAttr("sysdig_secure_macro.sample", "version", "1"),
+			},
+			{
+				// An in-place update bumps the backend version to 2; state must agree.
+				Config: macroUpdatedWithName(name),
+				Check:  resource.TestCheckResourceAttr("sysdig_secure_macro.sample", "version", "2"),
+			},
+		},
+	})
+}
+
+// TestAccMacroAppendToCustomMacro covers appending a macro the customer owns,
+// rather than one Sysdig ships (which macroAppendToDefault already covers).
+//
+// This is only supported on backends that migrated to the v2 macro storage.
+// Earlier backends reject it with "The field 'name' must not be the same as
+// another Secure UI macro", so the test is opt-in via SYSDIG_SECURE_MACROS_V2.
+func TestAccMacroAppendToCustomMacro(t *testing.T) {
+	if os.Getenv("SYSDIG_SECURE_MACROS_V2") == "" {
+		t.Skip("Skipping append-to-custom-macro test because SYSDIG_SECURE_MACROS_V2 is not set")
+		return
+	}
+
+	name := randomText(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: preCheckAnyEnv(t, SysdigSecureApiTokenEnv),
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"sysdig": func() (*schema.Provider, error) {
+				return sysdig.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: macroAppendToCustomMacro(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sysdig_secure_macro.base", "append", "false"),
+					resource.TestCheckResourceAttr("sysdig_secure_macro.extension", "append", "true"),
+				),
+			},
+		},
+	})
+}
+
+func macroAppendToCustomMacro(name string) string {
+	return fmt.Sprintf(`
+resource "sysdig_secure_macro" "base" {
+  name      = "terraform_test_%s"
+  condition = "proc.name = foo"
+}
+
+resource "sysdig_secure_macro" "extension" {
+  name      = sysdig_secure_macro.base.name
+  condition = "or proc.name = bar"
+  append    = true
+}
 `, name)
 }

--- a/sysdig/resource_sysdig_secure_rule_container.go
+++ b/sysdig/resource_sysdig_secure_rule_container.go
@@ -116,11 +116,13 @@ func resourceSysdigRuleContainerUpdate(ctx context.Context, d *schema.ResourceDa
 	rule.Version = d.Get("version").(int)
 	rule.ID, _ = strconv.Atoi(d.Id())
 
-	_, err = client.UpdateRule(ctx, rule)
+	updatedRule, err := client.UpdateRule(ctx, rule)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
+	_ = d.Set("version", updatedRule.Version)
 
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_rule_filesystem.go
+++ b/sysdig/resource_sysdig_secure_rule_filesystem.go
@@ -165,11 +165,13 @@ func resourceSysdigRuleFilesystemUpdate(ctx context.Context, d *schema.ResourceD
 	rule.Version = d.Get("version").(int)
 	rule.ID, _ = strconv.Atoi(d.Id())
 
-	_, err = client.UpdateRule(ctx, rule)
+	updatedRule, err := client.UpdateRule(ctx, rule)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
+	_ = d.Set("version", updatedRule.Version)
 
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_rule_network.go
+++ b/sysdig/resource_sysdig_secure_rule_network.go
@@ -191,11 +191,13 @@ func resourceSysdigRuleNetworkUpdate(ctx context.Context, d *schema.ResourceData
 	rule.Version = d.Get("version").(int)
 	rule.ID, _ = strconv.Atoi(d.Id())
 
-	_, err = client.UpdateRule(ctx, rule)
+	updatedRule, err := client.UpdateRule(ctx, rule)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
+	_ = d.Set("version", updatedRule.Version)
 
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_rule_process.go
+++ b/sysdig/resource_sysdig_secure_rule_process.go
@@ -116,11 +116,13 @@ func resourceSysdigRuleProcessUpdate(ctx context.Context, d *schema.ResourceData
 	rule.Version = d.Get("version").(int)
 	rule.ID, _ = strconv.Atoi(d.Id())
 
-	_, err = client.UpdateRule(ctx, rule)
+	updatedRule, err := client.UpdateRule(ctx, rule)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
+	_ = d.Set("version", updatedRule.Version)
 
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_rule_stateful.go
+++ b/sysdig/resource_sysdig_secure_rule_stateful.go
@@ -207,10 +207,12 @@ func resourceSysdigRuleStatefulUpdate(ctx context.Context, d *schema.ResourceDat
 
 	rule.ID = id
 
-	_, err = client.UpdateStatefulRule(ctx, rule)
+	updatedRule, err := client.UpdateStatefulRule(ctx, rule)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	_ = d.Set("version", updatedRule.Version)
 
 	return nil
 }

--- a/sysdig/resource_sysdig_secure_rule_syscall.go
+++ b/sysdig/resource_sysdig_secure_rule_syscall.go
@@ -115,11 +115,13 @@ func resourceSysdigRuleSyscallUpdate(ctx context.Context, d *schema.ResourceData
 	rule.Version = d.Get("version").(int)
 	rule.ID, _ = strconv.Atoi(d.Id())
 
-	_, err = client.UpdateRule(ctx, rule)
+	updatedRule, err := client.UpdateRule(ctx, rule)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
+
+	_ = d.Set("version", updatedRule.Version)
 
 	return nil
 }

--- a/website/docs/r/secure_macro.md
+++ b/website/docs/r/secure_macro.md
@@ -15,15 +15,21 @@ Creates a Sysdig Secure Falco Macro.
 ## Example Usage
 
 ```terraform
-resource "sysdig_secure_macro" "http_port" {
-  name = "web_port"
+resource "sysdig_secure_macro" "web_port" {
+  name      = "web_port"
   condition = "fd.sport=80"
 }
+```
 
-resource "sysdig_secure_macro" "https_port" {
-  name = "web_port"
-  condition = "or fd.sport=443"
-  append = true # default: false
+To extend a macro that Sysdig ships, create a macro with the same `name` and
+`append = true`. The condition is concatenated onto the existing one, so it must
+begin with a logical operator (`or` / `and`):
+
+```terraform
+resource "sysdig_secure_macro" "allow_my_etc_writer" {
+  name      = "user_known_write_below_etc_activities"
+  condition = "or (proc.name = my_installer and fd.name startswith /etc/myapp/)"
+  append    = true # default: false
 }
 ```
 
@@ -33,9 +39,14 @@ resource "sysdig_secure_macro" "https_port" {
 
 * `condition` - (Required) Macro condition. It can contain lists or other macros.
 
-* `append` - (Optional)  Adds these elements to an existing macro. Used to extend existing macros provided by Sysdig.
-    The macros can only be extended once, for example if there is an existing macro called "foo", one can have another 
-    append macro called "foo" but not a second one. By default this is false.
+* `append` - (Optional) Adds these elements to an existing macro. Used to extend existing macros provided by Sysdig.
+    A macro of the same `name` must already exist, and `condition` must begin with a logical operator (`or` / `and`)
+    because it is concatenated onto the existing condition. By default this is false.
+
+    ~> **Note:** Appending a macro that you created yourself (rather than one provided by Sysdig) is only supported on
+    backends that have migrated to the v2 macro storage. On earlier backends the create fails with
+    `The field 'name' must not be the same as another Secure UI macro`. Appending a Sysdig-provided macro works on all
+    backends. On earlier backends a macro can also only be extended once; newer backends do not enforce that limit.
 
 * `minimum_engine_version` - (Optional) This is used to indicate that the macro requires a minimum engine version. This
     can allow you to add macros that would not normally pass validation with older agents in your environment. The macro


### PR DESCRIPTION
## What

The `Update` path of the Falco element resources sends the `version` held in state to the API, then discards the `version` returned in the response. `Create` already writes it back, so after any successful update state kept the pre-update version while the backend had moved on.

Fixed in `sysdig_secure_macro`, `sysdig_secure_list`, and the `container`, `filesystem`, `network`, `process`, `stateful` and `syscall` rule resources — all following the pattern `sysdig_secure_rule_falco` already used.

```go
-	_, err = client.UpdateMacro(ctx, macro)
+	updatedMacro, err := client.UpdateMacro(ctx, macro)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	sysdigClients.AddCleanupHook(sendPoliciesToAgents)
 
+	_ = d.Set("version", updatedMacro.Version)
```

## Impact

Latent today, worth fixing now. The v2 macro service performs no version comparison, and `Read` repopulates the field on the next refresh, so ordinary applies self-heal. It becomes user-visible the moment the backend treats `version` as an optimistic concurrency token — every second consecutive update would fail with a spurious conflict. It also already sends a knowingly stale value on `-refresh=false` runs and saved plans, and `terraform state show` reports a version the backend does not have.

Observed against an onprem backend before the fix: macro at server version 2 while state reported 1; a further `-refresh=false` update sent version 1 and the server advanced to 3.

## Documentation

The `sysdig_secure_macro` example appended a macro the customer had just created. Backends that have not migrated to the v2 macro storage reject that with `The field 'name' must not be the same as another Secure UI macro`, so the resource's primary documented example failed outright for those users. The example now appends a Sysdig-provided macro, which works on every backend.

The `append` note now also records that appending a customer-owned macro requires a migrated backend, that the appended condition must begin with a logical operator, and that the "extend only once" limit applies to earlier backends but is not enforced by newer ones.

## Tests

- **`TestAccMacroVersionIsPersistedOnUpdate`** — asserts `version` is `1` after create and `2` after an in-place update. Fails on the unfixed code with `Attribute 'version' expected "2", got "1"`.
- **`TestAccMacroAppendToCustomMacro`** — covers appending a customer-owned macro. Existing coverage only appended a Sysdig-provided macro (`macroAppendToDefault` uses `container`), which is why the documentation problem went unnoticed. Opt-in via `SYSDIG_SECURE_MACROS_V2` since it cannot pass on unmigrated backends.

`go build ./...`, `go vet` (incl. acceptance tags) and `gofmt` are clean. Acceptance run against an onprem backend:

| Test | Result |
|---|---|
| `TestAccMacroVersionIsPersistedOnUpdate` | PASS (FAIL on unfixed code, as intended) |
| `TestAccMacroAppendToCustomMacro` | PASS |
| `TestAccList` | PASS |
| `TestAccRuleFalcoTerminalShell`, `...WithMinimumEngineVersion` | PASS |
| `TestAccRuleFalcoDataSource`, `TestAccRuleFalcoCountDataSource` | PASS |

The rule resource changes are compile-verified only: `TestAccRuleContainer` / `Filesystem` / `Network` / `Process` / `Syscall` are unconditionally skipped in the repo (`List matching rules are deprecated - skipping tests`).

Two pre-existing failures on that environment, unrelated to this change and reproduced identically on unmodified `master`:

- `TestAccMacro` step 6/7 — `Undefined macro '<name>' used in filter` when a macro references another custom macro created in the same apply. Reproduces on `master`; step number and resource vary between runs, so it looks like a race in the v2 validation path rather than anything in this diff.
- `TestAccRuleStatefulDataSource` / `...CountDataSource` — `cannot append to a non-existent rule 'API Gateway Enumeration Detected'`; that default rule is absent on this backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)