### PR TITLE
fix(client): redact credentials from TF_LOG=DEBUG dumps

### DIFF
--- a/sysdig/internal/client/v2/client.go
+++ b/sysdig/internal/client/v2/client.go
@@ -36,19 +36,51 @@ const (
 
 var errMissingCurrentTeam = errors.New("missing user's current team")
 
-// sensitiveHeaderRe redacts the Authorization header from HTTP dumps.
-var sensitiveHeaderRe = regexp.MustCompile(`(?i)(\r?\n` + AuthorizationHeader + `: )[^\r\n]*`)
+// sensitiveHeaderRe redacts the value of any header whose name looks like it
+// carries a credential (Authorization, Proxy-Authorization, X-Api-Key, ...),
+// rather than matching only the literal "Authorization" header.
+var sensitiveHeaderRe = regexp.MustCompile(`(?im)^([\w-]*(?:auth|key|token|secret|password|credential)[\w-]*:[ \t]*).*$`)
 
-// sensitiveJSONFieldRe redacts well-known secret fields (e.g. the customer
-// accessKey returned by GetMePath) from HTTP dumps.
-var sensitiveJSONFieldRe = regexp.MustCompile(`(?i)("(?:accessKey|accessKeySecret|password|secret|token)"\s*:\s*)"[^"]*"`)
+// sensitiveJSONFieldRe redacts the value of any JSON field whose name looks
+// like it carries a credential (accessKey, apiKey, access_token,
+// clientSecret, publicToken, routingKey, serviceKey, ...). The value pattern
+// is escape-aware so it doesn't stop early on an escaped quote inside the
+// secret and leak the remainder.
+var sensitiveJSONFieldRe = regexp.MustCompile(`(?i)("\w*(?:key|token|secret|password|credential)\w*"\s*:\s*)"(?:[^"\\]|\\.)*"`)
 
-// redactDump scrubs sensitive headers and JSON fields out of a raw HTTP
-// request/response dump before it is written to the debug log.
-func redactDump(dump []byte) string {
-	redacted := sensitiveHeaderRe.ReplaceAllString(string(dump), "${1}<REDACTED>")
+// sensitiveFormFieldRe redacts the value of any x-www-form-urlencoded (or
+// URL query string) field whose name looks like it carries a credential,
+// e.g. IBM IAM's "apikey=..." token-exchange request body.
+var sensitiveFormFieldRe = regexp.MustCompile(`(?i)(\w*(?:key|token|secret|password|credential)\w*=)[^&\s"]*`)
+
+// redactDump scrubs sensitive headers, JSON fields, form-encoded values, and
+// any already-known credential values out of a raw HTTP request/response
+// dump before it is written to the debug log. knownSecrets covers values
+// that a name-based pattern might miss (e.g. a secret sent under a header
+// name we didn't anticipate).
+func redactDump(dump []byte, knownSecrets ...string) string {
+	redacted := string(dump)
+	for _, secret := range knownSecrets {
+		if secret == "" {
+			continue
+		}
+		redacted = strings.ReplaceAll(redacted, secret, "<REDACTED>")
+	}
+	redacted = sensitiveHeaderRe.ReplaceAllString(redacted, "${1}<REDACTED>")
 	redacted = sensitiveJSONFieldRe.ReplaceAllString(redacted, `${1}"<REDACTED>"`)
+	redacted = sensitiveFormFieldRe.ReplaceAllString(redacted, "${1}<REDACTED>")
 	return redacted
+}
+
+// knownSecrets returns the credential values the provider itself configured
+// for this client, so they get scrubbed from debug dumps even where they
+// show up under a header/field name the patterns above don't anticipate.
+func knownSecrets(cfg *config) []string {
+	secrets := []string{cfg.token, cfg.ibmAPIKey}
+	for _, v := range cfg.extraHeaders {
+		secrets = append(secrets, v)
+	}
+	return secrets
 }
 
 type Base interface {
@@ -187,12 +219,14 @@ func request(httpClient *http.Client, cfg *config, request *http.Request) (*http
 		}
 	}
 
+	secrets := knownSecrets(cfg)
+
 	out, err := httputil.DumpRequestOut(request, true)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Printf("[DEBUG] %s", redactDump(out))
+	log.Printf("[DEBUG] %s", redactDump(out, secrets...))
 	response, err := httpClient.Do(request)
 	if err != nil {
 		log.Println(err.Error())
@@ -203,7 +237,7 @@ func request(httpClient *http.Client, cfg *config, request *http.Request) (*http
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("[DEBUG] %s", redactDump(out))
+	log.Printf("[DEBUG] %s", redactDump(out, secrets...))
 	return response, err
 }
 

--- a/sysdig/internal/client/v2/client.go
+++ b/sysdig/internal/client/v2/client.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"regexp"
 	"strings"
 	"time"
 
@@ -34,6 +35,21 @@ const (
 )
 
 var errMissingCurrentTeam = errors.New("missing user's current team")
+
+// sensitiveHeaderRe redacts the Authorization header from HTTP dumps.
+var sensitiveHeaderRe = regexp.MustCompile(`(?i)(\r?\n` + AuthorizationHeader + `: )[^\r\n]*`)
+
+// sensitiveJSONFieldRe redacts well-known secret fields (e.g. the customer
+// accessKey returned by GetMePath) from HTTP dumps.
+var sensitiveJSONFieldRe = regexp.MustCompile(`(?i)("(?:accessKey|accessKeySecret|password|secret|token)"\s*:\s*)"[^"]*"`)
+
+// redactDump scrubs sensitive headers and JSON fields out of a raw HTTP
+// request/response dump before it is written to the debug log.
+func redactDump(dump []byte) string {
+	redacted := sensitiveHeaderRe.ReplaceAllString(string(dump), "${1}<REDACTED>")
+	redacted = sensitiveJSONFieldRe.ReplaceAllString(redacted, `${1}"<REDACTED>"`)
+	return redacted
+}
 
 type Base interface {
 	CurrentTeamID(ctx context.Context) (int, error)
@@ -176,7 +192,7 @@ func request(httpClient *http.Client, cfg *config, request *http.Request) (*http
 		return nil, err
 	}
 
-	log.Printf("[DEBUG] %s", string(out))
+	log.Printf("[DEBUG] %s", redactDump(out))
 	response, err := httpClient.Do(request)
 	if err != nil {
 		log.Println(err.Error())
@@ -187,7 +203,7 @@ func request(httpClient *http.Client, cfg *config, request *http.Request) (*http
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("[DEBUG] %s", string(out))
+	log.Printf("[DEBUG] %s", redactDump(out))
 	return response, err
 }
 

--- a/sysdig/internal/client/v2/client_test.go
+++ b/sysdig/internal/client/v2/client_test.go
@@ -268,6 +268,91 @@ func TestClient_APIErrorFromResponse(t *testing.T) {
 	}
 }
 
+func TestRedactDump(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		dump         string
+		knownSecrets []string
+		wantRedacted string   // substring that must appear in the output
+		wantAbsent   []string // secret values that must NOT appear in the output
+	}{
+		{
+			name:         "authorization header",
+			dump:         "GET / HTTP/1.1\r\nHost: example.com\r\nAuthorization: Bearer sekret-token\r\n\r\n",
+			wantRedacted: "Authorization: <REDACTED>",
+			wantAbsent:   []string{"sekret-token"},
+		},
+		{
+			name:         "proxy-authorization header from extra_headers",
+			dump:         "GET / HTTP/1.1\r\nHost: example.com\r\nProxy-Authorization: Basic sekret\r\n\r\n",
+			wantRedacted: "Proxy-Authorization: <REDACTED>",
+			wantAbsent:   []string{"sekret"},
+		},
+		{
+			name:         "accessKey in JSON body",
+			dump:         `{"user":{"customer":{"accessKey":"AKIA-sekret"}}}`,
+			wantRedacted: `"accessKey":"<REDACTED>"`,
+			wantAbsent:   []string{"AKIA-sekret"},
+		},
+		{
+			name:         "camelCase apiKey and clientSecret in JSON body",
+			dump:         `{"apiKey":"sekret-api","clientSecret":"sekret-client"}`,
+			wantRedacted: `"apiKey":"<REDACTED>","clientSecret":"<REDACTED>"`,
+			wantAbsent:   []string{"sekret-api", "sekret-client"},
+		},
+		{
+			name:         "snake_case access_token in JSON body",
+			dump:         `{"access_token":"sekret-ibm","expiration":123}`,
+			wantRedacted: `"access_token":"<REDACTED>"`,
+			wantAbsent:   []string{"sekret-ibm"},
+		},
+		{
+			name:         "routingKey, serviceKey and publicToken in JSON body",
+			dump:         `{"routingKey":"sekret-1","serviceKey":"sekret-2","publicToken":"sekret-3"}`,
+			wantRedacted: `"routingKey":"<REDACTED>","serviceKey":"<REDACTED>","publicToken":"<REDACTED>"`,
+			wantAbsent:   []string{"sekret-1", "sekret-2", "sekret-3"},
+		},
+		{
+			name:         "escaped quote inside secret value doesn't leak the remainder",
+			dump:         `{"password":"ab\"cd"}`,
+			wantRedacted: `"password":"<REDACTED>"`,
+			wantAbsent:   []string{"ab", "cd"},
+		},
+		{
+			name:         "apikey in x-www-form-urlencoded body",
+			dump:         "grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey=sekret-ibm-key",
+			wantRedacted: "apikey=<REDACTED>",
+			wantAbsent:   []string{"sekret-ibm-key"},
+		},
+		{
+			name:         "known secret value under an unanticipated header name",
+			dump:         "GET / HTTP/1.1\r\nHost: example.com\r\nX-Custom: sekret-value\r\n\r\n",
+			knownSecrets: []string{"sekret-value"},
+			wantRedacted: "X-Custom: <REDACTED>",
+			wantAbsent:   []string{"sekret-value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := redactDump([]byte(tt.dump), tt.knownSecrets...)
+
+			if !strings.Contains(got, tt.wantRedacted) {
+				t.Errorf("expected output to contain %q, got %q", tt.wantRedacted, got)
+			}
+			for _, secret := range tt.wantAbsent {
+				if strings.Contains(got, secret) {
+					t.Errorf("expected secret %q to be redacted, got %q", secret, got)
+				}
+			}
+		})
+	}
+}
+
 func TestRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		agent := r.Header.Get(UserAgentHeader)


### PR DESCRIPTION
`DumpRequestOut`/`DumpResponse` with body=true logged raw HTTP request/response bytes at DEBUG level, including the Authorization bearer token and any secret-bearing JSON/form field (IBM's access_token, apikey, accessKey, apiKey, clientSecret, routingKey, serviceKey, publicToken...). Anyone running with TF_LOG=DEBUG leaked live credentials into their logs.

Redact by pattern instead of hardcoding field names: any header, JSON field, or form value whose name looks like a credential (auth/key/token/secret/password/credential) gets scrubbed, escape-aware so an escaped quote inside a secret can't leak the rest of the string. Also strip the provider's own configured secrets (token, IBM apikey, extra_headers values) as a literal-value fallback for anything the name-based patterns miss.