### PR TITLE
Use TypeSet for unordered organization collection attributes

### DIFF
--- a/sysdig/common_test.go
+++ b/sysdig/common_test.go
@@ -1,6 +1,7 @@
 package sysdig_test
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -44,4 +45,14 @@ func sysdigOrIBMMonitorPreCheck(t *testing.T) func() {
 
 func randomText(len int) string {
 	return acctest.RandStringFromCharSet(len, acctest.CharSetAlphaNum)
+}
+
+// quoteJoin renders values as the elements of an HCL list, so an empty slice yields an empty list
+// instead of a single empty string.
+func quoteJoin(values []string) string {
+	quoted := make([]string, len(values))
+	for i, value := range values {
+		quoted[i] = fmt.Sprintf("%q", value)
+	}
+	return strings.Join(quoted, ", ")
 }

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_component.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_component.go
@@ -160,9 +160,6 @@ func resourceSysdigSecureCloudauthAccountComponentDelete(ctx context.Context, da
 	return nil
 }
 
-/*
-This function validates and restricts any fields not allowed to be updated during resource updates.
-*/
 func cloudauthAccountComponentFromResourceData(data *schema.ResourceData) *v2.CloudauthAccountComponentSecure {
 	cloudAccountComponent := &v2.CloudauthAccountComponentSecure{
 		AccountComponent: cloudauth.AccountComponent{

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_component.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_component.go
@@ -99,6 +99,7 @@ func resourceSysdigSecureCloudauthAccountComponentRead(ctx context.Context, data
 		ctx, data.Get(SchemaAccountID).(string), data.Get(SchemaType).(string), data.Get(SchemaInstance).(string))
 	if err != nil {
 		if strings.Contains(errStatus, "404") {
+			data.SetId("")
 			return nil
 		}
 		return diag.Errorf("Error reading resource: %s %s", errStatus, err)
@@ -119,21 +120,13 @@ func resourceSysdigSecureCloudauthAccountComponentUpdate(ctx context.Context, da
 	}
 
 	accountID := data.Get(SchemaAccountID).(string)
-	_, errStatus, err := client.GetCloudauthAccountComponentSecure(
-		ctx, accountID, data.Get(SchemaType).(string), data.Get(SchemaInstance).(string))
-	if err != nil {
-		if strings.Contains(errStatus, "404") {
-			return nil
-		}
-		return diag.Errorf("Error reading resource: %s %s", errStatus, err)
-	}
-
 	newCloudAccountComponent := cloudauthAccountComponentFromResourceData(data)
 
-	_, errStatus, err = client.UpdateCloudauthAccountComponentSecure(
+	_, errStatus, err := client.UpdateCloudauthAccountComponentSecure(
 		ctx, accountID, data.Get(SchemaType).(string), data.Get(SchemaInstance).(string), newCloudAccountComponent)
 	if err != nil {
 		if strings.Contains(errStatus, "404") {
+			data.SetId("")
 			return nil
 		}
 		return diag.Errorf("Error updating resource: %s %s", errStatus, err)

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_component.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_component.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"maps"
 	"strings"
 	"time"
@@ -46,10 +45,21 @@ func getAccountComponentSchema() map[string]*schema.Schema {
 		SchemaAccountID: {
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 	}
 
 	maps.Copy(componentSchema, accountComponent.Schema)
+
+	// account_id, type and instance make up the component's API path and resource id, so they can
+	// only change by replacement; copied because accountComponent.Schema is shared with the nested
+	// component block of sysdig_secure_cloud_auth_account, where ForceNew would replace the account
+	for _, key := range []string{SchemaType, SchemaInstance} {
+		immutable := *componentSchema[key]
+		immutable.ForceNew = true
+		componentSchema[key] = &immutable
+	}
+
 	return componentSchema
 }
 
@@ -109,7 +119,7 @@ func resourceSysdigSecureCloudauthAccountComponentUpdate(ctx context.Context, da
 	}
 
 	accountID := data.Get(SchemaAccountID).(string)
-	existingCloudAccountComponent, errStatus, err := client.GetCloudauthAccountComponentSecure(
+	_, errStatus, err := client.GetCloudauthAccountComponentSecure(
 		ctx, accountID, data.Get(SchemaType).(string), data.Get(SchemaInstance).(string))
 	if err != nil {
 		if strings.Contains(errStatus, "404") {
@@ -119,12 +129,6 @@ func resourceSysdigSecureCloudauthAccountComponentUpdate(ctx context.Context, da
 	}
 
 	newCloudAccountComponent := cloudauthAccountComponentFromResourceData(data)
-
-	// validate and reject non-updatable resource schema fields upfront
-	err = validateCloudauthAccountComponentUpdate(existingCloudAccountComponent, newCloudAccountComponent)
-	if err != nil {
-		return diag.Errorf("Error updating resource: %s", err)
-	}
 
 	_, errStatus, err = client.UpdateCloudauthAccountComponentSecure(
 		ctx, accountID, data.Get(SchemaType).(string), data.Get(SchemaInstance).(string), newCloudAccountComponent)
@@ -159,15 +163,6 @@ func resourceSysdigSecureCloudauthAccountComponentDelete(ctx context.Context, da
 /*
 This function validates and restricts any fields not allowed to be updated during resource updates.
 */
-func validateCloudauthAccountComponentUpdate(existingComponent *v2.CloudauthAccountComponentSecure, newComponent *v2.CloudauthAccountComponentSecure) error {
-	if existingComponent.Type != newComponent.Type || existingComponent.Instance != newComponent.Instance {
-		errorInvalidResourceUpdate := fmt.Sprintf("Bad Request. Updating restricted fields not allowed: %s", []string{"type", "instance"})
-		return errors.New(errorInvalidResourceUpdate)
-	}
-
-	return nil
-}
-
 func cloudauthAccountComponentFromResourceData(data *schema.ResourceData) *v2.CloudauthAccountComponentSecure {
 	cloudAccountComponent := &v2.CloudauthAccountComponentSecure{
 		AccountComponent: cloudauth.AccountComponent{

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_component_unit_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_component_unit_test.go
@@ -1,0 +1,31 @@
+package sysdig
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// The standalone component resource and the account resource's nested component block share
+// accountComponent.Schema, so ForceNew may only be set on the standalone resource's own copy:
+// on the nested block it would replace the entire cloud account when a component is renamed.
+func TestCloudauthAccountComponentIdentityIsForceNew(t *testing.T) {
+	standalone := resourceSysdigSecureCloudauthAccountComponent().Schema
+
+	for _, key := range []string{SchemaAccountID, SchemaType, SchemaInstance} {
+		if !standalone[key].ForceNew {
+			t.Errorf("%s must be ForceNew: it identifies the component in the API path and in the resource id", key)
+		}
+	}
+
+	if standalone[SchemaVersion].ForceNew {
+		t.Errorf("%s must stay updatable in place", SchemaVersion)
+	}
+
+	nested := resourceSysdigSecureCloudauthAccount().Schema[SchemaComponent].Elem.(*schema.Resource).Schema
+	for key, attribute := range nested {
+		if attribute.ForceNew {
+			t.Errorf("nested %s block: %s must not be ForceNew, it would replace the cloud account", SchemaComponent, key)
+		}
+	}
+}

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_feature_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_feature_test.go
@@ -48,10 +48,9 @@ func TestAccSecureCloudAuthAccountFeature(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				// reordering the components set elements must not produce a diff (SSPROD-71536)
-				Config:             secureAzureWithServicePrincipalFeature(accID, tenantID, true),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
+				// reordering the components set elements must not produce a diff
+				Config:   secureAzureWithServicePrincipalFeature(accID, tenantID, true),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -111,7 +110,7 @@ resource "sysdig_secure_cloud_auth_account_component" "azure_service_principal_2
 				display_name              = "some-display-name-2"
 				app_display_name          = "some-app-display-name-2"
 				app_id                    = "some-app-id-2"
-				app_owner_organization_id = "some-app-owner-organization-id"
+				app_owner_organization_id = "some-app-owner-organization-id-2"
 		  }
 	  }
   })

--- a/sysdig/resource_sysdig_secure_cloud_auth_account_feature_test.go
+++ b/sysdig/resource_sysdig_secure_cloud_auth_account_feature_test.go
@@ -24,6 +24,9 @@ import (
 func TestAccSecureCloudAuthAccountFeature(t *testing.T) {
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	accID := rText()
+	// generated once so every step renders the same tenant id, otherwise the reorder step
+	// would also diff on provider_tenant_id
+	tenantID := acctest.RandStringFromCharSet(36, acctest.CharSetAlphaNum)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
@@ -37,23 +40,31 @@ func TestAccSecureCloudAuthAccountFeature(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: secureAzureWithServicePrincipalFeature(accID),
+				Config: secureAzureWithServicePrincipalFeature(accID, tenantID, false),
 			},
 			{
 				ResourceName:      "sysdig_secure_cloud_auth_account.azure_sample",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				// reordering the components set elements must not produce a diff (SSPROD-71536)
+				Config:             secureAzureWithServicePrincipalFeature(accID, tenantID, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }
 
-func secureAzureWithServicePrincipalFeature(accountID string) string {
+func secureAzureWithServicePrincipalFeature(accountID string, randomTenantId string, reorderComponents bool) string {
 	// to replicate user behavior, snippet creates an actual azure account and
-	// an actual Service Principal component. It then passes cloudauth returned account_id
+	// two actual Service Principal components. It then passes cloudauth returned account_id
 	// as input to the account feature calls.
-	rID := func() string { return acctest.RandStringFromCharSet(36, acctest.CharSetAlphaNum) }
-	randomTenantId := rID()
+	components := `["COMPONENT_SERVICE_PRINCIPAL/secure-posture", "COMPONENT_SERVICE_PRINCIPAL/secure-posture-2"]`
+	if reorderComponents {
+		components = `["COMPONENT_SERVICE_PRINCIPAL/secure-posture-2", "COMPONENT_SERVICE_PRINCIPAL/secure-posture"]`
+	}
 
 	return fmt.Sprintf(`
 resource "sysdig_secure_cloud_auth_account" "azure_sample" {
@@ -88,15 +99,36 @@ resource "sysdig_secure_cloud_auth_account_component" "azure_service_principal" 
   })
 }
 
+resource "sysdig_secure_cloud_auth_account_component" "azure_service_principal_2" {
+  account_id		         = sysdig_secure_cloud_auth_account.azure_sample.id
+  type                       = "COMPONENT_SERVICE_PRINCIPAL"
+  instance                   = "secure-posture-2"
+  service_principal_metadata = jsonencode({
+	  azure = {
+		  active_directory_service_principal = {
+				id                        = "some-id-2"
+				account_enabled           = true
+				display_name              = "some-display-name-2"
+				app_display_name          = "some-app-display-name-2"
+				app_id                    = "some-app-id-2"
+				app_owner_organization_id = "some-app-owner-organization-id"
+		  }
+	  }
+  })
+}
+
 resource "sysdig_secure_cloud_auth_account_feature" "azure_config_posture" {
   account_id		         = sysdig_secure_cloud_auth_account.azure_sample.id
   type                       = "FEATURE_SECURE_CONFIG_POSTURE"
   enabled                    = true
-  components                 = ["COMPONENT_SERVICE_PRINCIPAL/secure-posture"]
+  components                 = %s
 
-  depends_on = [ sysdig_secure_cloud_auth_account_component.azure_service_principal ]
+  depends_on = [
+	sysdig_secure_cloud_auth_account_component.azure_service_principal,
+	sysdig_secure_cloud_auth_account_component.azure_service_principal_2,
+  ]
 }
-`, accountID, randomTenantId)
+`, accountID, randomTenantId, components)
 }
 
 func TestAccSecureCloudAuthAccountFeatureWithFlags(t *testing.T) {

--- a/sysdig/resource_sysdig_secure_organization.go
+++ b/sysdig/resource_sysdig_secure_organization.go
@@ -172,45 +172,12 @@ func secureOrganizationFromResourceData(data *schema.ResourceData) *v2.Organizat
 	secureOrganization.ManagementAccountId = data.Get(SchemaManagementAccountID).(string)
 	secureOrganization.OrganizationRootId = data.Get(SchemaOrganizationRootID).(string)
 	secureOrganization.AutomaticOnboarding = data.Get(SchemaAutomaticOnboarding).(bool)
-	organizationalUnitIdsData := data.Get(SchemaOrganizationalUnitIds).(*schema.Set).List()
-	for _, organizationalUnitIDData := range organizationalUnitIdsData {
-		secureOrganization.OrganizationalUnitIds = append(
-			secureOrganization.OrganizationalUnitIds,
-			organizationalUnitIDData.(string),
-		)
-	}
+	secureOrganization.OrganizationalUnitIds = schemaSetToList(data.Get(SchemaOrganizationalUnitIds))
+	secureOrganization.IncludedOrganizationalGroups = schemaSetToList(data.Get(SchemaIncludedOrganizationalGroups))
+	secureOrganization.ExcludedOrganizationalGroups = schemaSetToList(data.Get(SchemaExcludedOrganizationalGroups))
+	secureOrganization.IncludedCloudAccounts = schemaSetToList(data.Get(SchemaIncludedCloudAccounts))
+	secureOrganization.ExcludedCloudAccounts = schemaSetToList(data.Get(SchemaExcludedCloudAccounts))
 
-	includedOrganizationalGroups := data.Get(SchemaIncludedOrganizationalGroups).(*schema.Set).List()
-	for _, includedOrganizationalGroup := range includedOrganizationalGroups {
-		secureOrganization.IncludedOrganizationalGroups = append(
-			secureOrganization.IncludedOrganizationalGroups,
-			includedOrganizationalGroup.(string),
-		)
-	}
-
-	excludedOrganizationalGroups := data.Get(SchemaExcludedOrganizationalGroups).(*schema.Set).List()
-	for _, excludedOrganizationalGroup := range excludedOrganizationalGroups {
-		secureOrganization.ExcludedOrganizationalGroups = append(
-			secureOrganization.ExcludedOrganizationalGroups,
-			excludedOrganizationalGroup.(string),
-		)
-	}
-
-	includedCloudAccounts := data.Get(SchemaIncludedCloudAccounts).(*schema.Set).List()
-	for _, includedCloudAccount := range includedCloudAccounts {
-		secureOrganization.IncludedCloudAccounts = append(
-			secureOrganization.IncludedCloudAccounts,
-			includedCloudAccount.(string),
-		)
-	}
-
-	excludedCloudAccounts := data.Get(SchemaExcludedCloudAccounts).(*schema.Set).List()
-	for _, excludedCloudAccount := range excludedCloudAccounts {
-		secureOrganization.ExcludedCloudAccounts = append(
-			secureOrganization.ExcludedCloudAccounts,
-			excludedCloudAccount.(string),
-		)
-	}
 	return secureOrganization
 }
 

--- a/sysdig/resource_sysdig_secure_organization.go
+++ b/sysdig/resource_sysdig_secure_organization.go
@@ -22,6 +22,14 @@ func resourceSysdigSecureOrganization() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    resourceSysdigSecureOrganizationV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceSysdigSecureOrganizationUpgradeV0,
+			},
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(timeout),
 			Update: schema.DefaultTimeout(timeout),
@@ -228,4 +236,34 @@ func secureOrganizationToResourceData(data *schema.ResourceData, org *v2.Organiz
 	}
 
 	return nil
+}
+
+// resourceSysdigSecureOrganizationV0 is the schema as released before the include/exclude
+// collections became sets, so state written by those versions is decoded with the types it was
+// written with. The collections carry no nested state, hence the no-op upgrade.
+func resourceSysdigSecureOrganizationV0() *schema.Resource {
+	stringList := func() *schema.Schema {
+		return &schema.Schema{
+			Type: schema.TypeList,
+			Elem: &schema.Schema{Type: schema.TypeString},
+		}
+	}
+
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			SchemaIDKey:                        {Type: schema.TypeString},
+			SchemaManagementAccountID:          {Type: schema.TypeString},
+			SchemaOrganizationalUnitIds:        stringList(),
+			SchemaIncludedOrganizationalGroups: stringList(),
+			SchemaExcludedOrganizationalGroups: stringList(),
+			SchemaIncludedCloudAccounts:        stringList(),
+			SchemaExcludedCloudAccounts:        stringList(),
+			SchemaOrganizationRootID:           {Type: schema.TypeString},
+			SchemaAutomaticOnboarding:          {Type: schema.TypeBool},
+		},
+	}
+}
+
+func resourceSysdigSecureOrganizationUpgradeV0(_ context.Context, rawState map[string]any, _ any) (map[string]any, error) {
+	return rawState, nil
 }

--- a/sysdig/resource_sysdig_secure_organization.go
+++ b/sysdig/resource_sysdig_secure_organization.go
@@ -39,35 +39,35 @@ func resourceSysdigSecureOrganization() *schema.Resource {
 				Required: true,
 			},
 			SchemaOrganizationalUnitIds: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			SchemaIncludedOrganizationalGroups: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			SchemaExcludedOrganizationalGroups: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			SchemaIncludedCloudAccounts: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			SchemaExcludedCloudAccounts: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -172,7 +172,7 @@ func secureOrganizationFromResourceData(data *schema.ResourceData) *v2.Organizat
 	secureOrganization.ManagementAccountId = data.Get(SchemaManagementAccountID).(string)
 	secureOrganization.OrganizationRootId = data.Get(SchemaOrganizationRootID).(string)
 	secureOrganization.AutomaticOnboarding = data.Get(SchemaAutomaticOnboarding).(bool)
-	organizationalUnitIdsData := data.Get(SchemaOrganizationalUnitIds).([]any)
+	organizationalUnitIdsData := data.Get(SchemaOrganizationalUnitIds).(*schema.Set).List()
 	for _, organizationalUnitIDData := range organizationalUnitIdsData {
 		secureOrganization.OrganizationalUnitIds = append(
 			secureOrganization.OrganizationalUnitIds,
@@ -180,7 +180,7 @@ func secureOrganizationFromResourceData(data *schema.ResourceData) *v2.Organizat
 		)
 	}
 
-	includedOrganizationalGroups := data.Get(SchemaIncludedOrganizationalGroups).([]any)
+	includedOrganizationalGroups := data.Get(SchemaIncludedOrganizationalGroups).(*schema.Set).List()
 	for _, includedOrganizationalGroup := range includedOrganizationalGroups {
 		secureOrganization.IncludedOrganizationalGroups = append(
 			secureOrganization.IncludedOrganizationalGroups,
@@ -188,7 +188,7 @@ func secureOrganizationFromResourceData(data *schema.ResourceData) *v2.Organizat
 		)
 	}
 
-	excludedOrganizationalGroups := data.Get(SchemaExcludedOrganizationalGroups).([]any)
+	excludedOrganizationalGroups := data.Get(SchemaExcludedOrganizationalGroups).(*schema.Set).List()
 	for _, excludedOrganizationalGroup := range excludedOrganizationalGroups {
 		secureOrganization.ExcludedOrganizationalGroups = append(
 			secureOrganization.ExcludedOrganizationalGroups,
@@ -196,7 +196,7 @@ func secureOrganizationFromResourceData(data *schema.ResourceData) *v2.Organizat
 		)
 	}
 
-	includedCloudAccounts := data.Get(SchemaIncludedCloudAccounts).([]any)
+	includedCloudAccounts := data.Get(SchemaIncludedCloudAccounts).(*schema.Set).List()
 	for _, includedCloudAccount := range includedCloudAccounts {
 		secureOrganization.IncludedCloudAccounts = append(
 			secureOrganization.IncludedCloudAccounts,
@@ -204,7 +204,7 @@ func secureOrganizationFromResourceData(data *schema.ResourceData) *v2.Organizat
 		)
 	}
 
-	excludedCloudAccounts := data.Get(SchemaExcludedCloudAccounts).([]any)
+	excludedCloudAccounts := data.Get(SchemaExcludedCloudAccounts).(*schema.Set).List()
 	for _, excludedCloudAccount := range excludedCloudAccounts {
 		secureOrganization.ExcludedCloudAccounts = append(
 			secureOrganization.ExcludedCloudAccounts,

--- a/sysdig/resource_sysdig_secure_organization_test.go
+++ b/sysdig/resource_sysdig_secure_organization_test.go
@@ -26,7 +26,9 @@ func TestAccSecureOrganization(t *testing.T) {
 	// Skipping the test based on this error when it occurs.
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	accID := rText()
-	organizationApiUrl := fmt.Sprintf(`%s/api/cloudauth/v1/organizations`, os.Getenv("SYSDIG_SECURE_URL"))
+	// the host is left out on purpose: SYSDIG_SECURE_URL is not set in every environment, and with
+	// it interpolated the pattern stops matching the error raised against the default endpoint
+	organizationAPIFailure := regexp.MustCompile(`POST \S*/api/cloudauth/v1/organizations giving up after \d+ attempt\(s\)`)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
@@ -39,8 +41,7 @@ func TestAccSecureOrganization(t *testing.T) {
 			},
 		},
 		ErrorCheck: func(err error) error {
-			re := regexp.MustCompile(fmt.Sprintf(`POST %s giving up after \d+ attempt\(s\)`, regexp.QuoteMeta(organizationApiUrl)))
-			if re.MatchString(err.Error()) {
+			if organizationAPIFailure.MatchString(err.Error()) {
 				t.Skipf("skipping test; this POST call is not supported without actual existing GCP projects and service principal.")
 			}
 			// anything else is a real failure; returning nil here would make the test pass vacuously
@@ -66,27 +67,28 @@ func TestAccSecureOrganization(t *testing.T) {
 	})
 }
 
+// the values have to satisfy cloudauth's per-provider validation: organizational groups are
+// `folders/<id>` and cloud accounts are GCP project ids. organizational_unit_ids is left unset on
+// purpose, the API rejects it when the include/exclude fields are used.
 func secureOrgWithAccountID(accountID string) string {
 	return secureOrgConfig(accountID,
-		[]string{"ou-1111", "ou-2222"},
-		[]string{"group-a", "group-b"},
-		[]string{"group-c", "group-d"},
-		[]string{"111111111111", "222222222222"},
-		[]string{"333333333333", "444444444444"},
+		[]string{"folders/111111111111", "folders/222222222222"},
+		[]string{"folders/333333333333", "folders/444444444444"},
+		[]string{"sample-project-one", "sample-project-two"},
+		[]string{"sample-project-three", "sample-project-four"},
 	)
 }
 
 func secureOrgWithAccountIDReordered(accountID string) string {
 	return secureOrgConfig(accountID,
-		[]string{"ou-2222", "ou-1111"},
-		[]string{"group-b", "group-a"},
-		[]string{"group-d", "group-c"},
-		[]string{"222222222222", "111111111111"},
-		[]string{"444444444444", "333333333333"},
+		[]string{"folders/222222222222", "folders/111111111111"},
+		[]string{"folders/444444444444", "folders/333333333333"},
+		[]string{"sample-project-two", "sample-project-one"},
+		[]string{"sample-project-four", "sample-project-three"},
 	)
 }
 
-func secureOrgConfig(accountID string, organizationalUnitIDs, includedGroups, excludedGroups, includedAccounts, excludedAccounts []string) string {
+func secureOrgConfig(accountID string, includedGroups, excludedGroups, includedAccounts, excludedAccounts []string) string {
 	// this is a base64 encoded service account key
 	test_service_account_key_encoded := getEncodedGCPServiceAccountKeyForOrg("sample", accountID)
 	quote := func(values []string) string { return `"` + strings.Join(values, `", "`) + `"` }
@@ -149,16 +151,15 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
 }
 resource "sysdig_secure_organization" "sample-org" {
   management_account_id		     = sysdig_secure_cloud_auth_account.sample.id
-  organization_root_id 		     = "test-id"
+  organization_root_id 		     = "organizations/123456789012"
   automatic_onboarding           = false
-  organizational_unit_ids        = [%s]
   included_organizational_groups = [%s]
   excluded_organizational_groups = [%s]
   included_cloud_accounts        = [%s]
   excluded_cloud_accounts        = [%s]
 }
 `, accountID, test_service_account_key_encoded, test_service_account_key_encoded,
-		quote(organizationalUnitIDs), quote(includedGroups), quote(excludedGroups), quote(includedAccounts), quote(excludedAccounts))
+		quote(includedGroups), quote(excludedGroups), quote(includedAccounts), quote(excludedAccounts))
 }
 
 func getEncodedGCPServiceAccountKeyForOrg(resourceName string, accountID string) string {

--- a/sysdig/resource_sysdig_secure_organization_test.go
+++ b/sysdig/resource_sysdig_secure_organization_test.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -20,15 +18,16 @@ import (
 )
 
 func TestAccSecureOrganization(t *testing.T) {
-	// XXX: TF acceptance tests for secure org onboarding need an actual existing gcp project
-	// along with an actual service_principal_key to scrape all folders and projects under the org.
-	// Without it POST /organizations call will fail with 500 error.
-	// Skipping the test based on this error when it occurs.
+	// The organization API scrapes every folder and project under the organization with the service
+	// principal from the config, so it only succeeds against a real GCP organization. Gate the test
+	// on that fixture: recognising the resulting failure by its message cannot be told apart from a
+	// genuine outage against the same endpoint.
+	if os.Getenv("SYSDIG_SECURE_GCP_ORG_TESTS") == "" {
+		t.Skip("Skipping tests on sysdig_secure_organization resource because SYSDIG_SECURE_GCP_ORG_TESTS is not set")
+	}
+
 	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
 	accID := rText()
-	// the host is left out on purpose: SYSDIG_SECURE_URL is not set in every environment, and with
-	// it interpolated the pattern stops matching the error raised against the default endpoint
-	organizationAPIFailure := regexp.MustCompile(`POST \S*/api/cloudauth/v1/organizations giving up after \d+ attempt\(s\)`)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
@@ -39,13 +38,6 @@ func TestAccSecureOrganization(t *testing.T) {
 			"sysdig": func() (*schema.Provider, error) {
 				return sysdig.Provider(), nil
 			},
-		},
-		ErrorCheck: func(err error) error {
-			if organizationAPIFailure.MatchString(err.Error()) {
-				t.Skipf("skipping test; this POST call is not supported without actual existing GCP projects and service principal.")
-			}
-			// anything else is a real failure; returning nil here would make the test pass vacuously
-			return err
 		},
 		Steps: []resource.TestStep{
 			{
@@ -58,10 +50,9 @@ func TestAccSecureOrganization(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"component"},
 			},
 			{
-				// reordering the include/exclude set elements must not produce a diff (SSPROD-71536)
-				Config:             secureOrgWithAccountIDReordered(accID),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
+				// reordering the include/exclude set elements must not produce a diff
+				Config:   secureOrgWithAccountIDReordered(accID),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -70,28 +61,39 @@ func TestAccSecureOrganization(t *testing.T) {
 // the values have to satisfy cloudauth's per-provider validation: organizational groups are
 // `folders/<id>` and cloud accounts are GCP project ids. organizational_unit_ids is left unset on
 // purpose, the API rejects it when the include/exclude fields are used.
+var (
+	secureOrgIncludedGroups   = []string{"folders/111111111111", "folders/222222222222"}
+	secureOrgExcludedGroups   = []string{"folders/333333333333", "folders/444444444444"}
+	secureOrgIncludedAccounts = []string{"sample-project-one", "sample-project-two"}
+	secureOrgExcludedAccounts = []string{"sample-project-three", "sample-project-four"}
+)
+
 func secureOrgWithAccountID(accountID string) string {
 	return secureOrgConfig(accountID,
-		[]string{"folders/111111111111", "folders/222222222222"},
-		[]string{"folders/333333333333", "folders/444444444444"},
-		[]string{"sample-project-one", "sample-project-two"},
-		[]string{"sample-project-three", "sample-project-four"},
+		secureOrgIncludedGroups, secureOrgExcludedGroups,
+		secureOrgIncludedAccounts, secureOrgExcludedAccounts,
 	)
 }
 
+// derived from the same slices so the two configs cannot drift apart and stop exercising a reorder
 func secureOrgWithAccountIDReordered(accountID string) string {
 	return secureOrgConfig(accountID,
-		[]string{"folders/222222222222", "folders/111111111111"},
-		[]string{"folders/444444444444", "folders/333333333333"},
-		[]string{"sample-project-two", "sample-project-one"},
-		[]string{"sample-project-four", "sample-project-three"},
+		reversed(secureOrgIncludedGroups), reversed(secureOrgExcludedGroups),
+		reversed(secureOrgIncludedAccounts), reversed(secureOrgExcludedAccounts),
 	)
+}
+
+func reversed(values []string) []string {
+	out := make([]string, 0, len(values))
+	for i := len(values) - 1; i >= 0; i-- {
+		out = append(out, values[i])
+	}
+	return out
 }
 
 func secureOrgConfig(accountID string, includedGroups, excludedGroups, includedAccounts, excludedAccounts []string) string {
 	// this is a base64 encoded service account key
 	test_service_account_key_encoded := getEncodedGCPServiceAccountKeyForOrg("sample", accountID)
-	quote := func(values []string) string { return `"` + strings.Join(values, `", "`) + `"` }
 
 	return fmt.Sprintf(`
 resource "sysdig_secure_cloud_auth_account" "sample" {
@@ -159,7 +161,7 @@ resource "sysdig_secure_organization" "sample-org" {
   excluded_cloud_accounts        = [%s]
 }
 `, accountID, test_service_account_key_encoded, test_service_account_key_encoded,
-		quote(includedGroups), quote(excludedGroups), quote(includedAccounts), quote(excludedAccounts))
+		quoteJoin(includedGroups), quoteJoin(excludedGroups), quoteJoin(includedAccounts), quoteJoin(excludedAccounts))
 }
 
 func getEncodedGCPServiceAccountKeyForOrg(resourceName string, accountID string) string {

--- a/sysdig/resource_sysdig_secure_organization_test.go
+++ b/sysdig/resource_sysdig_secure_organization_test.go
@@ -3,31 +3,41 @@
 package sysdig_test
 
 import (
-	"bytes"
-	b64 "encoding/base64"
-	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/draios/terraform-provider-sysdig/sysdig"
 )
 
+const (
+	gcpOrgServiceAccountKeyEnv = "SYSDIG_SECURE_GCP_ORG_SERVICE_ACCOUNT_KEY"
+	gcpOrgRootIDEnv            = "SYSDIG_SECURE_GCP_ORG_ROOT_ID"
+	gcpOrgProjectIDEnv         = "SYSDIG_SECURE_GCP_ORG_PROJECT_ID"
+)
+
+type gcpOrgFixture struct {
+	projectID          string
+	organizationRootID string
+	serviceAccountKey  string
+}
+
 func TestAccSecureOrganization(t *testing.T) {
-	// The organization API scrapes every folder and project under the organization with the service
-	// principal from the config, so it only succeeds against a real GCP organization. Gate the test
-	// on that fixture: recognising the resulting failure by its message cannot be told apart from a
-	// genuine outage against the same endpoint.
-	if os.Getenv("SYSDIG_SECURE_GCP_ORG_TESTS") == "" {
-		t.Skip("Skipping tests on sysdig_secure_organization resource because SYSDIG_SECURE_GCP_ORG_TESTS is not set")
+	// Creating the organization scrapes every folder and project under it with this service
+	// principal, so the key, the organization root and the management project all have to be real.
+	fixture := gcpOrgFixture{
+		projectID:          os.Getenv(gcpOrgProjectIDEnv),
+		organizationRootID: os.Getenv(gcpOrgRootIDEnv),
+		serviceAccountKey:  os.Getenv(gcpOrgServiceAccountKeyEnv),
+	}
+	if fixture.projectID == "" || fixture.organizationRootID == "" || fixture.serviceAccountKey == "" {
+		t.Skipf("Skipping tests on sysdig_secure_organization resource because %s, %s and %s are not all set",
+			gcpOrgProjectIDEnv, gcpOrgRootIDEnv, gcpOrgServiceAccountKeyEnv)
 	}
 
-	rText := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum) }
-	accID := rText()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			if v := os.Getenv("SYSDIG_SECURE_API_TOKEN"); v == "" {
@@ -41,7 +51,7 @@ func TestAccSecureOrganization(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: secureOrgWithAccountID(accID),
+				Config: secureOrgConfigInOrder(fixture),
 			},
 			{
 				ResourceName:            "sysdig_secure_cloud_auth_account.sample",
@@ -51,16 +61,16 @@ func TestAccSecureOrganization(t *testing.T) {
 			},
 			{
 				// reordering the include/exclude set elements must not produce a diff
-				Config:   secureOrgWithAccountIDReordered(accID),
+				Config:   secureOrgConfigReordered(fixture),
 				PlanOnly: true,
 			},
 		},
 	})
 }
 
-// the values have to satisfy cloudauth's per-provider validation: organizational groups are
-// `folders/<id>` and cloud accounts are GCP project ids. organizational_unit_ids is left unset on
-// purpose, the API rejects it when the include/exclude fields are used.
+// The include/exclude values stay synthetic: cloudauth validates their shape, not their
+// existence, so well-formed folder ids and project ids are enough and keep the reorder under the
+// test's control. organizational_unit_ids is left unset, the API rejects it alongside these.
 var (
 	secureOrgIncludedGroups   = []string{"folders/111111111111", "folders/222222222222"}
 	secureOrgExcludedGroups   = []string{"folders/333333333333", "folders/444444444444"}
@@ -68,16 +78,16 @@ var (
 	secureOrgExcludedAccounts = []string{"sample-project-three", "sample-project-four"}
 )
 
-func secureOrgWithAccountID(accountID string) string {
-	return secureOrgConfig(accountID,
+func secureOrgConfigInOrder(fixture gcpOrgFixture) string {
+	return secureOrgConfig(fixture,
 		secureOrgIncludedGroups, secureOrgExcludedGroups,
 		secureOrgIncludedAccounts, secureOrgExcludedAccounts,
 	)
 }
 
 // derived from the same slices so the two configs cannot drift apart and stop exercising a reorder
-func secureOrgWithAccountIDReordered(accountID string) string {
-	return secureOrgConfig(accountID,
+func secureOrgConfigReordered(fixture gcpOrgFixture) string {
+	return secureOrgConfig(fixture,
 		reversed(secureOrgIncludedGroups), reversed(secureOrgExcludedGroups),
 		reversed(secureOrgIncludedAccounts), reversed(secureOrgExcludedAccounts),
 	)
@@ -91,13 +101,10 @@ func reversed(values []string) []string {
 	return out
 }
 
-func secureOrgConfig(accountID string, includedGroups, excludedGroups, includedAccounts, excludedAccounts []string) string {
-	// this is a base64 encoded service account key
-	test_service_account_key_encoded := getEncodedGCPServiceAccountKeyForOrg("sample", accountID)
-
+func secureOrgConfig(fixture gcpOrgFixture, includedGroups, excludedGroups, includedAccounts, excludedAccounts []string) string {
 	return fmt.Sprintf(`
 resource "sysdig_secure_cloud_auth_account" "sample" {
-  provider_id   = "%s"
+  provider_id   = %q
   provider_type = "PROVIDER_GCP"
   enabled       = "true"
   feature {
@@ -115,7 +122,7 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
     instance                   = "secure-posture"
     service_principal_metadata = jsonencode({
       gcp = {
-        key = "%s"
+        key = %q
       }
     })
   }
@@ -124,7 +131,7 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
     instance                   = "secure-onboarding"
     service_principal_metadata = jsonencode({
       gcp = {
-        key = "%s"
+        key = %q
       }
     })
   }
@@ -153,41 +160,13 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
 }
 resource "sysdig_secure_organization" "sample-org" {
   management_account_id		     = sysdig_secure_cloud_auth_account.sample.id
-  organization_root_id 		     = "organizations/123456789012"
+  organization_root_id 		     = %q
   automatic_onboarding           = false
   included_organizational_groups = [%s]
   excluded_organizational_groups = [%s]
   included_cloud_accounts        = [%s]
   excluded_cloud_accounts        = [%s]
 }
-`, accountID, test_service_account_key_encoded, test_service_account_key_encoded,
+`, fixture.projectID, fixture.serviceAccountKey, fixture.serviceAccountKey, fixture.organizationRootID,
 		quoteJoin(includedGroups), quoteJoin(excludedGroups), quoteJoin(includedAccounts), quoteJoin(excludedAccounts))
-}
-
-func getEncodedGCPServiceAccountKeyForOrg(resourceName string, accountID string) string {
-	test_service_account_key_bytes, err := json.Marshal(map[string]any{
-		"type":                        "service_account",
-		"project_id":                  fmt.Sprintf("%s-%s", resourceName, accountID),
-		"private_key_id":              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		"private_key":                 "-----BEGIN PRIVATE KEY-----\nxxxxxxxxxxxxxxxxxxxxxxxxxxx\n-----END PRIVATE KEY-----\n",
-		"client_email":                fmt.Sprintf("some-sa-name@%s-%s.iam.gserviceaccount.com", resourceName, accountID),
-		"client_id":                   "some-client-id",
-		"auth_uri":                    "https://some-auth-uri",
-		"token_uri":                   "https://some-token-uri",
-		"auth_provider_x509_cert_url": "https://some-authprovider-cert-url",
-		"client_x509_cert_url":        "https://some-client-cert-url",
-		"universe_domain":             "googleapis.com",
-	})
-	if err != nil {
-		fmt.Printf("Failed to marshal test_service_account_key: %v", err)
-	}
-
-	var out bytes.Buffer
-	err = json.Indent(&out, test_service_account_key_bytes, "", "  ")
-	if err != nil {
-		fmt.Printf("Failed to indent test_service_account_key: %v", err)
-	}
-	out.WriteByte('\n')
-
-	return b64.StdEncoding.EncodeToString(out.Bytes())
 }

--- a/sysdig/resource_sysdig_secure_organization_test.go
+++ b/sysdig/resource_sysdig_secure_organization_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -38,12 +39,12 @@ func TestAccSecureOrganization(t *testing.T) {
 			},
 		},
 		ErrorCheck: func(err error) error {
-			// if regex matches with the expected error, do t.Skip
-			re := regexp.MustCompile(fmt.Sprintf(`POST %s giving up after 5 attempt(s)`, organizationApiUrl))
+			re := regexp.MustCompile(fmt.Sprintf(`POST %s giving up after \d+ attempt\(s\)`, regexp.QuoteMeta(organizationApiUrl)))
 			if re.MatchString(err.Error()) {
 				t.Skipf("skipping test; this POST call is not supported without actual existing GCP projects and service principal.")
 			}
-			return nil
+			// anything else is a real failure; returning nil here would make the test pass vacuously
+			return err
 		},
 		Steps: []resource.TestStep{
 			{
@@ -55,13 +56,40 @@ func TestAccSecureOrganization(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"component"},
 			},
+			{
+				// reordering the include/exclude set elements must not produce a diff (SSPROD-71536)
+				Config:             secureOrgWithAccountIDReordered(accID),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }
 
 func secureOrgWithAccountID(accountID string) string {
+	return secureOrgConfig(accountID,
+		[]string{"ou-1111", "ou-2222"},
+		[]string{"group-a", "group-b"},
+		[]string{"group-c", "group-d"},
+		[]string{"111111111111", "222222222222"},
+		[]string{"333333333333", "444444444444"},
+	)
+}
+
+func secureOrgWithAccountIDReordered(accountID string) string {
+	return secureOrgConfig(accountID,
+		[]string{"ou-2222", "ou-1111"},
+		[]string{"group-b", "group-a"},
+		[]string{"group-d", "group-c"},
+		[]string{"222222222222", "111111111111"},
+		[]string{"444444444444", "333333333333"},
+	)
+}
+
+func secureOrgConfig(accountID string, organizationalUnitIDs, includedGroups, excludedGroups, includedAccounts, excludedAccounts []string) string {
 	// this is a base64 encoded service account key
 	test_service_account_key_encoded := getEncodedGCPServiceAccountKeyForOrg("sample", accountID)
+	quote := func(values []string) string { return `"` + strings.Join(values, `", "`) + `"` }
 
 	return fmt.Sprintf(`
 resource "sysdig_secure_cloud_auth_account" "sample" {
@@ -120,11 +148,17 @@ resource "sysdig_secure_cloud_auth_account" "sample" {
 	}
 }
 resource "sysdig_secure_organization" "sample-org" {
-  management_account_id		= sysdig_secure_cloud_auth_account.sample.id
-  organization_root_id 		= "test-id"
-  automatic_onboarding      = false
+  management_account_id		     = sysdig_secure_cloud_auth_account.sample.id
+  organization_root_id 		     = "test-id"
+  automatic_onboarding           = false
+  organizational_unit_ids        = [%s]
+  included_organizational_groups = [%s]
+  excluded_organizational_groups = [%s]
+  included_cloud_accounts        = [%s]
+  excluded_cloud_accounts        = [%s]
 }
-`, accountID, test_service_account_key_encoded, test_service_account_key_encoded)
+`, accountID, test_service_account_key_encoded, test_service_account_key_encoded,
+		quote(organizationalUnitIDs), quote(includedGroups), quote(excludedGroups), quote(includedAccounts), quote(excludedAccounts))
 }
 
 func getEncodedGCPServiceAccountKeyForOrg(resourceName string, accountID string) string {

--- a/sysdig/resource_sysdig_secure_organization_unit_test.go
+++ b/sysdig/resource_sysdig_secure_organization_unit_test.go
@@ -1,0 +1,53 @@
+package sysdig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+// State written by released versions carries these collections as lists, so the V0 type has to
+// keep that shape while the current schema reads them as sets.
+func TestSecureOrganizationStateUpgradeFromV0(t *testing.T) {
+	collections := []string{
+		SchemaOrganizationalUnitIds,
+		SchemaIncludedOrganizationalGroups,
+		SchemaExcludedOrganizationalGroups,
+		SchemaIncludedCloudAccounts,
+		SchemaExcludedCloudAccounts,
+	}
+
+	res := resourceSysdigSecureOrganization()
+	if res.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1", res.SchemaVersion)
+	}
+	if len(res.StateUpgraders) != 1 || res.StateUpgraders[0].Version != 0 {
+		t.Fatalf("expected exactly one upgrader from version 0, got %+v", res.StateUpgraders)
+	}
+
+	v0 := resourceSysdigSecureOrganizationV0().CoreConfigSchema().ImpliedType()
+	current := res.CoreConfigSchema().ImpliedType()
+	for _, key := range collections {
+		if got := v0.AttributeType(key); !got.Equals(cty.List(cty.String)) {
+			t.Errorf("v0 %s = %s, want list of string", key, got.FriendlyName())
+		}
+		if got := current.AttributeType(key); !got.Equals(cty.Set(cty.String)) {
+			t.Errorf("current %s = %s, want set of string", key, got.FriendlyName())
+		}
+	}
+
+	// the collections carry no nested state, so the upgrade only re-reads them under the new type
+	state := map[string]any{
+		"id":                      "org-id",
+		"excluded_cloud_accounts": []any{"second", "first"},
+	}
+	upgraded, err := res.StateUpgraders[0].Upgrade(context.Background(), state, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	accounts, ok := upgraded["excluded_cloud_accounts"].([]any)
+	if !ok || len(accounts) != 2 || accounts[0] != "second" || accounts[1] != "first" {
+		t.Errorf("upgrade altered the raw state: %+v", upgraded)
+	}
+}

--- a/sysdig/resource_sysdig_secure_zone_rules_ordering_plan_test.go
+++ b/sysdig/resource_sysdig_secure_zone_rules_ordering_plan_test.go
@@ -378,11 +378,6 @@ func TestAccZoneRulesOrderingRealChangeIsApplied(t *testing.T) {
 }
 
 func zoneExpressionConfig(url, name string, values ...string) string {
-	quoted := make([]string, len(values))
-	for i, v := range values {
-		quoted[i] = fmt.Sprintf("%q", v)
-	}
-
 	return fmt.Sprintf(`
 provider "sysdig" {
   sysdig_secure_url       = %q
@@ -411,7 +406,7 @@ resource "sysdig_secure_zone" "test" {
     }
   }
 }
-`, url, name, strings.Join(quoted, ", "))
+`, url, name, quoteJoin(values))
 }
 
 // Expression-based scopes keep the stock set hash. Two scope blocks must stay

--- a/website/docs/r/secure_cloud_auth_account_feature.md
+++ b/website/docs/r/secure_cloud_auth_account_feature.md
@@ -60,7 +60,7 @@ resource "sysdig_secure_cloud_auth_account_feature" "sample" {
 
 * `enabled` - (Required) Whether or not to enable this feature on the given cloud account.
 
-* `components` - (Required) Based on the feature type to be created, this is the list of components to be enabled on the cloud account.
+* `components` - (Required) Based on the feature type to be created, this is the set of components to be enabled on the cloud account.
 
 * `flags` - (Optional) Based on the feature type to be created, these are the flags to be added to the feature on the cloud account.
 

--- a/website/docs/r/secure_organization.md
+++ b/website/docs/r/secure_organization.md
@@ -28,11 +28,11 @@ resource "sysdig_secure_organization" "sample" {
 ## Argument Reference
 
 * `management_account_id` - (Required) Cloud Account created using resource sysdig_secure_cloud_auth_account.
-* `organizational_unit_ids` - (Optional) List of organizational unit identifiers from which to onboard. If empty, the entire organization is onboarded. 
-* `included_organizational_groups` - (Optional) List of organizational groups to include during onboarding.
-* `excluded_organizational_groups` - (Optional) List of organizational groups to exclude during onboarding.
-* `included_cloud_accounts` - (Optional) List of cloud accounts to include during onboarding.
-* `excluded_cloud_accounts` - (Optional) List of cloud accounts to exclude during onboarding.
+* `organizational_unit_ids` - (Optional) Set of organizational unit identifiers from which to onboard. If empty, the entire organization is onboarded. 
+* `included_organizational_groups` - (Optional) Set of organizational groups to include during onboarding.
+* `excluded_organizational_groups` - (Optional) Set of organizational groups to exclude during onboarding.
+* `included_cloud_accounts` - (Optional) Set of cloud accounts to include during onboarding.
+* `excluded_cloud_accounts` - (Optional) Set of cloud accounts to exclude during onboarding.
 * `organization_root_id` - (Optional) Organization's root id if available, else organization/tenant id.
 * `automatic_onboarding` - (Optional) Whether or not accounts in organization are to be detected automatically.
 


### PR DESCRIPTION
The include/exclude collections on `sysdig_secure_organization` were `TypeList`, so element order was part of the diff and every plan where the backend returned a different order showed a spurious in-place update — which sends a full org PUT and re-runs the org scrape on the backend. Verified live on AWS and Azure org onboarding: the released provider plans an update on a plain refresh, this build reports no changes.

Second commit: `account_id`, `type` and `instance` on `sysdig_secure_cloud_auth_account_component` are now `ForceNew`. They form the component's API path, and the update path looked the component up by its *new* identity, got a 404 and returned nil — so a rename silently wrote new state while the backend kept the old component. The guard meant to reject this was unreachable for the same reason and is removed.

Note for release notes: indexing the organization attributes (e.g. `excluded_cloud_accounts[0]`) no longer works, since sets are not indexable.